### PR TITLE
Update videos.yml - fix one EuRuKo2024 video_id reference

### DIFF
--- a/data/euruko/euruko-2024/videos.yml
+++ b/data/euruko/euruko-2024/videos.yml
@@ -989,7 +989,7 @@
     And last but not least, how do we visualize a simulation?\n\nThis presentation
     is a pure Ruby feast. We will operate on MRI and visualize the simulation in two
     ways: with d3.js, and through ASCII art. See you there! \U0001F695"
-  video_id: gS9w_yDJvqo
+  video_id: Qu_Wqe6wkLY
   video_provider: youtube
 
 - title: "The Modern Rubyist: When and How to Use the Latest Features"


### PR DESCRIPTION
video_id of one presentation got changed. 
Currently it shows video unavailable, so here's a fix.

Related links:
https://www.rubyevents.org/talks/visualized-multi-threaded-simulators-in-ruby https://www.youtube.com/watch?v=Qu_Wqe6wkLY