### PR TITLE
Prevent overflow in the events header

### DIFF
--- a/app/views/events/_header.html.erb
+++ b/app/views/events/_header.html.erb
@@ -22,7 +22,7 @@
             style: "view-transition-name: avatar",
             loading: :lazy %>
 
-      <div class="flex-col flex justify-center">
+      <div class="flex-col flex justify-center break-all">
         <h1 class="mb-2 text-black font-bold" style="view-transition-name: title"><%= event.name %></h1>
         <h3 class="text-[#636B74]"><%= event.location %> • <%= event.formatted_dates %></h3>
         <%= external_link_to event.website.gsub(%r{^https?://}, "").gsub(%r{/$}, ""), event.website %>


### PR DESCRIPTION
Tiny PR that prevents an overflow which could occur in the mobile app when an event has a long URL

| Before | After |
|--------|-------|
| ![before](https://github.com/user-attachments/assets/efba8b4d-6f29-441f-b145-e6156ed6535a) | ![after](https://github.com/user-attachments/assets/9149b405-1606-4ecb-b847-2805e0833f1f) |
