### PR TITLE
Fix event countries error

### DIFF
--- a/app/controllers/events/countries_controller.rb
+++ b/app/controllers/events/countries_controller.rb
@@ -3,11 +3,15 @@ class Events::CountriesController < ApplicationController
 
   def index
     @countries_by_continent = Event.all.map { |event| event.static_metadata&.country }.uniq.group_by { |country| country&.continent || "Unknown" }.sort_by { |key, _value| key || "ZZ" }.to_h
-    @events_by_country = Event.all.sort_by { |event| event.static_metadata&.home_sort_date }.reverse.group_by { |event| event.static_metadata&.country || "Unknown" }.sort_by { |key, value| (key.is_a?(String) ? key : key&.iso_short_name) || "ZZ" }.to_h
+    @events_by_country = Event.all.sort_by { |event| event.static_metadata&.home_sort_date || Time.at(0).to_date }.reverse.group_by { |event| event.static_metadata&.country || "Unknown" }.sort_by { |key, value| (key.is_a?(String) ? key : key&.iso_short_name) || "ZZ" }.to_h
   end
 
   def show
     @country = Country.find(params[:country])
-    @events = Event.all.select { |event| @country.present? && event.static_metadata&.country == @country }.sort_by { |event| event.static_metadata&.home_sort_date || Time.at(0).to_date }.reverse
+    if @country.present?
+      @events = Event.all.select { |event| event.static_metadata&.country == @country }.sort_by { |event| event.static_metadata&.home_sort_date || Time.at(0).to_date }.reverse
+    else
+      head :not_found
+    end
   end
 end

--- a/app/controllers/events/countries_controller.rb
+++ b/app/controllers/events/countries_controller.rb
@@ -9,7 +9,7 @@ class Events::CountriesController < ApplicationController
   def show
     @country = Country.find(params[:country])
     if @country.present?
-      @events = Event.all.select { |event| event.static_metadata&.country == @country }.sort_by { |event| event.static_metadata&.home_sort_date || Time.at(0).to_date }.reverse
+      @events = Event.includes(:organisation).all.select { |event| event.static_metadata&.country == @country }.sort_by { |event| event.static_metadata&.home_sort_date || Time.at(0).to_date }.reverse
     else
       head :not_found
     end

--- a/test/controllers/events/countries_controller_test.rb
+++ b/test/controllers/events/countries_controller_test.rb
@@ -1,0 +1,89 @@
+require "test_helper"
+
+class Events::CountriesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @railsconf_event = events(:railsconf_2017)
+    @rubyconfth_event = events(:rubyconfth_2022)
+    @rails_world_event = events(:rails_world_2023)
+    @tropical_rb_event = events(:tropical_rb_2024)
+    @brightonruby_event = events(:brightonruby_2024)
+  end
+
+  test "should get index" do
+    get countries_path
+    assert_response :success
+    assert_select "h1", /Events by Country/i
+  end
+
+  test "should display countries grouped by continent on index" do
+    get countries_path
+    assert_response :success
+
+    # Verify that @countries_by_continent is assigned
+    assert_not_nil assigns(:countries_by_continent)
+    assert_not_nil assigns(:events_by_country)
+
+    # Check that the assigned variables are hashes
+    assert_kind_of Hash, assigns(:countries_by_continent)
+    assert_kind_of Hash, assigns(:events_by_country)
+  end
+
+  test "should handle invalid country parameter" do
+    get country_path("nonexistent-country")
+    assert_response :not_found
+  end
+
+  test "should filter events by country on show page" do
+    # Test the filtering logic by checking that events are properly filtered
+    get country_path("united-states")
+    assert_response :success
+
+    events = assigns(:events)
+    assert_not_nil events
+    assert_kind_of Array, events
+
+    # All events should either match the country or be filtered out
+    # The controller filters events where event.static_metadata&.country == @country
+    country = assigns(:country)
+    if country.present?
+      events.each do |event|
+        # Each event should either have matching country or be included due to the filtering logic
+        assert event.static_metadata.nil? || event.static_metadata.country == country || event.static_metadata.country.nil?
+      end
+    end
+  end
+
+  test "should sort events by home_sort_date in reverse order on show page" do
+    get country_path("united-states")
+    assert_response :success
+
+    events = assigns(:events)
+    assert_not_nil events
+    assert_kind_of Array, events
+
+    # Check that events are sorted in reverse order (most recent first)
+    # The controller sorts by home_sort_date || Time.at(0).to_date in reverse
+    if events.size > 1
+      dates = events.map { |event| event.static_metadata&.home_sort_date || Time.at(0).to_date }
+      assert_equal dates.sort.reverse, dates, "Events should be sorted by date in reverse order"
+    end
+  end
+
+  test "should handle special characters in country parameter" do
+    # Test with country parameter containing special characters
+    get country_path("united-kingdom")
+    assert_response :success
+
+    assert_not_nil assigns(:events)
+    assert_kind_of Array, assigns(:events)
+  end
+
+  test "should handle case sensitivity in country parameter" do
+    # Test with different case variations
+    get country_path("United-States")
+    assert_response :success
+
+    assert_not_nil assigns(:events)
+    assert_kind_of Array, assigns(:events)
+  end
+end


### PR DESCRIPTION
close #786 


this PR fixes the error in countries#index when the static_metadata can be nil resulting in an impossible date comparaison (why is it nil is probably something else to investigate)

It also adds test to cover the index and show route for this controller