### PR TITLE
Improve transcript prompt

### DIFF
--- a/app/avo/actions/enhance_transcript.rb
+++ b/app/avo/actions/enhance_transcript.rb
@@ -1,7 +1,8 @@
 class Avo::Actions::EnhanceTranscript < Avo::BaseAction
   self.name = "Enhance Transcript"
   def handle(query:, fields:, current_user:, resource:, **args)
-    query.each do |talk|
+    query.each do |item|
+      talk = item.is_a?(Talk::Transcript) ? item.talk : item
       talk.agents.improve_transcript_later
     end
   end

--- a/app/avo/resources/talk.rb
+++ b/app/avo/resources/talk.rb
@@ -30,12 +30,18 @@ class Avo::Resources::Talk < Avo::BaseResource
     end
     field :updated_at, as: :date, sortable: true
     field :slides_url, as: :text, hide_on: :index
-    field :summary, as: :markdown, hide_on: :index
+    field :summary, as: :easy_mde, hide_on: :index
     field :has_raw_transcript, name: "Raw Transcript", as: :boolean do
       record.raw_transcript.present?
     end
     field :has_enhanced_transcript, hide_on: :index, name: "Enhanced Transcript", as: :boolean do
       record.enhanced_transcript.present?
+    end
+    field :raw_transcript_length, name: "Raw Transcript length", as: :number do
+      record.raw_transcript&.to_text&.length
+    end
+    field :enhanced_transcript_length, name: "Enhanced Transcript length", as: :number do
+      record.enhanced_transcript&.to_text&.length
     end
     field :has_duration, name: "Duration", as: :boolean do
       record.duration_in_seconds.present?
@@ -66,8 +72,8 @@ class Avo::Resources::Talk < Avo::BaseResource
     field :thumbnail_md, as: :external_image, hide_on: :index
     field :thumbnail_lg, as: :external_image, hide_on: :index
     field :thumbnail_xl, as: :external_image, hide_on: :index
-    field :speaker_talks, as: :has_many, attach_scope: -> { query.order(name: :asc) }
-    field :speakers, as: :has_many, attach_scope: -> { query.order(name: :asc) }
+    # field :speaker_talks, as: :has_many, attach_scope: -> { query.order(name: :asc) }
+    field :speakers, as: :has_many
     field :raw_transcript, as: :textarea, hide_on: :index, format_using: -> { value&.to_text }, readonly: true
     field :enhanced_transcript, as: :textarea, hide_on: :index, format_using: -> { value&.to_text }, readonly: true
     # field :suggestions, as: :has_many

--- a/app/avo/resources/talk_transcript.rb
+++ b/app/avo/resources/talk_transcript.rb
@@ -1,0 +1,21 @@
+class Avo::Resources::TalkTranscript < Avo::BaseResource
+  # self.includes = []
+  # self.attachments = []
+  self.model_class = ::Talk::Transcript
+  # self.search = {
+  #   query: -> { query.ransack(id_eq: params[:q], m: "or").result(distinct: false) }
+  # }
+
+  def fields
+    field :id, as: :id
+    field :talk, as: :belongs_to
+    field :raw_transcript, as: :textarea, hide_on: [:index]
+    field :enhanced_transcript, as: :textarea, hide_on: [:index]
+    field :created_at, as: :date_time, sortable: true, hide_on: [:index]
+    field :updated_at, as: :date_time, sortable: true
+  end
+
+  def actions
+    action Avo::Actions::EnhanceTranscript
+  end
+end

--- a/app/controllers/avo/talk_transcripts_controller.rb
+++ b/app/controllers/avo/talk_transcripts_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/3.0/controllers.html
+class Avo::TalkTranscriptsController < Avo::ResourcesController
+end

--- a/app/models/llm/client.rb
+++ b/app/models/llm/client.rb
@@ -1,0 +1,13 @@
+module Llm
+  class Client
+    def initialize(provider_client = OpenAI::Client.new)
+      @provider_client = provider_client
+    end
+
+    def chat(parameters:, resource:, task_name:)
+      LlmRequest.find_or_create_by_request!(parameters, resource: resource, task_name: task_name) do
+        @provider_client.chat(parameters: parameters)
+      end
+    end
+  end
+end

--- a/app/models/llm_request.rb
+++ b/app/models/llm_request.rb
@@ -1,0 +1,51 @@
+# == Schema Information
+#
+# Table name: llm_requests
+#
+#  id            :integer          not null, primary key
+#  duration      :float            not null
+#  raw_response  :json             not null
+#  request_hash  :string           not null, indexed
+#  resource_type :string           not null, indexed => [resource_id]
+#  success       :boolean          default(FALSE), not null
+#  task_name     :string           default(""), not null, indexed
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  resource_id   :integer          not null, indexed => [resource_type]
+#
+# Indexes
+#
+#  index_llm_requests_on_request_hash  (request_hash) UNIQUE
+#  index_llm_requests_on_resource      (resource_type,resource_id)
+#  index_llm_requests_on_task_name     (task_name)
+#
+class LlmRequest < ApplicationRecord
+  belongs_to :resource, polymorphic: true
+
+  validates :request_hash, presence: true, uniqueness: true
+  validates :raw_response, presence: true
+  validates :duration, presence: true
+  validates :success, inclusion: {in: [true, false]}
+
+  class << self
+    def find_or_create_by_request!(request_params, resource:, task_name:, &block)
+      request_hash = Digest::SHA256.hexdigest(request_params.to_json)
+
+      if (cached_request = find_by(request_hash: request_hash, success: true))
+        return cached_request.raw_response
+      end
+
+      start_time = Time.current
+      response = yield
+      duration = Time.current - start_time
+
+      create!(
+        request_hash: request_hash,
+        raw_response: response,
+        duration: duration,
+        resource: resource,
+        success: true # if there is an error the llm api call raise an error and we don't save the request
+      ).raw_response
+    end
+  end
+end

--- a/app/models/prompts/base.rb
+++ b/app/models/prompts/base.rb
@@ -1,5 +1,7 @@
 module Prompts
   class Base
+    MODEL = "gpt-4.1-nano"
+
     def to_params
       {
         model: model,
@@ -11,7 +13,7 @@ module Prompts
     private
 
     def model
-      "gpt-4o-mini"
+      self.class::MODEL
     end
 
     def response_format

--- a/app/models/prompts/talk/enhance_transcript.rb
+++ b/app/models/prompts/talk/enhance_transcript.rb
@@ -1,7 +1,7 @@
 module Prompts
   module Talk
     class EnhanceTranscript < Prompts::Base
-      MODEL = "gpt-4.1-nano"
+      MODEL = "gpt-4.1-mini"
 
       def initialize(talk:)
         @talk = talk
@@ -55,8 +55,14 @@ module Prompts
           4. Group related sentences into paragraphs.
           5. Determine the start and end times for each paragraph.
           6. Format the improved transcript into the specified JSON structure.
+          7. Agregate the timestamps for the paragraphs and write them in the format "00:00:00". Don't include the milliseconds.
 
           Remember to preserve the original meaning of the content while making improvements. Ensure that each JSON object in the array represents a paragraph with its corresponding start time, end time, and improved text.
+
+          Very important :
+          - improve the entire transcript don't stop in the middle of the transcript.
+          - do not add any other text than the transcript.
+          - respect the original timestamps and agregate correctly the timestamps for the paragraphs.
         PROMPT
       end
 

--- a/app/models/prompts/talk/enhance_transcript.rb
+++ b/app/models/prompts/talk/enhance_transcript.rb
@@ -1,6 +1,8 @@
 module Prompts
   module Talk
     class EnhanceTranscript < Prompts::Base
+      MODEL = "gpt-4.1-nano"
+
       def initialize(talk:)
         @talk = talk
       end

--- a/app/models/prompts/talk/summary.rb
+++ b/app/models/prompts/talk/summary.rb
@@ -1,7 +1,7 @@
 module Prompts
   module Talk
     class Summary < Prompts::Base
-      MODEL = "gpt-4.1-mini"
+      MODEL = "gpt-4.1"
 
       def initialize(talk:)
         @talk = talk
@@ -56,7 +56,7 @@ module Prompts
 
           6. Format your summary as a JSON object with the following schema:
             {
-              "summary": "Your summary text here",
+              "summary": "Your summary text here using markdown",
               "keywords": ["keyword1", "keyword2", "keyword3"]
             }
 
@@ -66,6 +66,8 @@ module Prompts
             - Free of personal opinions or external information not present in the provided content
 
           8. Output your JSON object containing the summary, ensuring it is properly formatted and enclosed in <answer> tags.
+
+          9. Uses markdown for the summary to make it more readable define clear sections and uses bullets for the key points. do not use level 1 headings only start from level 2 (##).
         PROMPT
       end
 

--- a/app/models/prompts/talk/summary.rb
+++ b/app/models/prompts/talk/summary.rb
@@ -1,6 +1,8 @@
 module Prompts
   module Talk
     class Summary < Prompts::Base
+      MODEL = "gpt-4.1-mini"
+
       def initialize(talk:)
         @talk = talk
       end

--- a/app/models/prompts/talk/topics.rb
+++ b/app/models/prompts/talk/topics.rb
@@ -1,6 +1,8 @@
 module Prompts
   module Talk
     class Topics < Prompts::Base
+      MODEL = "gpt-4.1-mini"
+
       def initialize(talk:)
         @talk = talk
       end

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -81,7 +81,7 @@ class Talk < ApplicationRecord
   has_many :watch_list_talks, dependent: :destroy
   has_many :watch_lists, through: :watch_list_talks
 
-  has_one :talk_transcript, class_name: "Talk::Transcript", dependent: :destroy, touch: true
+  has_one :talk_transcript, class_name: "Talk::Transcript", dependent: :destroy
   accepts_nested_attributes_for :talk_transcript
   delegate :transcript, :raw_transcript, :enhanced_transcript, to: :talk_transcript, allow_nil: true
 

--- a/app/models/talk/agents.rb
+++ b/app/models/talk/agents.rb
@@ -7,7 +7,9 @@ class Talk::Agents < ActiveRecord::AssociatedObject
 
   performs def improve_transcript
     response = client.chat(
-      parameters: Prompts::Talk::EnhanceTranscript.new(talk: talk).to_params
+      parameters: Prompts::Talk::EnhanceTranscript.new(talk: talk).to_params,
+      resource: talk,
+      task_name: "enhance_transcript"
     )
     raw_response = JSON.repair(response.dig("choices", 0, "message", "content"))
     enhanced_json_transcript = JSON.parse(raw_response).dig("transcript")
@@ -19,7 +21,9 @@ class Talk::Agents < ActiveRecord::AssociatedObject
     return unless talk.raw_transcript.present?
 
     response = client.chat(
-      parameters: Prompts::Talk::Summary.new(talk: talk).to_params
+      parameters: Prompts::Talk::Summary.new(talk: talk).to_params,
+      resource: talk,
+      task_name: "summarize"
     )
 
     raw_response = JSON.repair(response.dig("choices", 0, "message", "content"))
@@ -31,7 +35,9 @@ class Talk::Agents < ActiveRecord::AssociatedObject
     return if talk.raw_transcript.blank?
 
     response = client.chat(
-      parameters: Prompts::Talk::Topics.new(talk: talk).to_params
+      parameters: Prompts::Talk::Topics.new(talk: talk).to_params,
+      resource: talk,
+      task_name: "analyze_topics"
     )
 
     raw_response = JSON.repair(response.dig("choices", 0, "message", "content"))
@@ -50,6 +56,6 @@ class Talk::Agents < ActiveRecord::AssociatedObject
   private
 
   def client
-    OpenAI::Client.new
+    @client ||= Llm::Client.new
   end
 end

--- a/app/models/talk/transcript.rb
+++ b/app/models/talk/transcript.rb
@@ -18,7 +18,7 @@
 #  talk_id  (talk_id => talks.id)
 #
 class Talk::Transcript < ApplicationRecord
-  belongs_to :talk
+  belongs_to :talk, touch: true
 
   serialize :enhanced_transcript, coder: TranscriptSerializer
   serialize :raw_transcript, coder: TranscriptSerializer

--- a/db/migrate/20250426063312_add_llm_requests.rb
+++ b/db/migrate/20250426063312_add_llm_requests.rb
@@ -1,0 +1,11 @@
+class AddLlmRequests < ActiveRecord::Migration[8.0]
+    def change
+    create_table :llm_requests do |t|
+      t.string :request_hash, null: false, index: { unique: true }
+      t.json :raw_response, null: false
+      t.float :duration, null: false
+      t.references :resource, polymorphic: true, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250427062021_add_success_to_llm_requests.rb
+++ b/db/migrate/20250427062021_add_success_to_llm_requests.rb
@@ -1,0 +1,8 @@
+class AddSuccessToLlmRequests < ActiveRecord::Migration[8.0]
+  def change
+    add_column :llm_requests, :success, :boolean, null: false, default: false
+    add_column :llm_requests, :task_name, :string, null: false, default: ""
+
+    add_index :llm_requests, :task_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_18_073648) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_27_062021) do
   create_table "ahoy_events", force: :cascade do |t|
     t.integer "visit_id"
     t.integer "user_id"
@@ -87,6 +87,21 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_18_073648) do
     t.index ["name"], name: "index_events_on_name"
     t.index ["organisation_id"], name: "index_events_on_organisation_id"
     t.index ["slug"], name: "index_events_on_slug"
+  end
+
+  create_table "llm_requests", force: :cascade do |t|
+    t.string "request_hash", null: false
+    t.json "raw_response", null: false
+    t.float "duration", null: false
+    t.string "resource_type", null: false
+    t.integer "resource_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "success", default: false, null: false
+    t.string "task_name", default: "", null: false
+    t.index ["request_hash"], name: "index_llm_requests_on_request_hash", unique: true
+    t.index ["resource_type", "resource_id"], name: "index_llm_requests_on_resource"
+    t.index ["task_name"], name: "index_llm_requests_on_task_name"
   end
 
   create_table "organisations", force: :cascade do |t|

--- a/test/models/talk_test.rb
+++ b/test/models/talk_test.rb
@@ -105,9 +105,11 @@ class TalkTest < ActiveSupport::TestCase
 
     refute @talk.enhanced_transcript.cues.present?
     VCR.use_cassette("talks/transcript-enhancement") do
-      assert_changes "@talk.reload.enhanced_transcript.cues.count" do
-        perform_enqueued_jobs do
-          @talk.agents.improve_transcript_later
+      assert_changes "@talk.reload.updated_at" do
+        assert_changes "@talk.reload.enhanced_transcript.cues.count" do
+          perform_enqueued_jobs do
+            @talk.agents.improve_transcript_later
+          end
         end
       end
       assert @talk.enhanced_transcript.cues.present?

--- a/test/models/talk_test.rb
+++ b/test/models/talk_test.rb
@@ -324,4 +324,119 @@ class TalkTest < ActiveSupport::TestCase
     assert_equal 0, talk.kept_speaker_talks.count
     assert_equal 0, speaker_talk.speaker.talks_count
   end
+
+  test "llm request caching for transcript enhancement" do
+    @talk = talks(:one)
+    @talk = Talk.includes(event: :organisation).find(@talk.id)
+
+    refute @talk.enhanced_transcript.cues.present?
+    VCR.use_cassette("talks/transcript-enhancement") do
+      assert_changes "@talk.reload.updated_at" do
+        assert_changes "@talk.reload.enhanced_transcript.cues.count" do
+          perform_enqueued_jobs do
+            @talk.agents.improve_transcript_later
+          end
+        end
+      end
+      assert @talk.enhanced_transcript.cues.present?
+
+      # Verify LLM request was created
+      assert_equal 1, LlmRequest.count
+      request = LlmRequest.first
+      assert_equal @talk, request.resource
+      assert request.duration > 0
+      assert request.raw_response.present?
+
+      # Second call should use cache
+      assert_no_changes "LlmRequest.count" do
+        perform_enqueued_jobs do
+          @talk.agents.improve_transcript_later
+        end
+      end
+    end
+  end
+
+  test "llm request caching for summarization" do
+    @talk = talks(:one)
+    @talk = Talk.includes(event: :organisation).find(@talk.id)
+
+    refute @talk.summary.present?
+    VCR.use_cassette("talks/summarize") do
+      assert_changes "@talk.reload.summary.present?" do
+        perform_enqueued_jobs do
+          @talk.agents.summarize_later
+        end
+      end
+      assert @talk.summary.present?
+
+      # Verify LLM request was created
+      assert_equal 1, LlmRequest.count
+      request = LlmRequest.first
+      assert_equal @talk, request.resource
+      assert request.duration > 0
+      assert request.raw_response.present?
+
+      # Second call should use cache
+      assert_no_changes "LlmRequest.count" do
+        perform_enqueued_jobs do
+          @talk.agents.summarize_later
+        end
+      end
+    end
+  end
+
+  test "llm request caching for topic analysis" do
+    @talk = talks(:one)
+
+    VCR.use_cassette("talks/extract_topics") do
+      assert_changes "@talk.topics.count" do
+        perform_enqueued_jobs do
+          @talk.agents.analyze_topics_later
+        end
+      end
+
+      # Verify LLM request was created
+      assert_equal 1, LlmRequest.count
+      request = LlmRequest.first
+      assert_equal @talk, request.resource
+      assert request.duration > 0
+      assert request.raw_response.present?
+
+      # Second call should use cache
+      assert_no_changes "LlmRequest.count" do
+        perform_enqueued_jobs do
+          @talk.agents.analyze_topics_later
+        end
+      end
+    end
+  end
+
+  test "llm request caching with successful response" do
+    @talk = talks(:one)
+    @talk = Talk.includes(event: :organisation).find(@talk.id)
+
+    VCR.use_cassette("talks/transcript-enhancement") do
+      # First call should succeed and create a successful request
+      assert_changes "@talk.reload.enhanced_transcript.cues.count" do
+        perform_enqueued_jobs do
+          @talk.agents.improve_transcript_later
+        end
+      end
+
+      # Verify successful request was created
+      assert_equal 1, LlmRequest.count
+      request = LlmRequest.first
+      assert_equal @talk, request.resource
+      assert request.duration > 0
+      assert request.raw_response.present?
+      assert request.success
+
+      # Second call should use cache
+      assert_no_changes "LlmRequest.count" do
+        perform_enqueued_jobs do
+          @talk.agents.improve_transcript_later
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR adds several improvements to the AI prompts and Agents
- uses by default OpenAI 4.1-nano and mini that offers a 1M context (good for long transcript) and better performances
- I have reworked a bit the prompt
- added an LlmRequest model to store the request and response. This model provides a way to track with which modle and prompt the talk was processed