### PR TITLE
add marksmith as a markdown editor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -143,7 +143,12 @@ gem "json-repair", "~> 0.2.0"
 
 gem "redcarpet", "~> 3.6"
 gem "country_select"
+
+# admin
 gem "avo"
+gem "marksmith"
+gem "commonmarker"
+
 gem "frozen_record", "~> 0.27.2"
 gem "diffy"
 gem "discard"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,10 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     chartkick (5.1.4)
+    commonmarker (2.3.0-aarch64-linux)
+    commonmarker (2.3.0-arm64-darwin)
+    commonmarker (2.3.0-x86_64-darwin)
+    commonmarker (2.3.0-x86_64-linux)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
     countries (7.1.1)
@@ -295,6 +299,8 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
+    marksmith (0.4.4)
+      activesupport
     matrix (0.4.2)
     meilisearch (0.28.4)
       httparty (~> 0.17)
@@ -623,6 +629,7 @@ DEPENDENCIES
   byebug (~> 11.1)
   capybara
   chartkick (~> 5.0)
+  commonmarker
   countries
   country_select
   debug
@@ -642,6 +649,7 @@ DEPENDENCIES
   json-repair (~> 0.2.0)
   kamal
   listen (~> 3.5)
+  marksmith
   meilisearch-rails (= 0.14.2)
   meta-tags (~> 2.18)
   minisky (~> 0.4.0)


### PR DESCRIPTION
we were getting some warning in the admin as since a recent AVO release the markdown editor was replaced by the Marksmith editor that mimic Github. 

This PR adds the missing gems to support it. I think it provides a nicer experience than tiny_mce editor

![CleanShot 2025-04-21 at 23 05 15@2x](https://github.com/user-attachments/assets/74ce3785-229b-4c61-9461-4a9e6b2c24e0)
