### PR TITLE
Add metatags

### DIFF
--- a/app/controllers/events/talks_controller.rb
+++ b/app/controllers/events/talks_controller.rb
@@ -5,6 +5,7 @@ class Events::TalksController < ApplicationController
   before_action :set_user_favorites, only: %i[index]
 
   def index
+    set_meta_tags(@event)
     @talks = @event.talks_in_running_order.where(meta_talk: false).includes(:speakers, :parent_talk, child_talks: :speakers).order(date: :desc)
   end
 

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -19,6 +19,7 @@ class TopicsController < ApplicationController
       overflow: :empty_page,
       page: page_number
     )
+    set_meta_tags(@topic)
   end
 
   def set_user_favorites

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -81,6 +81,24 @@ class Topic < ApplicationRecord
     canonical || self
   end
 
+  def to_meta_tags
+    {
+      title: name,
+      description: description,
+      og: {
+        title: name,
+        type: :website,
+        description: description,
+        site_name: "RubyEvents.org"
+      },
+      twitter: {
+        card: "summary",
+        title: name,
+        description: description
+      }
+    }
+  end
+
   # enums state machine
 
   def rejected!

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -7,7 +7,7 @@
       <div style="view-transition-name: title"><%= back_to_title %></div>
     </div>
   <% end %>
-  <div class="flex items-center gap-2 title text-primary">
+  <div class="flex items-center gap-2 title text-primary hotwire-native:hidden">
     <h1 class="mb-4"><%= @topic.name %></h1>
   </div>
   <div id="topic-talks" class="grid min-w-full grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4 gallery">


### PR DESCRIPTION
While exploring the mobile app, I noticed some screens don’t have native titles.
This PR adds titles to those screens.