### PR TITLE
Add https:// to speaker website when missing for fix redirect

### DIFF
--- a/app/helpers/view_component_helper.rb
+++ b/app/helpers/view_component_helper.rb
@@ -25,8 +25,6 @@ module ViewComponentHelper
       text = capture(&)
     end
 
-    url = "http://#{url}" if URI(url).scheme.nil?
-
     classes = class_names("link inline-flex items-center gap-2 flex-nowrap", attributes.delete(:class))
     link_to url, class: classes, target: "_blank", rel: "noopener noreferrer", **attributes do
       concat(content_tag(:span) { text }).concat(fa("arrow-up-right-from-square", size: :xs))

--- a/app/helpers/view_component_helper.rb
+++ b/app/helpers/view_component_helper.rb
@@ -25,6 +25,8 @@ module ViewComponentHelper
       text = capture(&)
     end
 
+    url = "http://#{url}" if URI(url).scheme.nil?
+
     classes = class_names("link inline-flex items-center gap-2 flex-nowrap", attributes.delete(:class))
     link_to url, class: classes, target: "_blank", rel: "noopener noreferrer", **attributes do
       concat(content_tag(:span) { text }).concat(fa("arrow-up-right-from-square", size: :xs))

--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -103,7 +103,7 @@ class Speaker < ApplicationRecord
     return website if website.start_with?("https://")
 
     # if it starts with http://, convert it to https://
-    return website.sub("http://", "https://") if website.start_with?("http://")
+    return website if website.start_with?("http://")
 
     # otherwise, prepend https://
     "https://#{website}"

--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -96,6 +96,19 @@ class Speaker < ApplicationRecord
     "https://#{instance}/@#{handle}"
   }
 
+  normalizes :website, with: ->(website) {
+    return "" if website.blank?
+
+    # if it already starts with https://, return as is
+    return website if website.start_with?("https://")
+
+    # if it starts with http://, convert it to https://
+    return website.sub("http://", "https://") if website.start_with?("http://")
+
+    # otherwise, prepend https://
+    "https://#{website}"
+  }
+
   def self.reset_talks_counts
     find_each do |speaker|
       speaker.update_column(:talks_count, speaker.talks.count)
@@ -177,19 +190,6 @@ class Speaker < ApplicationRecord
 
   def broadcast_header
     broadcast_update target: dom_id(self, :header_content), partial: "speakers/header_content", locals: {speaker: self}
-  end
-
-  def valid_website_url
-    return "#" if website.blank?
-
-    # if it already starts with https://, return as is
-    return website if website.start_with?("https://")
-
-    # if it starts with http://, convert it to https://
-    return website.sub("http://", "https://") if website.start_with?("http://")
-
-    # otherwise, prepend https://
-    "https://#{website}"
   end
 
   def to_meta_tags

--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -102,7 +102,7 @@ class Speaker < ApplicationRecord
     # if it already starts with https://, return as is
     return website if website.start_with?("https://")
 
-    # if it starts with http://, convert it to https://
+    # if it starts with http://, return as is
     return website if website.start_with?("http://")
 
     # otherwise, prepend https://

--- a/db/migrate/20250524174213_normalize_speaker_website.rb
+++ b/db/migrate/20250524174213_normalize_speaker_website.rb
@@ -1,9 +1,5 @@
 class NormalizeSpeakerWebsite < ActiveRecord::Migration[8.0]
   def change
-    # Fix an edge case where twitter and website are in the same field
-    speaker = Speaker.find_by(slug: "derrick-ko")
-    speaker.update(website: "http://derrickko.com", twitter: "http://twitter.com/derrickko")
-
     Speaker.where.not(website: [nil, ""]).find_in_batches do |speakers|
       speakers.each do |speaker|
         speaker.normalize_attribute(:website)

--- a/db/migrate/20250524174213_normalize_speaker_website.rb
+++ b/db/migrate/20250524174213_normalize_speaker_website.rb
@@ -1,0 +1,14 @@
+class NormalizeSpeakerWebsite < ActiveRecord::Migration[8.0]
+  def change
+    # Fix an edge case where twitter and website are in the same field
+    speaker = Speaker.find_by(slug: "derrick-ko")
+    speaker.update(website: "http://derrickko.com", twitter: "http://twitter.com/derrickko")
+
+    Speaker.where.not(website: [nil, ""]).find_in_batches do |speakers|
+      speakers.each do |speaker|
+        speaker.normalize_attribute(:website)
+        speaker.save
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_21_011731) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_24_174213) do
   create_table "ahoy_events", force: :cascade do |t|
     t.integer "visit_id"
     t.integer "user_id"

--- a/test/controllers/speakers_controller_test.rb
+++ b/test/controllers/speakers_controller_test.rb
@@ -95,7 +95,7 @@ class SpeakersControllerTest < ActionDispatch::IntegrationTest
     assert_equal "new bio", @speaker.reload.bio
     assert_equal @speaker.name, "new-name"
     assert_equal @speaker.twitter, "new-twitter"
-    assert_equal @speaker.website, "new-website"
+    assert_equal @speaker.website, "https://new-website"
     assert_equal user.id, @speaker.suggestions.last.suggested_by_id
   end
 

--- a/test/models/speaker_test.rb
+++ b/test/models/speaker_test.rb
@@ -11,9 +11,9 @@ class SpeakerTest < ActiveSupport::TestCase
     assert_equal "https://www.google.com", speaker.website
   end
 
-  test "normalizes website convert http to https" do
+  test "normalizes website keep http" do
     speaker = Speaker.new(website: "http://www.google.com")
-    assert_equal "https://www.google.com", speaker.website
+    assert_equal "http://www.google.com", speaker.website
   end
 
   test "normalizes website returns '' if website is blank" do

--- a/test/models/speaker_test.rb
+++ b/test/models/speaker_test.rb
@@ -1,24 +1,24 @@
 require "test_helper"
 
 class SpeakerTest < ActiveSupport::TestCase
-  test "valid_website_url preserve the website url if already valid" do
+  test "normalizes website preserve the website url if already valid" do
     speaker = Speaker.new(website: "https://www.google.com")
-    assert_equal "https://www.google.com", speaker.valid_website_url
+    assert_equal "https://www.google.com", speaker.website
   end
 
-  test "valid_website_url add https to the website if it is not present" do
+  test "normalizes website add https to the website if it is not present" do
     speaker = Speaker.new(website: "www.google.com")
-    assert_equal "https://www.google.com", speaker.valid_website_url
+    assert_equal "https://www.google.com", speaker.website
   end
 
-  test "valid_website_url convert http to https" do
+  test "normalizes website convert http to https" do
     speaker = Speaker.new(website: "http://www.google.com")
-    assert_equal "https://www.google.com", speaker.valid_website_url
+    assert_equal "https://www.google.com", speaker.website
   end
 
-  test "valid_website_url returns # if website is blank" do
+  test "normalizes website returns '' if website is blank" do
     speaker = Speaker.new(website: "")
-    assert_equal "#", speaker.valid_website_url
+    assert_equal "", speaker.website
   end
 
   test "speaker user association" do


### PR DESCRIPTION
I took a look at #680 issue. This problem was happening because some speaker's website is missing http://.


Before fixing

![Screenshot 2025-05-23 at 00 03 48](https://github.com/user-attachments/assets/428797a6-6727-4c5b-ae82-830277704467)

After fixing

![Screenshot 2025-05-23 at 00 04 25](https://github.com/user-attachments/assets/78a36e24-5005-44a0-a658-1aac39737e81)

Resolves https://github.com/rubyevents/rubyevents/issues/680