### PR TITLE
Back `Event#kind` by a database column

### DIFF
--- a/app/avo/resources/event.rb
+++ b/app/avo/resources/event.rb
@@ -22,6 +22,7 @@ class Avo::Resources::Event < Avo::BaseResource
     field :end_date, as: :date, hide_on: :index
     field :city, as: :text, hide_on: :index
     field :country_code, as: :select, options: country_options, include_blank: true
+    field :kind, hide_on: :index
     field :slug, as: :text
     field :updated_at, as: :date, sortable: true
     # field :suggestions, as: :has_many

--- a/app/controllers/events/past_controller.rb
+++ b/app/controllers/events/past_controller.rb
@@ -3,8 +3,9 @@ class Events::PastController < ApplicationController
 
   def index
     @events = Event.includes(:organisation, :keynote_speakers)
+      .conference
       .where(end_date: ..Date.today)
       .order(start_date: :desc)
-      .select { |event| event.static_metadata.conference? }
+      .limit(50)
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,9 +8,9 @@ class EventsController < ApplicationController
   # GET /events
   def index
     @events = Event.includes(:organisation, :keynote_speakers)
+      .conference
       .where(start_date: Date.today..)
       .order(start_date: :asc)
-      .select { |event| event.static_metadata.conference? }
   end
 
   # GET /events/1

--- a/app/models/event/static_metadata.rb
+++ b/app/models/event/static_metadata.rb
@@ -3,12 +3,20 @@
 class Event::StaticMetadata < ActiveRecord::AssociatedObject
   delegate :published_date, :home_sort_date, to: :static_repository, allow_nil: true
 
+  def kind
+    return static_repository.kind if static_repository&.kind
+    return "conference" if event.organisation.conference?
+    return "meetup" if event.organisation.meetup?
+
+    "event"
+  end
+
   def conference?
-    static_repository&.kind == "conference" || event.organisation.conference?
+    kind == "conference"
   end
 
   def meetup?
-    static_repository&.kind == "meetup" || event.organisation.meetup?
+    kind == "meetup"
   end
 
   def frequency

--- a/data/ruby-nz/playlists.yml
+++ b/data/ruby-nz/playlists.yml
@@ -3,7 +3,7 @@
   title: Ruby Retreat NZ 2020 (Cancelled)
   description: ''
   location: Mt Cheeseman, near Christchurch, New Zealand
-  kind: conference
+  kind: event
   start_date: '2020-03-27'
   end_date: '2020-03-30'
   metadata_parser: Youtube::VideoMetadata
@@ -16,7 +16,7 @@
   title: Ruby Retreat 2023
   description: ''
   location: Mount Cheeseman, Aotearoa, New Zealand
-  kind: conference
+  kind: event
   start_date: '2023-10-27'
   end_date: '2023-10-30'
   metadata_parser: Youtube::VideoMetadata
@@ -27,7 +27,7 @@
   title: Ruby Retreat 2025
   description: ''
   location: Whangaparāoa, Auckland, New Zealand
-  kind: conference
+  kind: event
   start_date: '2025-05-09'
   end_date: '2025-05-12'
   metadata_parser: Youtube::VideoMetadata

--- a/data/ruby-retreat/playlists.yml
+++ b/data/ruby-retreat/playlists.yml
@@ -3,7 +3,7 @@
   title: Ruby Retreat 2024
   description: ''
   location: Warrnambool, VIC, Australia
-  kind: conference
+  kind: event
   start_date: '2024-10-18'
   end_date: '2024-10-21'
   metadata_parser: Youtube::VideoMetadata

--- a/db/migrate/20250614131810_add_kind_to_event.rb
+++ b/db/migrate/20250614131810_add_kind_to_event.rb
@@ -1,0 +1,23 @@
+class AddKindToEvent < ActiveRecord::Migration[8.0]
+  def up
+    add_column :events, :kind, :string, default: "event", null: false
+    add_index :events, :kind
+
+    Event.find_in_batches.each do |events|
+      events.each do |event|
+        if event.static_metadata.meetup?
+          event.update!(kind: "meetup")
+        elsif event.static_metadata.conference?
+          event.update!(kind: "conference")
+        else
+          event.update!(kind: "event")
+        end
+      end
+    end
+  end
+
+  def down
+    remove_index :events, :kind
+    remove_column :events, :kind
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_09_072113) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_14_131810) do
   create_table "ahoy_events", force: :cascade do |t|
     t.integer "visit_id"
     t.integer "user_id"
@@ -85,7 +85,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_09_072113) do
     t.string "website", default: ""
     t.date "start_date"
     t.date "end_date"
+    t.string "kind", default: "event", null: false
     t.index ["canonical_id"], name: "index_events_on_canonical_id"
+    t.index ["kind"], name: "index_events_on_kind"
     t.index ["name"], name: "index_events_on_name"
     t.index ["organisation_id"], name: "index_events_on_organisation_id"
     t.index ["slug"], name: "index_events_on_slug"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -40,7 +40,8 @@ MeiliSearch::Rails.deactivate! do
         organisation: organisation,
         website: event_data["website"],
         start_date: event.static_metadata.start_date,
-        end_date: event.static_metadata.end_date
+        end_date: event.static_metadata.end_date,
+        kind: event.static_metadata.kind
       )
 
       puts event.slug unless Rails.env.test?

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -41,7 +41,7 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
 
   test "should show event" do
     get event_url(@event)
-    assert_redirected_to event_events_url(@event)
+    assert_redirected_to event_talks_url(@event)
   end
 
   test "should show event talks" do

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -8,6 +8,7 @@
 #  country_code    :string
 #  date            :date
 #  end_date        :date
+#  kind            :string           default("event"), not null, indexed
 #  name            :string           default(""), not null, indexed
 #  slug            :string           default(""), not null, indexed
 #  start_date      :date
@@ -21,6 +22,7 @@
 # Indexes
 #
 #  index_events_on_canonical_id     (canonical_id)
+#  index_events_on_kind             (kind)
 #  index_events_on_name             (name)
 #  index_events_on_organisation_id  (organisation_id)
 #  index_events_on_slug             (slug)
@@ -36,6 +38,7 @@ railsconf_2017:
   date: 2017-05-01
   organisation: railsconf
   city: Phoenix
+  kind: conference
   name: RailsConf 2017
   slug: railsconf-2017
 
@@ -43,6 +46,7 @@ rubyconfth_2022:
   date: 2022-05-01
   organisation: rubyconfth
   city: Bangkok
+  kind: conference
   name: RubyConf TH 2022
   slug: rubyconfth-2022
 
@@ -50,16 +54,19 @@ rails_world_2023:
   date: 2023-10-26
   organisation: rails_world
   name: Rails World 2023
+  kind: conference
   slug: rails-world-2023
 
 tropical_rb_2024:
   date: 2024-04-04
   organisation: rails_world
   name: Tropical Ruby 2024
+  kind: conference
   slug: tropical-rb-2024
 
 brightonruby_2024:
   date: 2024-06-28
   organisation: brightonruby
   name: Brighton Ruby 2024
+  kind: conference  
   slug: brightonruby-2024


### PR DESCRIPTION
Similar to #786: This pull request backs the `kind` of `Event` by a database column.