### PR TITLE
Add Tropical on Rails 2025 talks

### DIFF
--- a/data/tropicalrb/playlists.yml
+++ b/data/tropicalrb/playlists.yml
@@ -20,7 +20,7 @@
   title: Tropical on Rails 2025
   location: "São Paulo, Brazil"
   description: Nearly twice as big, Tropical on Rails is back! Seasoned programmers, entrepreneurs, and students from all over Latin America and other countries, gathering for two days of top-notch content, international speakers, and networking!
-  published_at: "TODO"
+  published_at: "2025-05-09"
   start_date: "2025-04-03"
   end_date: "2025-04-04"
   channel_id: ""

--- a/data/tropicalrb/tropical-on-rails-2025/videos.yml
+++ b/data/tropicalrb/tropical-on-rails-2025/videos.yml
@@ -4,10 +4,10 @@
     - Irina Nazarova
   event_name: Tropical on Rails 2025
   date: "2025-04-03"
-  published_at: "TODO"
+  published_at: "2025-04-25"
   announced_at: "2024-10-23 18:00:00 UTC"
-  video_provider: not_published
-  video_id: "irina-nazarova-tropical-on-rails-2025"
+  video_provider: youtube
+  video_id: "_eLfPFxztjs"
   id: "irina-nazarova-tropical-on-rails-2025"
   language: "english"
   slides_url: https://speakerdeck.com/irinanazarova/startups-on-rails-2025-at-tropical-on-rails
@@ -24,10 +24,10 @@
     - Gustavo Araújo
   event_name: Tropical on Rails 2025
   date: "2025-04-03"
-  published_at: "TODO"
+  published_at: "2025-05-06"
   announced_at: "2025-01-29 17:23:00 UTC"
-  video_provider: not_published
-  video_id: "gustavo-araujo-tropical-on-rails-2025"
+  video_provider: youtube
+  video_id: "O7fzUfAjZQA"
   id: "gustavo-araujo-tropical-on-rails-2025"
   language: "portuguese"
   slides_url: https://www.slideshare.net/slideshow/scalling-rails-the-journey-to-200m-notifications/277497024
@@ -42,10 +42,10 @@
     - Marco Roth
   event_name: Tropical on Rails 2025
   date: "2025-04-03"
-  published_at: "TODO"
+  published_at: "2025-05-06"
   announced_at: "2025-02-05 17:47:00 UTC"
-  video_provider: not_published
-  video_id: "marco-roth-tropical-on-rails-2025"
+  video_provider: youtube
+  video_id: "cmsSA41eWxs"
   id: "marco-roth-tropical-on-rails-2025"
   language: "english"
   slides_url: https://speakerdeck.com/marcoroth/scaling-rubyvideo-dot-dev-the-mission-to-index-all-ruby-conferences
@@ -54,16 +54,16 @@
 
     In his talk "Scaling RubyVideo.dev: The mission to index all Ruby conferences", Marco will share how he is building a comprehensive repository of Ruby talks. He will address technical challenges, strategies, and bring exclusive announcements!
 
-- title: "Keynote: Padronização estratégica: direcionando inovação"
+- title: "Keynote: Strategic Standardization: Driving Innovation"
   raw_title: "Keynote - Padronização estratégica: direcionando inovação"
   speakers:
     - Vinicius Stock
   event_name: Tropical on Rails 2025
   date: "2025-04-03"
-  published_at: "TODO"
+  published_at: "2025-05-01"
   announced_at: "2024-10-22 15:00:00 UTC"
-  video_provider: not_published
-  video_id: "vinicius-stock-tropical-on-rails-2025"
+  video_provider: youtube
+  video_id: "Syfa0wSzqdE"
   id: "vinicius-stock-tropical-on-rails-2025"
   language: "portuguese"
   description: |-
@@ -79,10 +79,10 @@
     - Edigleysson Silva
   event_name: Tropical on Rails 2025
   date: "2025-04-03"
-  published_at: "TODO"
+  published_at: "2025-05-06"
   announced_at: "2025-01-29 17:23:00 UTC"
-  video_provider: not_published
-  video_id: "edigleysson-silva-tropical-on-rails-2025"
+  video_provider: youtube
+  video_id: "iG9ZOc103hk"
   id: "edigleysson-silva-tropical-on-rails-2025"
   language: "english"
   slides_url: https://docs.google.com/presentation/d/1Wk6f0VJ3G_GBXghl9AUskJQy2XAY9i63UyqOZxhHdgA/view
@@ -99,10 +99,10 @@
     - Daniel Medina
   event_name: Tropical on Rails 2025
   date: "2025-04-03"
-  published_at: "TODO"
+  published_at: "2025-05-06"
   announced_at: "2025-02-04 14:51:00 UTC"
-  video_provider: not_published
-  video_id: "daniel-medina-tropical-on-rails-2025"
+  video_provider: youtube
+  video_id: "gVh3qzq3MAw"
   id: "daniel-medina-tropical-on-rails-2025"
   language: "english"
   description: |-
@@ -116,10 +116,10 @@
     - Jackson Pires
   event_name: Tropical on Rails 2025
   date: "2025-04-03"
-  published_at: "TODO"
+  published_at: "2025-05-06"
   announced_at: "2025-01-27 15:43:00 UTC"
-  video_provider: not_published
-  video_id: "jackson-pires-tropical-on-rails-2025"
+  video_provider: youtube
+  video_id: "4dXtI4QyT6Y"
   id: "jackson-pires-tropical-on-rails-2025"
   language: "portuguese"
   description: |-
@@ -133,8 +133,8 @@
   date: "2025-04-03"
   published_at: "TODO"
   announced_at: "2025-02-04 14:56:00 UTC"
-  video_provider: not_published
-  video_id: "svyatoslav-kryukov-tropical-on-rails-2025"
+  video_provider: youtube
+  video_id: "uLFItMoF_wA"
   id: "svyatoslav-kryukov-tropical-on-rails-2025"
   slides_url: https://speakerdeck.com/skryukov/defying-front-end-inertia-inertia-dot-js-on-rails
   language: "english"
@@ -149,10 +149,10 @@
     - Xavier Noria
   event_name: Tropical on Rails 2025
   date: "2025-04-03"
-  published_at: "TODO"
+  published_at: "2025-04-29"
   announced_at: "2024-10-24 18:50:00 UTC"
-  video_provider: not_published
-  video_id: "xavier-noria-tropical-on-rails-2025"
+  video_provider: youtube
+  video_id: "94cEvPuy3no"
   id: "xavier-noria-tropical-on-rails-2025"
   language: "english"
   description: |-
@@ -166,10 +166,10 @@
     - Chris Oliver
   event_name: Tropical on Rails 2025
   date: "2025-04-04"
-  published_at: "TODO"
+  published_at: "2025-05-07"
   announced_at: "2024-10-11 15:30:00 UTC"
-  video_provider: not_published
-  video_id: "chris-oliver-tropical-on-rails-2025"
+  video_provider: youtube
+  video_id: "9LekwjCer3M"
   id: "chris-oliver-tropical-on-rails-2025"
   slides_url: https://a.cl.ly/jkuBq5L9
   language: "english"
@@ -302,10 +302,10 @@
     - Rosa Gutiérrez
   event_name: Tropical on Rails 2025
   date: "2025-04-04"
-  published_at: "TODO"
+  published_at: "2025-06-08"
   announced_at: "2024-10-16 15:59:00 UTC"
-  video_provider: not_published
-  video_id: "rosa-gutierrez-tropical-on-rails-2025"
+  video_provider: youtube
+  video_id: "1y1N9Fa7VDA"
   id: "rosa-gutierrez-tropical-on-rails-2025"
   language: "english"
   slides_url: https://rosa.codes/executor2025/presentation/


### PR DESCRIPTION
Adds the Tropical on Rails 2025 talks that have been published so far

![CleanShot 2025-05-09 at 12 59 02@2x](https://github.com/user-attachments/assets/aafe305f-25be-4786-b5f7-37cdeda641f3)
