### PR TITLE
add caching back

### DIFF
--- a/app/components/ui/modal_component.rb
+++ b/app/components/ui/modal_component.rb
@@ -28,6 +28,7 @@ class Ui::ModalComponent < ApplicationComponent
     attributes[:data] = {
       controller: "modal",
       modal_open_value: open,
+      turbo_temporary: true,
       action: combined_action
     }.merge(attributes[:data] || {})
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,6 @@
     <%= vite_stylesheet_tag "application.css", media: "all", "data-turbo-track": "reload" %>
 
     <% unless hotwire_native_app? %>
-      <meta name="turbo-cache-control" content="no-cache">
       <meta name="view-transition" content="same-origin">
     <% end %>
 


### PR DESCRIPTION
I'm not sure why this header is here. The default configuration of turbo is to cache navigation as much as possible. 

I have added it back. This introduces a small bug with modals where turbo caches the modal 

- the user dismisses the modal 
- clicks back, it will display the modal in it's open state.

 I added `data-turbo-temporary` to the modal in order to prevent turbo from caching it when navigating.

https://share.cleanshot.com/Dq9TpfXt