### PR TITLE
Add XML feed for latest talks and update routes

### DIFF
--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -43,6 +43,13 @@ class TalksController < ApplicationController
     end
   end
 
+  def feed
+    @talks = Talk.order(created_at: :desc).limit(20)
+    respond_to do |format|
+      format.xml
+    end
+  end
+
   private
 
   def order_by

--- a/app/views/talks/feed.xml.builder
+++ b/app/views/talks/feed.xml.builder
@@ -1,0 +1,19 @@
+xml.instruct! :xml, version: "1.0"
+xml.rss version: "2.0" do
+  xml.channel do
+    xml.title "Ruby Events - Talks Feed"
+    xml.link talks_url
+    xml.description "Latest talks in the Ruby ecosystem"
+    xml.language "en-us"
+
+    @talks.each do |talk|
+      xml.item do
+        xml.title talk.title
+        xml.description talk.description
+        xml.pubDate talk.created_at.to_s
+        xml.link talk_url(talk)
+        xml.guid talk_url(talk)
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,9 @@ Rails.application.routes.draw do
       resource :watched_talk, only: [:create, :destroy]
       resource :slides, only: :show
     end
+    collection do
+      get :feed, defaults: {format: "xml"}
+    end
   end
 
   resources :speakers, param: :slug, only: [:index, :show, :update, :edit]


### PR DESCRIPTION
This PR introduces an RSS feed for the `/talks` page to enable external consumption of recent Ruby-related talks published on the site.

**What’s Included**
Adds a new feed action in the TalksController

Defines an XML builder view (feed.xml.builder) that generates an RSS 2.0 feed

Limits feed to the 20 most recent talks, ordered by creation date

Adds a <link rel="alternate"> tag in the HTML head for better discoverability by feed readers

**Endpoint**
RSS feed available at: `/talks/feed.xml`

**Why?**
![Screenshot 2025-06-04 at 18 18 27](https://github.com/user-attachments/assets/ab3f8df9-4917-4b12-9ccb-5914cfed17cc)
This allows users and feed readers (e.g., podcast apps, Notion widgets, RSS aggregators) to stay updated on new Ruby talks without manually checking the site.

![Screenshot 2025-06-04 at 18 13 41](https://github.com/user-attachments/assets/9d9172e2-5c91-4f05-9b8d-eeb786a8a3e5)


