### PR TITLE
Group talks on `speakers#show` page

### DIFF
--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -26,8 +26,10 @@ class SpeakersController < ApplicationController
 
     @grouped_talks = @talks.group_by { |talk| talk.groupable_title.downcase }.map { |title, talks| [talks.first.groupable_title, talks] }.to_h
 
-    @ungrouped_talks = @grouped_talks.select { |title, talks| talks.count == 1 }.values.flatten
-    @grouped_talks = @grouped_talks.reject { |_title, talks| talks.count == 1 }.sort_by { |_title, talks| -talks.map(&:date).max.to_time.to_i }
+    @ungrouped_by_year = @grouped_talks.select { |title, talks| talks.count == 1 }.values.flatten.group_by { |talk| "#{talk.date.year} talks" }
+    @grouped_talks = @grouped_talks.reject { |_title, talks| talks.count == 1 }
+
+    @grouped_talks = (@ungrouped_by_year.to_a + @grouped_talks.to_a).to_h.sort_by { |_title, talks| -talks.map(&:date).max.to_time.to_i }
 
     set_meta_tags(@speaker)
     # fresh_when(@speaker)

--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -23,6 +23,12 @@ class SpeakersController < ApplicationController
   def show
     @talks = @speaker.talks.with_essential_card_data.order(date: :desc)
     @back_path = speakers_path
+
+    @grouped_talks = @talks.group_by { |talk| talk.groupable_title.downcase }.map { |title, talks| [talks.first.groupable_title, talks] }.to_h
+
+    @ungrouped_talks = @grouped_talks.select { |title, talks| talks.count == 1 }.values.flatten
+    @grouped_talks = @grouped_talks.reject { |_title, talks| talks.count == 1 }.sort_by { |_title, talks| -talks.map(&:date).max.to_time.to_i }
+
     set_meta_tags(@speaker)
     # fresh_when(@speaker)
   end

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -175,6 +175,18 @@ class Talk < ApplicationRecord
     Talk.where(id: ids)
   end
 
+  def groupable_title
+    prefixes = ["Keynote", "Opening Keynote", "Closing Keynote", "Lightning Talks"]
+
+    return slug if title.in?(prefixes)
+
+    title.dup.tap do |t|
+      prefixes.each do |prefix|
+        t.delete_prefix!("#{prefix}: ")
+      end
+    end
+  end
+
   def transcript
     enhanced_transcript.presence || raw_transcript
   end

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -178,7 +178,7 @@ class Talk < ApplicationRecord
   def groupable_title
     prefixes = ["Keynote", "Opening Keynote", "Closing Keynote", "Lightning Talks"]
 
-    return slug if title.in?(prefixes)
+    return "#{title} - #{event.name}" if title.in?(prefixes)
 
     title.dup.tap do |t|
       prefixes.each do |prefix|

--- a/app/views/speakers/_talks.html.erb
+++ b/app/views/speakers/_talks.html.erb
@@ -1,0 +1,15 @@
+<h1 class="mb-6"><%= title %></h1>
+
+<div id="talks" class="min-w-full grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 h-full mb-12">
+  <%= render(
+        partial: "talks/card",
+        collection: talks,
+        as: :talk,
+        locals: {
+          favoritable: true,
+          user_favorite_talks_ids: user_favorite_talks_ids,
+          back_to: request.fullpath,
+          back_to_title: speaker.name
+        }
+      ) %>
+</div>

--- a/app/views/speakers/show.html.erb
+++ b/app/views/speakers/show.html.erb
@@ -30,17 +30,25 @@
     </div>
 
     <div class="w-full">
-      <div id="talks" class="min-w-full grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 h-full sm:p-4">
-        <%= render partial: "talks/card",
-              collection: @talks,
-              as: :talk,
-              locals: {
-                favoritable: true,
-                user_favorite_talks_ids: @user_favorite_talks_ids,
-                back_to: request.fullpath,
-                back_to_title: @speaker.name
-              } %>
-      </div>
+      <% if @grouped_talks.any? %>
+        <div role="tablist" class="tabs tabs-bordered">
+          <input type="radio" name="talk_type" role="tab" class="tab" aria-label="Grouped" checked="checked" style="width: 150px">
+          <div role="tabpanel" class="tab-content border-none rounded-box mt-6">
+            <% @grouped_talks.each do |title, talks| %>
+              <%= render partial: "talks", locals: {title: title, talks: talks, speaker: @speaker, user_favorite_talks_ids: @user_favorite_talks_ids} %>
+            <% end %>
+
+            <%= render partial: "talks", locals: {title: "Ungrouped", talks: @ungrouped_talks, speaker: @speaker, user_favorite_talks_ids: @user_favorite_talks_ids} %>
+          </div>
+
+          <input type="radio" name="talk_type" role="tab" class="tab" aria-label="Ungrouped" style="width: 150px">
+          <div role="tabpanel" class="tab-content border-none rounded-box mt-6">
+            <%= render partial: "talks", locals: {talks: @talks, speaker: @speaker, user_favorite_talks_ids: @user_favorite_talks_ids} %>
+          </div>
+        </div>
+      <% else %>
+        <%= render partial: "talks", locals: {talks: @talks, speaker: @speaker, user_favorite_talks_ids: @user_favorite_talks_ids} %>
+      <% end %>
     </div>
   </div>
 

--- a/app/views/speakers/show.html.erb
+++ b/app/views/speakers/show.html.erb
@@ -37,8 +37,6 @@
             <% @grouped_talks.each do |title, talks| %>
               <%= render partial: "talks", locals: {title: title, talks: talks, speaker: @speaker, user_favorite_talks_ids: @user_favorite_talks_ids} %>
             <% end %>
-
-            <%= render partial: "talks", locals: {title: "Ungrouped", talks: @ungrouped_talks, speaker: @speaker, user_favorite_talks_ids: @user_favorite_talks_ids} %>
           </div>
 
           <input type="radio" name="talk_type" role="tab" class="tab" aria-label="Ungrouped" style="width: 150px">

--- a/data/balkanruby/balkanruby-2019/videos.yml
+++ b/data/balkanruby/balkanruby-2019/videos.yml
@@ -1,5 +1,5 @@
 ---
-- title: 'Compacting GC for MRI'
+- title: 'Compacting GC for MRI in Ruby 2.7'
   raw_title: Balkan Ruby 2019 – Aaron Patterson – Compacting GC for MRI
   speakers:
     - Aaron Patterson
@@ -35,7 +35,7 @@
   description: ''
   video_id: QMhgm9ir8js
 
-- title: 'The Past, Present and Future of Rails at GitHub'
+- title: 'The Past, Present, and Future of Rails at GitHub'
   raw_title: Balkan Ruby 2019 – Eileen Uchitelle – The Past, Present and Future of Rails at GitHub
   speakers:
     - Eileen M. Uchitelle

--- a/data/balkanruby/balkanruby-2024/videos.yml
+++ b/data/balkanruby/balkanruby-2024/videos.yml
@@ -86,7 +86,7 @@
     Join him on a journey to explore the use-cases and benefits of running SQLite in a production environment.
   video_id: 7QMYfpU6_-s
 
-- title: 'The history of a Rails monolith'
+- title: '2000 Engineers, 2 Millions Lines of Code: The History of a Rails Monolith'
   raw_title: Cristian Planas & Anatoly Mikhaylov – The history of a Rails monolith
   speakers:
     - Cristian Planas

--- a/data/balticruby/balticruby-2024/videos.yml
+++ b/data/balticruby/balticruby-2024/videos.yml
@@ -36,7 +36,7 @@
     data integrity, efficiency and performance along the way!
   video_id: xa9ixrLU7X4
 
-- title: "2000 engineers, 2 millions lines of code: the history of a Rails monolith"
+- title: "2000 Engineers, 2 Millions Lines of Code: The History of a Rails Monolith"
   raw_title: '"2000 engineers, 2 millions lines of code: the history of a Rails monolith"'
   speakers:
     - Cristian Planas
@@ -167,7 +167,7 @@
     problems along the way.
   video_id: mZzIJ4QpQck
 
-- title: "Keynote: Second system syndrome"
+- title: "Keynote: Second System Syndrome"
   raw_title: '"Second system syndrome"'
   speakers:
     - Yukihiro "Matz" Matsumoto

--- a/data/euruko/euruko-2023/videos.yml
+++ b/data/euruko/euruko-2023/videos.yml
@@ -156,7 +156,7 @@
   description: ""
   video_id: 79LN5Sn4Nac
 
-- title: "Panel: 30 years of Ruby"
+- title: "Panel: 30 Years of Ruby"
   raw_title: Panel discussion "30 years of Ruby"
   speakers:
     - James Bell

--- a/data/pivorak/pivorak-conf-3/videos.yml
+++ b/data/pivorak/pivorak-conf-3/videos.yml
@@ -23,7 +23,7 @@
     benefits: https://bit.ly/313cImj"
   video_id: vKN3v3omJqM
 
-- title: Do You Need That Validation?
+- title: Do You Need That Validation? Let Me Call You Back About It
   raw_title: Do You Need That Validation? - Tobias Pfeiffer
   speakers:
     - Tobias Pfeiffer

--- a/data/pivorak/pivorak-conf-3/videos.yml
+++ b/data/pivorak/pivorak-conf-3/videos.yml
@@ -42,7 +42,7 @@
     benefits: https://bit.ly/313cImj"
   video_id: Bm7XpipPU9g
 
-- title: 'Compacting GC in Ruby 2.7'
+- title: 'Compacting GC for MRI in Ruby 2.7'
   raw_title: Compacting GC in Ruby 2.7 - Aaron Patterson
   speakers:
     - Aaron Patterson

--- a/data/railsconf/railsconf-2021/videos.yml
+++ b/data/railsconf/railsconf-2021/videos.yml
@@ -1236,7 +1236,7 @@
     After a quick recap of the fundamentals, you'll learn the procedural, technical and human factors that can affect the trustworthiness of a test. More importantly, I'll show you how to mitigate these issues with easy, actionable tips that will have you A/B testing accurately in no time!
   video_id: IsgQ9RJ0rJE
 
-- title: The Rising Storm of Ethics in Open Source
+- title: The Rising Ethical Storm in Open Source
   raw_title: "RailsConf 2021: The Rising Storm of Ethics in Open Source - Coraline Ada Ehmke"
   speakers:
     - Coraline Ada Ehmke

--- a/data/ruby-warsaw-community-conference/ruby-warsaw-community-conference-summer-edition-2024/videos.yml
+++ b/data/ruby-warsaw-community-conference/ruby-warsaw-community-conference-summer-edition-2024/videos.yml
@@ -22,7 +22,7 @@
     https://github.com/visualitypl"
   video_id: TDQ2wtmgeKw
 
-- title: '2000 Engineers, 2 millions lines of code: The history of a Rails monolith'
+- title: '2000 Engineers, 2 Millions Lines of Code: The History of a Rails Monolith'
   raw_title: "[EN] 2000 Engineers, 2 millions lines of code: The history of a Rails monolith - Cristian Planas"
   speakers:
     - Cristian Planas

--- a/data/rubyconf/rubyconf-2015/videos.yml
+++ b/data/rubyconf/rubyconf-2015/videos.yml
@@ -234,7 +234,7 @@
     Your code is your partner. It struggles against you, but also alongside you. Your code comes to you as it is, not as you wish it were. Like a real-life partner, it has a history that you’ll never fully know; like a real-life child, it bears your imprint, but it is wild, unruly, and fiercely self-sovereign. You’ll never stop working with code that’s hard to figure out or difficult to change. But this code, this stubborn creature, is entrusted to you. Let go of your anger at the developer who wrote it. Let go of the terror of being blamed for its unforeseeable regressions. Let go--and find joy.
   video_id: JC4mS7sYQlU
 
-- title: How does Bundler work, anyway?
+- title: How Does Bundler Work, Anyway?
   raw_title: RubyConf 2015 - How does Bundler work, anyway? by Andre Arko
   speakers:
     - André Arko

--- a/data/rubyconf/rubyconf-2019/videos.yml
+++ b/data/rubyconf/rubyconf-2019/videos.yml
@@ -1068,7 +1068,7 @@
     so I'll try to explain it by emoji\n\n\n\n#confreaks #rubyconf2019"
   video_id: SzgmcVN7qu4
 
-- title: Compacting Heaps in Ruby 2.7
+- title: Compacting GC for MRI in Ruby 2.7
   raw_title: RubyConf 2019 - Compacting Heaps in Ruby 2.7 by Aaron Patterson
   speakers:
     - Aaron Patterson

--- a/data/rubyconf/rubyconf-2021/videos.yml
+++ b/data/rubyconf/rubyconf-2021/videos.yml
@@ -1231,7 +1231,7 @@
   description: ""
   video_id: cWzsmOw-AFw
 
-- title: "Keynote: Beyond Ruby3.0"
+- title: "Keynote: Beyond Ruby 3.0"
   raw_title: "RubyConf 2021 - Keynote: Beyond Ruby3.0 by Yukihiro (Matz) Matsumoto"
   speakers:
     - Yukihiro "Matz" Matsumoto

--- a/data/rubyday/rubyday-2021/videos.yml
+++ b/data/rubyday/rubyday-2021/videos.yml
@@ -71,7 +71,7 @@
     7th 2021. \n\nSpeaker and details on https://2021.rubyday.it/"
   video_id: OevCwq5I9fM
 
-- title: "Ruby 3.0 and Beyond"
+- title: "Ruby 3 and Beyond"
   raw_title: Ruby3.0 and Beyond - Yukihiro "Matz" Matsumoto - rubyday 2021
   speakers:
     - Yukihiro "Matz" Matsumoto


### PR DESCRIPTION
This pull request introduces the concept of grouped talks (similar to what was described in https://github.com/adrienpoly/rubyvideo/issues/236).

If we find grouped talks on a speaker profile we show a tab bar with "Grouped" and "Ungrouped" options, where the ungrouped option is the previous show page.

| Grouped | Ungrouped |
| --- | --- |
| ![CleanShot 2024-10-27 at 18 33 19](https://github.com/user-attachments/assets/8c08ad64-912c-4fb4-ab10-40209a5a113f) | ![CleanShot 2024-10-27 at 18 39 46](https://github.com/user-attachments/assets/db052602-762a-4432-918b-6de548b40080) | 

if we don't find any grouped talks on a speakers profile we show just the list of talks as it was before:

| No Grouped Talks |
| --- | 
| ![CleanShot 2024-10-25 at 18 52 42](https://github.com/user-attachments/assets/7b6a9a36-1dc1-4149-8785-ed01da286dda) |

