### PR TITLE
Fix tooltip in talk partial, remove tooltip-top class 

### DIFF
--- a/app/views/talks/_talk.html.erb
+++ b/app/views/talks/_talk.html.erb
@@ -119,29 +119,29 @@
           <% if signed_in? && !talk.scheduled? %>
             <%= turbo_frame_tag dom_id(talk, :watched_talk) do %>
               <% if talk.watched? %>
-                <div class="tooltip tooltip-top" data-tip="Mark talk as unwatched">
+                <%= ui_tooltip "Mark talk as unwatched" do %>
                   <%= ui_button url: talk_watched_talk_path(talk), method: :delete, kind: :pill do %>
                     <%= fa("circle-check", size: :xs, style: :solid, class: "fill-green-700") %>
                     <span class="text-xs text-nowrap">Watched</span>
                   <% end %>
-                </div>
+                <% end %>
               <% else %>
-                <div class="tooltip tooltip-top" data-tip="Mark talk as watched">
+                <%= ui_tooltip "Mark talk as watched" do %>
                   <%= ui_button url: talk_watched_talk_path(talk), method: :post, kind: :pill do %>
                     <%= fa("circle", size: :xs, style: :regular) %>
                     <span class="text-xs text-nowrap">Watched</span>
                   <% end %>
-                </div>
+                <% end %>
               <% end %>
             <% end %>
           <% end %>
 
-          <div class="tooltip tooltip-top hotwire-native:hidden" data-tip="You can suggest some modifications to this talk">
+          <%= ui_tooltip "You can suggest some modifications to this talk" do %>
             <%= ui_button url: edit_talk_path(talk), kind: :pill, data: {turbo_frame: "modal"} do %>
               <%= fa("pen", size: :xs, style: :solid) %>
               <span class="text-xs">Edit</span>
             <% end %>
-          </div>
+          <% end %>
         </div>
 
         <div class="flex justify-between w-full py-2">

--- a/app/views/talks/_talk.html.erb
+++ b/app/views/talks/_talk.html.erb
@@ -136,12 +136,12 @@
             <% end %>
           <% end %>
 
-          <%= ui_tooltip "You can suggest some modifications to this talk" do %>
+          <div class="tooltip hotwire-native:hidden" data-tip="You can suggest some modifications to this talk">
             <%= ui_button url: edit_talk_path(talk), kind: :pill, data: {turbo_frame: "modal"} do %>
               <%= fa("pen", size: :xs, style: :solid) %>
               <span class="text-xs">Edit</span>
             <% end %>
-          <% end %>
+          </div>
         </div>
 
         <div class="flex justify-between w-full py-2">


### PR DESCRIPTION
This PR improves the _talk partial using the `ui_tooltip` helper method, where possible, and by removing the tooltip-top class 



Before

![CleanShot 2025-05-25 at 12 40 45](https://github.com/user-attachments/assets/d8abb05c-6df1-4a5a-92c9-69b0501fee76)

After

![CleanShot 2025-05-25 at 12 41 15](https://github.com/user-attachments/assets/ded0a552-e781-4105-9b24-4c044e7bc259)

