### PR TITLE
Enable page caching for Hotwire Native apps

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,9 @@
     <%= vite_javascript_tag "application", media: "all", "data-turbo-track": "reload" %>
     <%= vite_stylesheet_tag "application.css", media: "all", "data-turbo-track": "reload" %>
 
-    <meta name="turbo-cache-control" content="no-cache">
+    <% unless hotwire_native_app? %>
+      <meta name="turbo-cache-control" content="no-cache">
+    <% end %>
     <meta name="view-transition" content="same-origin">
 
     <%= favicon_link_tag "favicon/favicon.ico", rel: "icon", type: "image/x-icon" %>


### PR DESCRIPTION
Currently, on every back navigation in the iOS mobile app, the app reloads the page, like this:


https://github.com/user-attachments/assets/ed19964b-e731-4cc6-bdba-b71e194742ec


Normally, a reload like this happens when an asset marked with `data-turbo-track="reload"` has changed, or after submitting a form and going back to the previous page.


But that’s not what’s happening here. Instead, it’s caused by this meta tag:

```html
<meta name="turbo-cache-control" content="no-cache">
```

This was added in this [PR](https://github.com/rubyevents/rubyevents/pull/367), and it seems to be added to prevent some glitches in page view transitions.

However, it comes with a side effect: when navigating back, the user sees a brief loading spinner in the center of the screen — and during that time, they can't interact with the app. It also adds a bit of unnecessary server load.

This PR removes the meta tag when the site is requested by a Hotwire Native app.

---

Ideally, we wouldn’t need the `turbo-cache-control` meta tag at all. In the original PR, it was added to smooth out some page transition glitches:

> fixes a few page view transition glitchs so they are now smoother


@adrienpoly, do you remember where those glitches occurred? I clicked through the web app a bit, without this meta tag, but didn’t notice anything at first glance.
If the glitches only affect a few pages,  another option might be to use the [`turbo_exempts_page_from_cache`](https://github.com/hotwired/turbo-rails/blob/cb47713ab2abc0692e36215cb7e60d48461ae654/app/helpers/turbo/drive_helper.rb#L21) method provided by the turbo-rails gem, to set the meta tag only on those specific pages.