### PR TITLE
Add original title for talks

### DIFF
--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -15,6 +15,7 @@
 #  language            :string           default("en"), not null
 #  like_count          :integer          default(0)
 #  meta_talk           :boolean          default(FALSE), not null
+#  original_title      :string           default(""), not null
 #  published_at        :datetime
 #  slides_url          :string
 #  slug                :string           default(""), not null, indexed
@@ -488,6 +489,7 @@ class Talk < ApplicationRecord
     assign_attributes(
       event: event,
       title: static_metadata.title,
+      original_title: static_metadata.original_title || "",
       description: static_metadata.description,
       date: static_metadata.try(:date) || parent_talk&.static_metadata.try(:date),
       published_at: static_metadata.try(:published_at) || parent_talk&.static_metadata.try(:published_at),

--- a/app/views/talks/_talk.html.erb
+++ b/app/views/talks/_talk.html.erb
@@ -72,6 +72,10 @@
       <div class="flex flex-wrap w-full divide-y justify-between">
         <div class="py-4 font-bold text-xl">
           <span><%= talk.title %></span>
+          <% if talk.original_title.present? %>
+            <div class="text-gray-500 text-xs mb-2">Original title: <%= talk.original_title %></div>
+          <% end %>
+
         </div>
 
         <div class="flex grow gap-1 py-3 lg:divide-y-0 text-xs xl:justify-end overflow-y-visible overflow-x-scroll lg:overflow-x-hidden order-last xl:order-none">

--- a/app/views/talks/show.json.jbuilder
+++ b/app/views/talks/show.json.jbuilder
@@ -1,6 +1,7 @@
 json.talk do
   json.slug @talk.slug
   json.title @talk.title
+  json.original_title @talk.original_title
   json.description @talk.description
   json.summary @talk.summary
   json.date @talk.date

--- a/db/migrate/20250521011731_add_original_title_to_talks.rb
+++ b/db/migrate/20250521011731_add_original_title_to_talks.rb
@@ -1,0 +1,5 @@
+class AddOriginalTitleToTalks < ActiveRecord::Migration[8.0]
+  def change
+    add_column :talks, :original_title, :string, default: "", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_18_073648) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_21_011731) do
   create_table "ahoy_events", force: :cascade do |t|
     t.integer "visit_id"
     t.integer "user_id"
@@ -232,6 +232,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_18_073648) do
     t.integer "duration_in_seconds"
     t.datetime "announced_at"
     t.datetime "published_at"
+    t.string "original_title", default: "", null: false
     t.index ["date"], name: "index_talks_on_date"
     t.index ["event_id"], name: "index_talks_on_event_id"
     t.index ["kind"], name: "index_talks_on_kind"

--- a/test/fixtures/talks.yml
+++ b/test/fixtures/talks.yml
@@ -15,6 +15,7 @@
 #  language            :string           default("en"), not null
 #  like_count          :integer          default(0)
 #  meta_talk           :boolean          default(FALSE), not null
+#  original_title      :string           default(""), not null
 #  published_at        :datetime
 #  slides_url          :string
 #  slug                :string           default(""), not null, indexed
@@ -96,3 +97,13 @@ brightonruby_2024_one:
   external_player: true
   event: brightonruby_2024
   date: "2024-06-30"
+
+non_english_talk_one:
+  title: Non English Talk Title
+  original_title: Palestra não em inglês
+  description: Non English talk description
+  slug: non-english-talk-title
+  kind: "talk"
+  video_provider: mp4
+  external_player: true
+  date: "2025-05-20"

--- a/test/models/talk_test.rb
+++ b/test/models/talk_test.rb
@@ -322,4 +322,10 @@ class TalkTest < ActiveSupport::TestCase
     assert_equal 0, talk.kept_speaker_talks.count
     assert_equal 0, speaker_talk.speaker.talks_count
   end
+
+  test "should return original title" do
+    talk = talks(:non_english_talk_one)
+
+    assert_equal "Palestra não em inglês", talk.original_title
+  end
 end


### PR DESCRIPTION
I read the issue #697 and I added the field `original_title` to talks table.
Below an example of usage:


<img width="1214" alt="Screenshot 2025-05-20 at 23 38 42" src="https://github.com/user-attachments/assets/74493042-66fe-4d47-ac07-01599b4bb571" />

After run `rake db:seed`


<img width="1357" alt="Screenshot 2025-05-20 at 23 39 01" src="https://github.com/user-attachments/assets/d2ace409-655c-4555-a906-e3247934ff82" />



