### PR TITLE
Lock `kamal` to `2.5.3`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ gem "tzinfo-data", platforms: %i[windows jruby]
 gem "bootsnap", require: false
 
 # Deploy this application anywhere as a Docker container [https://kamal-deploy.org]
-gem "kamal", require: false
+gem "kamal", "2.5.3", require: false
 
 # Add HTTP asset caching/compression and X-Sendfile acceleration to Puma [https://github.com/basecamp/thruster/]
 gem "thruster", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -273,13 +273,13 @@ GEM
     json-repair (0.2.0)
     jwt (2.10.1)
       base64
-    kamal (2.6.1)
+    kamal (2.5.3)
       activesupport (>= 7.0)
       base64 (~> 0.2)
       bcrypt_pbkdf (~> 1.0)
       concurrent-ruby (~> 1.2)
       dotenv (~> 3.1)
-      ed25519 (~> 1.4)
+      ed25519 (~> 1.2)
       net-ssh (~> 7.3)
       sshkit (>= 1.23.0, < 2.0)
       thor (~> 1.3)
@@ -647,7 +647,7 @@ DEPENDENCIES
   iso-639
   jbuilder
   json-repair (~> 0.2.0)
-  kamal
+  kamal (= 2.5.3)
   listen (~> 3.5)
   marksmith
   meilisearch-rails (= 0.14.2)


### PR DESCRIPTION
It looks like we accidentally bumped `kamal` in https://github.com/rubyevents/rubyevents/pull/811 which now stops us from deploying to production, which is why I'm locking it to the previous working version.

The deploy fails with:

```
Releasing the deploy lock...
  Finished all in 196.7 seconds
  ERROR (RuntimeError): Exception while executing on host [ip]: kamal-proxy version v0.8.4 is too old, run `kamal proxy reboot` in order to update to at least v0.9.0
Error: Process completed with exit code 1.
```

Trying to run `kamal proxy reboot` doesn't seem to work either because of some failure in the underlying docker call
```
❯ kamal proxy reboot
This will cause a brief outage on each host. Are you sure? [y, N] (N) y
  INFO [58cb504e] Running /usr/bin/env mkdir -p .kamal on [ip]
  INFO [58cb504e] Finished in 1.432 seconds with exit status 0 (successful).
Acquiring the deploy lock...
  INFO [bcabf9bc] Running docker login -u [REDACTED] -p [REDACTED] on [ip]
Releasing the deploy lock...
  ERROR (SSHKit::Command::Failed): Exception while executing on host [ip]: docker exit status: 125
docker stdout: Nothing written
docker stderr: flag needs an argument: 'p' in -p
See 'docker login --help'.
```