### PR TITLE
uses ahoy js to prevents bot tracking

### DIFF
--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -9,3 +9,10 @@ import '@hotwired/turbo-rails'
 // const channels = import.meta.globEager('./**/*_channel.js')
 
 import '~/controllers'
+
+import ahoy from 'ahoy.js'
+
+ahoy.trackView()
+ahoy.trackClicks('a, button, input[type=submit]')
+ahoy.trackSubmits('form')
+ahoy.trackChanges('input, textarea, select')

--- a/config/initializers/ahoy.rb
+++ b/config/initializers/ahoy.rb
@@ -8,3 +8,5 @@ Ahoy.api = false
 # we recommend configuring local geocoding as well
 # see https://github.com/ankane/ahoy#geocoding
 Ahoy.geocode = false
+
+Ahoy.server_side_visits = :when_needed

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@splidejs/splide": "^4.1.4",
     "@tailwindcss/forms": "^0.5.3",
     "@tailwindcss/typography": "^0.5.15",
+    "ahoy.js": "^0.4.4",
     "chart.js": "^4.3.0",
     "chartkick": "^5.0.1",
     "morphdom": "^2.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -435,6 +435,11 @@ acorn@^8.9.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.12.1.tgz#71616bdccbe25e27a54439e0046e89ca76df2248"
   integrity sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==
 
+ahoy.js@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/ahoy.js/-/ahoy.js-0.4.4.tgz#51bb393fbc6e53962eefac7155642c2d85405238"
+  integrity sha512-LpEf/4Xe4YWAbCN3SUjf58hhWKQzqECRdXJDCRSUp9cgwTul+CnukXxKXavGvoyiYg1QkdVQuO6tx/HELgizlA==
+
 ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"


### PR DESCRIPTION
We recently had lots of fake traffic creating a massive amount of visits 
Ahoy implemements a bot detection feature but backend side it is not always reliable. Using the front end package is [recommended in such cases](https://github.com/ankane/ahoy?tab=readme-ov-file#visits)

let's see if it filters more bot!!!