### PR TITLE
Add XML feed for latest events

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,7 +1,7 @@
 class EventsController < ApplicationController
   include WatchedTalks
   include Pagy::Backend
-  skip_before_action :authenticate_user!, only: %i[index show update]
+  skip_before_action :authenticate_user!, only: %i[index show update feed]
   before_action :set_event, only: %i[show edit update]
   before_action :set_user_favorites, only: %i[show]
 
@@ -33,6 +33,14 @@ class EventsController < ApplicationController
       redirect_to event_path(@event), notice: suggestion.notice
     else
       render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def feed
+    @events = Event.order(date: :desc).limit(20)
+
+    respond_to do |format|
+      format.xml
     end
   end
 

--- a/app/views/events/feed.xml.builder
+++ b/app/views/events/feed.xml.builder
@@ -1,0 +1,33 @@
+xml.instruct! :xml, version: "1.0", encoding: "UTF-8"
+
+xml.feed(xmlns: "http://www.w3.org/2005/Atom") do
+  xml.title "Ruby Events - Events Feed", type: "text", "xml:lang": "en"
+  xml.updated Time.now.utc.iso8601
+  xml.id "https://rubyevents/events/feed.xml"
+
+  @events.each do |event|
+    xml.entry do
+      xml.published event.date.to_time.utc.iso8601
+      xml.title event.name
+      xml.id event_url(event)
+      xml.link event_url(event)
+
+      html_content = <<~HTML
+        <div class="list-item #{event.name}">
+          <dt><a href="#{event_url(event)}">#{event.name}</a></dt>
+          <dd>
+            <ul>
+              <li>#{event.date.year}</li>
+              <li>#{event.city}</li>
+              <li>#{event.organisation.name}</li>
+            </ul>
+          </dd>
+        </div>
+      HTML
+
+      xml.content type: "html" do
+        xml.cdata! html_content.strip
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,9 @@ Rails.application.routes.draw do
       resources :events, only: [:index]
       resources :videos, only: [:index]
     end
+    collection do
+      get :feed, defaults: {format: "xml"}
+    end
   end
   resources :organisations, param: :slug, only: [:index, :show]
 


### PR DESCRIPTION
We discussed [here](https://github.com/rubyevents/rubyevents/pull/778) adding some endpoints for the feeds, and we’ve decided to start with the events feed.