### PR TITLE
Prevent overflow in schedules day navigation

### DIFF
--- a/app/views/events/schedules/_schedule.html.erb
+++ b/app/views/events/schedules/_schedule.html.erb
@@ -7,7 +7,7 @@
     <div class="flex items-start flex-wrap gap-8 sm:flex-nowrap w-full">
       <div class="w-full">
         <div id="schedule" class="min-w-full">
-          <div id="schedule-navigation" class="flex gap-4 justify-center">
+          <div id="schedule-navigation" class="flex gap-4 justify-center flex-wrap">
             <% days.each_with_index do |day, index| %>
               <% date_string = Date.parse(day.dig("date")).strftime("%A (%b %d, %Y)") %>
               <% kind = (day == current_day) ? :primary : :none %>


### PR DESCRIPTION
Small PR to fix overflow in schedule days navigation for multi-day conferences (encountered during helvetic ruby)

e.g. https://www.rubyevents.org/events/helveticruby-2025/schedule

| Before | After |
|--------|--------|
| <img width="516" alt="image" src="https://github.com/user-attachments/assets/12ea5385-97d0-462e-82e2-06a3dfc4a6b9" />  | <img width="510" alt="image" src="https://github.com/user-attachments/assets/0eaef282-bdea-45ed-942f-1c126344bc79" /> | 
