### PR TITLE
Skip authentication for `ContributionsController#show`

### DIFF
--- a/app/controllers/contributions_controller.rb
+++ b/app/controllers/contributions_controller.rb
@@ -1,7 +1,7 @@
 class ContributionsController < ApplicationController
   include Turbo::ForceFrameResponse
   force_frame_response only: %i[show]
-  skip_before_action :authenticate_user!, only: %i[index]
+  skip_before_action :authenticate_user!, only: %i[index show]
 
   STEPS = %i[speakers_without_github talks_without_slides events_without_videos
     events_without_location events_without_dates talks_dates_out_of_bounds missing_videos_cue].freeze


### PR DESCRIPTION
Tiny PR that skips the `authenticate_user!` method for the `ContributionsController#show` action.
The motivation is that currently, clicking on some tabs on the contribution page results in a Turbo Frame "Content missing" error, when you're not logged in, since the controller responds with a 302 redirect to `/sign_in`.

Please correct me if some of the show content is not meant to be accessible without authentication and I'm misinterpreting the situation.
