### PR TITLE
Shorten home page title for the Android app

### DIFF
--- a/app/views/page/home.html.erb
+++ b/app/views/page/home.html.erb
@@ -1,4 +1,4 @@
-<% title "RubyEvents.org - On a mission to index all Ruby events" %>
+<% title hotwire_native_app? ? "RubyEvents" : "RubyEvents.org - On a mission to index all Ruby events" %>
 
 <main class="container hotwire-native:mt-6">
   <div class="hotwire-native:hidden w-full flex flex-col items-center pt-16 pb-12 text-center">


### PR DESCRIPTION
As discussed with @marcoroth, the Android app will not have a native home screen. At least not in the first version.  
Therefore, the Android app will use the same home page as the web app, including its title.   
Currently, the title is a bit long for a mobile app. This PR would shorten the title a bit when rendering the HTML for a Hotwire Native app.

| Before | After |
|--------|-------|
| ![Screenshot_before](https://github.com/user-attachments/assets/04dbf3d0-3e57-4f32-82a5-7b6ceba3398a) | ![Screenshot_after](https://github.com/user-attachments/assets/7108613b-2ff6-4d0a-9a73-c0ea9e9e6b01) |
