### PR TITLE
Bump vlitejs from 6.0.5 to 7.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "rfs": "^10.0.0",
     "stimulus-use": "^0.52.0",
     "tippy.js": "^6.3.7",
-    "vlitejs": "^6.0.3",
+    "vlitejs": "^7.3.2",
     "yaml": "^2.7.1"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2774,16 +2774,7 @@ stimulus-vite-helpers@^3.0.0, stimulus-vite-helpers@^3.1.0:
   resolved "https://registry.yarnpkg.com/stimulus-vite-helpers/-/stimulus-vite-helpers-3.1.0.tgz#9216d703ac8d74befece4499ea738c18de408842"
   integrity sha512-qy9vnNnu6e/1PArEndp456BuSKLQkBgc+vX2pedOHT0N4GSLQY0l5fuQ4ft56xZ8xSWqrfuYSR+GXXIPtoESww==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2860,14 +2851,7 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -3167,10 +3151,10 @@ vite@^6.3.4:
   optionalDependencies:
     fsevents "~2.3.3"
 
-vlitejs@^6.0.3:
-  version "6.0.5"
-  resolved "https://registry.yarnpkg.com/vlitejs/-/vlitejs-6.0.5.tgz#492836fafca39cb663388882d9e39b8126f4706e"
-  integrity sha512-SLNl5KJlO+p7Wx/F4WU2eg1EWzO96d6f6jQPd2cU/VeJYx6/TIjvLc9EhTuW51rFcf7httWkKJqqiGVkCF0kvA==
+vlitejs@^7.3.2:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/vlitejs/-/vlitejs-7.3.2.tgz#f03d3a5190124298cbd47b7b2d4812e0a079d09c"
+  integrity sha512-4SwXTWyp+YOK1nqxjAvejq4y6v0P0gp6chKa8y9G9x26Rf8DdpAL0ygup0fDfOvqkJB4/wQlZ7qEbUWcrxDHbw==
   dependencies:
     validate-target "^3.1.1"
 


### PR DESCRIPTION
Resolves #757, resolves #311

This PR updates the `vlitejs` dependency from `6.0.5` to `7.3.2`.
Besides the additional features and bug fixes that come with the new version, it also includes a fix for the issue where the playback speed dropdown would close immediately after opening.

Player functionality tested in:
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Hotwire Native iOS App
- [x] Hotwire Native Android App
