### PR TITLE
Update Tailwind variants to detect Hotwire Native requests server-side

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" <%= 'data-hotwire-native-app' if hotwire_native_app? %>>
   <head>
     <meta name="viewport" content="width=device-width,initial-scale=1<%= ",maximum-scale=1,user-scalable=0" if hotwire_native_app? %>">
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" <%= 'data-hotwire-native-app' if hotwire_native_app? %>>
+<html lang="en" <%= "data-hotwire-native-app" if hotwire_native_app? %>>
   <head>
     <meta name="viewport" content="width=device-width,initial-scale=1<%= ",maximum-scale=1,user-scalable=0" if hotwire_native_app? %>">
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -90,8 +90,8 @@ module.exports = {
     require('@tailwindcss/typography'),
     require('daisyui'),
     plugin(function ({ addVariant }) {
-      addVariant('hotwire-native', 'html[data-bridge-platform] &')
-      addVariant('non-hotwire-native', 'html:not([data-bridge-platform]) &')
+      addVariant('hotwire-native', 'html[data-hotwire-native-app] &')
+      addVariant('non-hotwire-native', 'html:not([data-hotwire-native-app]) &')
     })
   ]
 }


### PR DESCRIPTION
I've noticed on my Android phone that the Tailwind variants `hotwire-native` and `non-hotwire-native` have a slight delay.
They don't work immediately but take a short moment to activate. This causes a brief flash of unwanted content in the mobile app.
Here’s a screen recording, where you can see the flash of the top banner and navbar briefly appear.

https://github.com/user-attachments/assets/a358d768-c803-4768-891c-5cb1b5bda224




This happens because the `data-bridge-platform` attribute isn't set right away. It's only set once the native code calls `setAdapter` on the HotwireBridge, which happens after the JS code is loaded and the first native component gets registered.
To be honest, I'm not sure why this isn't an issue on iOS. My guess is that iOS/WebKit is a bit more performant, so the JS loads faster.
Maybe you would see the same issue on an older iOS device 🤷

This PR uses the approach of determining mobile / desktop server-side by checking the user agent. 

---

Note: An alternative approach would be to set the necessary data attributes server-side by parsing the user agent.
I've done this in other projects to prevent flashing of bridge components:

```html
<html data-bridge-platform="<%= current_mobile_app.platform %>" data-bridge-components="<%= current_mobile_app.supported_bridge_components %>">
```

But since RubyEvents currently doesn't make use of bridge components, I though it's best to keep it simple.

