### PR TITLE
Remove View Transitions for mobile apps

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,8 +22,8 @@
 
     <% unless hotwire_native_app? %>
       <meta name="turbo-cache-control" content="no-cache">
+      <meta name="view-transition" content="same-origin">
     <% end %>
-    <meta name="view-transition" content="same-origin">
 
     <%= favicon_link_tag "favicon/favicon.ico", rel: "icon", type: "image/x-icon" %>
     <%= favicon_link_tag "favicon/favicon-16x16.png", rel: "icon", sizes: "16x16", type: "image/png" %>


### PR DESCRIPTION
Hey there
I've noticed on the iOS app, that navigating from one page to a previously visited page, doesn't show the cached version of the page.

Hotwire Native normally caches a page before leaving it, so that when you return, it can show the cached content while the page reloads in the background.

Currently, however, it shows a blank webview background for a moment instead of the cached page.
Turns out the the reason for this is the `view-transition` meta tag:
```html
<meta name="view-transition" content="same-origin">
```

When this tag is present, Hotwire Native either doesn't cache the page properly or doesn't display the cached content during back navigation.
I can't say for sure without looking further into Hotwire Native. This is also the first time I’ve encountered this behavior.


The simplest solution for now is to avoid using the view transition tag in the mobile apps.
This won’t remove any functionality, since view transitions don’t currently work with Hotwire Native anyway.

**Before**

https://github.com/user-attachments/assets/17ac0425-7d70-4936-bb1e-c28bfd3adfbc

**After**

https://github.com/user-attachments/assets/45a40137-1ae5-4e95-9199-97d46514263d