### PR TITLE
Clarify password change side-effect at the controller level

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -8,7 +8,7 @@ class PasswordsController < ApplicationController
     if !@user.authenticate(params[:current_password])
       redirect_to edit_password_path, alert: "The current password you entered is incorrect"
     elsif @user.update(user_params)
-      Current.session.sign_out_siblings
+      Current.session.sign_out_siblings!
       redirect_to root_path, notice: "Your password has been changed"
     else
       render :edit, status: :unprocessable_entity

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -8,6 +8,7 @@ class PasswordsController < ApplicationController
     if !@user.authenticate(params[:current_password])
       redirect_to edit_password_path, alert: "The current password you entered is incorrect"
     elsif @user.update(user_params)
+      Current.session.sign_out_siblings
       redirect_to root_path, notice: "Your password has been changed"
     else
       render :edit, status: :unprocessable_entity

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -27,7 +27,7 @@ class Session < ApplicationRecord
     self.ip_address = Current.ip_address
   end
 
-  def sign_out_siblings
+  def sign_out_siblings!
     user.sessions.without(self).delete_all
   end
 end

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -26,4 +26,8 @@ class Session < ApplicationRecord
     self.user_agent = Current.user_agent
     self.ip_address = Current.ip_address
   end
+
+  def sign_out_siblings
+    user.sessions.without(self).delete_all
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,10 +56,6 @@ class User < ApplicationRecord
       .strip.downcase
   end
 
-  after_update if: :password_digest_previously_changed? do
-    sessions.where.not(id: Current.session).delete_all
-  end
-
   def default_watch_list
     @default_watch_list ||= watch_lists.first || watch_lists.create(name: "Favorites")
   end


### PR DESCRIPTION
Changing a password has ramifications for the system, I'd say that's part of the main story that the controller is telling and so should be included in the controller.

So we extract the logic into the domain model method `sign_out_siblings` on `Session`.

This also means we don't tie `Current` context to `User` in this case.