### PR TITLE
Fix infinite stack loop

### DIFF
--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -102,6 +102,7 @@ class Talk < ApplicationRecord
 
   validates :date, presence: true
   # validates :published_at, presence: true, if: :published? # TODO: enable
+  validate :parent_talk_id_cannot_be_self
 
   # delegates
   delegate :name, to: :event, prefix: true, allow_nil: true
@@ -598,5 +599,15 @@ class Talk < ApplicationRecord
       speakers: speakers.map { |speaker| speaker.to_mobile_json(request) },
       url: Router.talk_url(self, host: "#{request.protocol}#{request.host}:#{request.port}")
     }
+  end
+
+  private
+
+  def parent_talk_id_cannot_be_self
+    return if parent_talk_id.nil?
+
+    if parent_talk_id == id
+      errors.add(:parent_talk_id, "cannot be the same as the talk itself")
+    end
   end
 end

--- a/db/migrate/20250609072113_remove_talk_parent_id_self.rb
+++ b/db/migrate/20250609072113_remove_talk_parent_id_self.rb
@@ -1,0 +1,5 @@
+class RemoveTalkParentIdSelf < ActiveRecord::Migration[8.0]
+  def change
+    Talk.where("parent_talk_id = id").update_all(parent_talk_id: nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_24_174213) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_09_072113) do
   create_table "ahoy_events", force: :cascade do |t|
     t.integer "visit_id"
     t.integer "user_id"
@@ -83,10 +83,27 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_24_174213) do
     t.integer "talks_count", default: 0, null: false
     t.integer "canonical_id"
     t.string "website", default: ""
+    t.date "start_date"
+    t.date "end_date"
     t.index ["canonical_id"], name: "index_events_on_canonical_id"
     t.index ["name"], name: "index_events_on_name"
     t.index ["organisation_id"], name: "index_events_on_organisation_id"
     t.index ["slug"], name: "index_events_on_slug"
+  end
+
+  create_table "llm_requests", force: :cascade do |t|
+    t.string "request_hash", null: false
+    t.json "raw_response", null: false
+    t.float "duration", null: false
+    t.string "resource_type", null: false
+    t.integer "resource_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "success", default: false, null: false
+    t.string "task_name", default: "", null: false
+    t.index ["request_hash"], name: "index_llm_requests_on_request_hash", unique: true
+    t.index ["resource_type", "resource_id"], name: "index_llm_requests_on_resource"
+    t.index ["task_name"], name: "index_llm_requests_on_task_name"
   end
 
   create_table "organisations", force: :cascade do |t|


### PR DESCRIPTION
close #784 

if a talk#parent_talk_id reference to self then we enter into an infinite loop when calling #published?

This PR prevents settings parent_talk_id to self and cleans up the data in db with a migration 