### PR TITLE
Fix "yearly conferences" chart

### DIFF
--- a/app/controllers/analytics/dashboards_controller.rb
+++ b/app/controllers/analytics/dashboards_controller.rb
@@ -23,7 +23,7 @@ class Analytics::DashboardsController < ApplicationController
     #   conferences at the moment. To optimize this code, we probably want to add yearly info to the Rollup class.
     # 2. Note that some years are integers and some are strings. We should probably convert them all to either format in import.
     #   (to reproduce, remove the `.to_s` in the map below)
-    @yearly_conferences = Event.all.select(&:conference?).select { |event| event.start_date.present? || event.year.present? }.group_by { |event| event.start_date&.year || event.year.to_i }.map { |year, events| [year.to_s, events.count] }.sort
+    @yearly_conferences = Event.all.select(&:conference?).select { |event| event.start_date.present? || event.static_metadata.year.present? }.group_by { |event| event.start_date&.year || event.static_metadata.year.to_i }.map { |year, events| [year.to_s, events.count] }.sort
   end
 
   def yearly_talks


### PR DESCRIPTION
Tiny PR that fixes the "Yearly Conferences" chart.
Currently, it displays a "Content missing" Turbo error because the`Analytics::DashboardsController#yearly_conferences` method raises an exception.
Seems like the `Event#year` method was moved to `Event::StaticMetadata#year` in bec4352.

BTW, lovely chart! I really like this metric and the growth in Ruby conferences!

![CleanShot 2025-06-18 at 10 51 28](https://github.com/user-attachments/assets/de58f0ba-daab-4c76-9bdc-5efac2024615)
