### PR TITLE
Add basic path configuration for Hotwire Native Android

### DIFF
--- a/app/controllers/hotwire/native/v1/android/path_configurations_controller.rb
+++ b/app/controllers/hotwire/native/v1/android/path_configurations_controller.rb
@@ -1,5 +1,20 @@
 class Hotwire::Native::V1::Android::PathConfigurationsController < ActionController::Base
   def show
-    render json: {}
+    render json: {
+      settings: {},
+      rules: [
+        {
+          patterns: [
+            ".*"
+          ],
+          properties: {
+            context: "default",
+            uri: "hotwire://fragment/web",
+            fallback_uri: "hotwire://fragment/web",
+            pull_to_refresh_enabled: true
+          }
+        }
+      ]
+    }
   end
 end


### PR DESCRIPTION
This PR adds a simple path configuration for Hotwire Native Android in preparation for the [RubyEvents Android](https://github.com/rubyevents/rubyevents-android) mobile app.
It doesn't include the same configuration as [the iOS version](https://github.com/rubyevents/rubyevents/blob/main/app/controllers/hotwire/native/v1/ios/path_configurations_controller.rb), since the config for `/player$`, `/new$`, and `/edit$` are currently not used. Please correct me if I'm wrong.