### PR TITLE
Add hotwire combobox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ service_account.json
 .ssh-keys/
 
 
+.claude

--- a/.gitignore
+++ b/.gitignore
@@ -87,5 +87,3 @@ service_account.json
 
 .ssh-keys/
 
-
-.claude

--- a/Gemfile
+++ b/Gemfile
@@ -156,9 +156,10 @@ gem "discard"
 # Use OmniAuth to support multi-provider authentication [https://github.com/omniauth/omniauth]
 gem "omniauth"
 gem "omniauth-github"
-
 # Provides a mitigation against CVE-2015-9284 [https://github.com/cookpad/omniauth-rails_csrf_protection]
 gem "omniauth-rails_csrf_protection"
 
 # silence Ruby 3.4 warnings
 gem "ostruct"
+
+gem "hotwire_combobox", "~> 0.4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,6 +246,11 @@ GEM
       activesupport (>= 7)
     hashdiff (1.1.2)
     hashie (5.0.0)
+    hotwire_combobox (0.4.0)
+      platform_agent (>= 1.0.1)
+      rails (>= 7.0.7.2)
+      stimulus-rails (>= 1.2)
+      turbo-rails (>= 1.2)
     httparty (0.23.1)
       csv
       mini_mime (>= 1.0.0)
@@ -382,6 +387,9 @@ GEM
     parser (3.3.8.0)
       ast (~> 2.4.1)
       racc
+    platform_agent (1.0.1)
+      activesupport (>= 5.2.0)
+      useragent (~> 0.16.3)
     pp (0.6.2)
       prettyprint
     pretty_please (0.2.0)
@@ -644,6 +652,7 @@ DEPENDENCIES
   frozen_record (~> 0.27.2)
   google-protobuf
   groupdate
+  hotwire_combobox (~> 0.4.0)
   iso-639
   jbuilder
   json-repair (~> 0.2.0)

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -6,6 +6,7 @@
 @import "components/diff.css";
 @import "components/dropdown.css";
 @import "components/form.css";
+@import "components/hotwire-combobox.css";
 @import "components/markdown.css";
 @import "components/modal.css";
 @import "components/nav.css";

--- a/app/assets/stylesheets/components/hotwire-combobox.css
+++ b/app/assets/stylesheets/components/hotwire-combobox.css
@@ -1,0 +1,27 @@
+@layer components {
+  .hw-combobox__main__wrapper {
+    @apply min-h-12;
+  }
+
+  .hw-combobox__main__wrapper:has(input:focus) {
+    box-shadow: none;
+    border-color: var(--fallback-bc, oklch(var(--bc)/0.2));
+    outline-style: solid;
+    outline-width: 2px;
+    outline-offset: 2px;
+    outline-color: var(--fallback-bc, oklch(var(--bc)/0.2));
+  }
+
+  .hw-combobox__main__wrapper input:focus {
+    box-shadow: none;
+    border-color: none;
+    outline-style: none;
+    outline-color: none;
+  }
+
+  :root {
+    --hw-focus-color: rgb(var(--fallback-bc));
+    --hw-combobox-width: 100%;
+    --hw-combobox-width--multiple: 100%;
+  }
+}

--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -22,7 +22,25 @@ class TemplatesController < ApplicationController
   def delete_child
   end
 
+  def speakers_search
+    @speakers = Speaker.canonical
+    @speakers = @speakers.ft_search(search_query) if search_query
+  end
+
+  def speakers_search_chips
+    @speakers = params[:combobox_values].split(",").map do |value|
+      Speaker.find_by(id: value) || OpenStruct.new(to_combobox_display: value, id: value)
+    end
+    render turbo_stream: helpers.combobox_selection_chips_for(@speakers)
+  end
+
   private
+
+  helper_method :search_query
+
+  def search_query
+    params[:q].presence
+  end
 
   def talk_params
     params.require(:template).permit(

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,6 +4,9 @@
 
 import { application } from "./application"
 
+import HwComboboxController from "@josefarias/hotwire_combobox"
+application.register("hw-combobox", HwComboboxController)
+
 import AutoClickController from "./auto-click_controller"
 application.register("auto-click", AutoClickController)
 

--- a/app/models/speaker.rb
+++ b/app/models/speaker.rb
@@ -218,6 +218,10 @@ class Speaker < ApplicationRecord
     }
   end
 
+  def to_combobox_display
+    name 
+  end
+
   def meta_description
     <<~HEREDOC
       Discover all the talks given by #{name} on subjects related to Ruby language or Ruby Frameworks such as Rails, Hanami and others

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,7 @@
     <%= display_meta_tags site: "" %>
 
     <%= vite_client_tag %>
+    <%= combobox_style_tag %>
     <%= vite_javascript_tag "application", media: "all", "data-turbo-track": "reload" %>
     <%= vite_stylesheet_tag "application.css", media: "all", "data-turbo-track": "reload" %>
 

--- a/app/views/templates/_talk_fields.html.erb
+++ b/app/views/templates/_talk_fields.html.erb
@@ -1,27 +1,28 @@
 <div
   id="child_<%= index %>"
-  class="card bg-base-100 border border-gray-200 mb-4">
+  class="card bg-base-100 border border-gray-200 mb-4"
+>
   <div class="card-body p-4">
     <div class="flex justify-between items-center mb-4">
       <h4 class="font-semibold">Talk</h4>
       <%= link_to "Remove",
-            delete_child_templates_path(index: index),
-            data: {
-              turbo_method: :delete
-            },
-            class: "btn btn-outline btn-error btn-xs" %>
+      delete_child_templates_path(index: index),
+      data: {
+        turbo_method: :delete,
+      },
+      class: "btn btn-outline btn-error btn-xs" %>
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div class="form-control">
         <%= form.label :title, "Title *", class: "label" %>
         <%= form.text_field :title,
-              class:
-                class_names(
-                  "input input-bordered w-full",
-                  "input-error": form.object.errors[:title].any?
-                ),
-              placeholder: "e.g., Introducing Type Guard to Steep" %>
+                        class:
+                          class_names(
+                            "input input-bordered w-full",
+                            "input-error": form.object.errors[:title].any?,
+                          ),
+                        placeholder: "e.g., Introducing Type Guard to Steep" %>
         <% if form.object.errors[:title].any? %>
           <div class="label">
             <span class="label-text-alt text-error"><%= form.object.errors[:title].join(", ") %></span>
@@ -32,12 +33,12 @@
       <div class="form-control">
         <%= form.label :event_name, "Event Name *", class: "label" %>
         <%= form.text_field :event_name,
-              class:
-                class_names(
-                  "input input-bordered w-full",
-                  "input-error": form.object.errors[:event_name].any?
-                ),
-              placeholder: "e.g., RubyKaigi 2025" %>
+                        class:
+                          class_names(
+                            "input input-bordered w-full",
+                            "input-error": form.object.errors[:event_name].any?,
+                          ),
+                        placeholder: "e.g., RubyKaigi 2025" %>
         <% if form.object.errors[:event_name].any? %>
           <div class="label">
             <span class="label-text-alt text-error"><%= form.object.errors[:event_name].join(", ") %></span>
@@ -47,19 +48,23 @@
 
       <div class="form-control">
         <%= form.label :speakers, "Speakers", class: "label" %>
-        <%= form.text_field :speakers,
-              class: "input input-bordered w-full",
-              placeholder: "Comma-separated, e.g., Takeshi KOMIYA, Jane Doe" %>
+        <!-- Using combobox tag here because form.combobox doesn't generate the right ID for some reason -->
+        <%= combobox_tag "template[children_attributes][#{index}][speakers]",
+        async_src: speakers_search_templates_path,
+        multiselect_chip_src: speakers_search_chips_templates_path,
+        name_when_new: "template[children_attributes][#{index}][speakers]",
+        free_text: true,
+        placeholder: "Search or add speakers..." %>
       </div>
 
       <div class="form-control">
         <%= form.label :date, "Date", class: "label" %>
         <%= form.date_field :date,
-              class:
-                class_names(
-                  "input input-bordered w-full",
-                  "input-error": form.object.errors[:date].any?
-                ) %>
+                        class:
+                          class_names(
+                            "input input-bordered w-full",
+                            "input-error": form.object.errors[:date].any?,
+                          ) %>
         <% if form.object.errors[:date].any? %>
           <div class="label">
             <span class="label-text-alt text-error"><%= form.object.errors[:date].join(", ") %></span>
@@ -70,11 +75,11 @@
       <div class="form-control">
         <%= form.label :published_at, "Published At", class: "label" %>
         <%= form.date_field :published_at,
-              class:
-                class_names(
-                  "input input-bordered w-full",
-                  "input-error": form.object.errors[:published_at].any?
-                ) %>
+                        class:
+                          class_names(
+                            "input input-bordered w-full",
+                            "input-error": form.object.errors[:published_at].any?,
+                          ) %>
         <% if form.object.errors[:published_at].any? %>
           <div class="label">
             <span class="label-text-alt text-error"><%= form.object.errors[:published_at].join(", ") %></span>
@@ -85,46 +90,46 @@
       <div class="form-control mt-4">
         <%= form.label :slides_url, "Slides URL", class: "label" %>
         <%= form.url_field :slides_url,
-              class: "input input-bordered w-full",
-              placeholder: "https://..." %>
+                       class: "input input-bordered w-full",
+                       placeholder: "https://..." %>
       </div>
 
       <div class="form-control">
         <%= form.label :video_provider, "Video Provider", class: "label" %>
         <%= form.select :video_provider,
-              ::Template::VIDEO_PROVIDERS.map { [it, it.squish.underscore] },
-              {prompt: "Select provider..."},
-              {class: "select select-bordered w-full"} %>
+                    ::Template::VIDEO_PROVIDERS.map { [it, it.squish.underscore] },
+                    { prompt: "Select provider..." },
+                    { class: "select select-bordered w-full" } %>
       </div>
 
       <div class="form-control">
         <%= form.label :video_id, "Video ID", class: "label" %>
         <%= form.text_field :video_id,
-              class: "input input-bordered w-full",
-              placeholder: "e.g., kp_jeGkUmhY" %>
+                        class: "input input-bordered w-full",
+                        placeholder: "e.g., kp_jeGkUmhY" %>
       </div>
 
       <div class="form-control">
         <%= form.label :start_cue, "Start Time", class: "label" %>
         <%= form.time_field :start_cue,
-              class: "input input-bordered w-full",
-              placeholder: "e.g., 02:00" %>
+                        class: "input input-bordered w-full",
+                        placeholder: "e.g., 02:00" %>
       </div>
 
       <div class="form-control">
         <%= form.label :end_cue, "End Time", class: "label" %>
         <%= form.time_field :end_cue,
-              class: "input input-bordered w-full",
-              placeholder: "e.g., 30:00" %>
+                        class: "input input-bordered w-full",
+                        placeholder: "e.g., 30:00" %>
       </div>
     </div>
 
     <div class="form-control mt-4">
       <%= form.label :description, "Description", class: "label" %>
       <%= form.text_area :description,
-            class: "textarea textarea-bordered w-full",
-            rows: 3,
-            placeholder: "Talk or event description..." %>
+                     class: "textarea textarea-bordered w-full",
+                     rows: 3,
+                     placeholder: "Talk or event description..." %>
     </div>
   </div>
 </div>

--- a/app/views/templates/_talk_fields.html.erb
+++ b/app/views/templates/_talk_fields.html.erb
@@ -1,28 +1,27 @@
 <div
   id="child_<%= index %>"
-  class="card bg-base-100 border border-gray-200 mb-4"
->
+  class="card bg-base-100 border border-gray-200 mb-4">
   <div class="card-body p-4">
     <div class="flex justify-between items-center mb-4">
       <h4 class="font-semibold">Talk</h4>
       <%= link_to "Remove",
-      delete_child_templates_path(index: index),
-      data: {
-        turbo_method: :delete,
-      },
-      class: "btn btn-outline btn-error btn-xs" %>
+            delete_child_templates_path(index: index),
+            data: {
+              turbo_method: :delete
+            },
+            class: "btn btn-outline btn-error btn-xs" %>
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div class="form-control">
         <%= form.label :title, "Title *", class: "label" %>
         <%= form.text_field :title,
-                        class:
-                          class_names(
-                            "input input-bordered w-full",
-                            "input-error": form.object.errors[:title].any?,
-                          ),
-                        placeholder: "e.g., Introducing Type Guard to Steep" %>
+              class:
+                class_names(
+                  "input input-bordered w-full",
+                  "input-error": form.object.errors[:title].any?
+                ),
+              placeholder: "e.g., Introducing Type Guard to Steep" %>
         <% if form.object.errors[:title].any? %>
           <div class="label">
             <span class="label-text-alt text-error"><%= form.object.errors[:title].join(", ") %></span>
@@ -33,12 +32,12 @@
       <div class="form-control">
         <%= form.label :event_name, "Event Name *", class: "label" %>
         <%= form.text_field :event_name,
-                        class:
-                          class_names(
-                            "input input-bordered w-full",
-                            "input-error": form.object.errors[:event_name].any?,
-                          ),
-                        placeholder: "e.g., RubyKaigi 2025" %>
+              class:
+                class_names(
+                  "input input-bordered w-full",
+                  "input-error": form.object.errors[:event_name].any?
+                ),
+              placeholder: "e.g., RubyKaigi 2025" %>
         <% if form.object.errors[:event_name].any? %>
           <div class="label">
             <span class="label-text-alt text-error"><%= form.object.errors[:event_name].join(", ") %></span>
@@ -50,21 +49,21 @@
         <%= form.label :speakers, "Speakers", class: "label" %>
         <!-- Using combobox tag here because form.combobox doesn't generate the right ID for some reason -->
         <%= combobox_tag "template[children_attributes][#{index}][speakers]",
-        async_src: speakers_search_templates_path,
-        multiselect_chip_src: speakers_search_chips_templates_path,
-        name_when_new: "template[children_attributes][#{index}][speakers]",
-        free_text: true,
-        placeholder: "Search or add speakers..." %>
+              async_src: speakers_search_templates_path,
+              multiselect_chip_src: speakers_search_chips_templates_path,
+              name_when_new: "template[children_attributes][#{index}][speakers]",
+              free_text: true,
+              placeholder: "Search or add speakers..." %>
       </div>
 
       <div class="form-control">
         <%= form.label :date, "Date", class: "label" %>
         <%= form.date_field :date,
-                        class:
-                          class_names(
-                            "input input-bordered w-full",
-                            "input-error": form.object.errors[:date].any?,
-                          ) %>
+              class:
+                class_names(
+                  "input input-bordered w-full",
+                  "input-error": form.object.errors[:date].any?
+                ) %>
         <% if form.object.errors[:date].any? %>
           <div class="label">
             <span class="label-text-alt text-error"><%= form.object.errors[:date].join(", ") %></span>
@@ -75,11 +74,11 @@
       <div class="form-control">
         <%= form.label :published_at, "Published At", class: "label" %>
         <%= form.date_field :published_at,
-                        class:
-                          class_names(
-                            "input input-bordered w-full",
-                            "input-error": form.object.errors[:published_at].any?,
-                          ) %>
+              class:
+                class_names(
+                  "input input-bordered w-full",
+                  "input-error": form.object.errors[:published_at].any?
+                ) %>
         <% if form.object.errors[:published_at].any? %>
           <div class="label">
             <span class="label-text-alt text-error"><%= form.object.errors[:published_at].join(", ") %></span>
@@ -90,46 +89,46 @@
       <div class="form-control mt-4">
         <%= form.label :slides_url, "Slides URL", class: "label" %>
         <%= form.url_field :slides_url,
-                       class: "input input-bordered w-full",
-                       placeholder: "https://..." %>
+              class: "input input-bordered w-full",
+              placeholder: "https://..." %>
       </div>
 
       <div class="form-control">
         <%= form.label :video_provider, "Video Provider", class: "label" %>
         <%= form.select :video_provider,
-                    ::Template::VIDEO_PROVIDERS.map { [it, it.squish.underscore] },
-                    { prompt: "Select provider..." },
-                    { class: "select select-bordered w-full" } %>
+              ::Template::VIDEO_PROVIDERS.map { [it, it.squish.underscore] },
+              {prompt: "Select provider..."},
+              {class: "select select-bordered w-full"} %>
       </div>
 
       <div class="form-control">
         <%= form.label :video_id, "Video ID", class: "label" %>
         <%= form.text_field :video_id,
-                        class: "input input-bordered w-full",
-                        placeholder: "e.g., kp_jeGkUmhY" %>
+              class: "input input-bordered w-full",
+              placeholder: "e.g., kp_jeGkUmhY" %>
       </div>
 
       <div class="form-control">
         <%= form.label :start_cue, "Start Time", class: "label" %>
         <%= form.time_field :start_cue,
-                        class: "input input-bordered w-full",
-                        placeholder: "e.g., 02:00" %>
+              class: "input input-bordered w-full",
+              placeholder: "e.g., 02:00" %>
       </div>
 
       <div class="form-control">
         <%= form.label :end_cue, "End Time", class: "label" %>
         <%= form.time_field :end_cue,
-                        class: "input input-bordered w-full",
-                        placeholder: "e.g., 30:00" %>
+              class: "input input-bordered w-full",
+              placeholder: "e.g., 30:00" %>
       </div>
     </div>
 
     <div class="form-control mt-4">
       <%= form.label :description, "Description", class: "label" %>
       <%= form.text_area :description,
-                     class: "textarea textarea-bordered w-full",
-                     rows: 3,
-                     placeholder: "Talk or event description..." %>
+            class: "textarea textarea-bordered w-full",
+            rows: 3,
+            placeholder: "Talk or event description..." %>
     </div>
   </div>
 </div>

--- a/app/views/templates/new.html.erb
+++ b/app/views/templates/new.html.erb
@@ -15,12 +15,12 @@
               <div class="form-control">
                 <%= form.label :title, "Title *", class: "label" %>
                 <%= form.text_field :title,
-                      class:
-                        class_names(
-                          "input input-bordered w-full",
-                          "input-error": @talk.errors[:title].any?
-                        ),
-                      placeholder: "e.g., Introducing Type Guard to Steep" %>
+                                class:
+                                  class_names(
+                                    "input input-bordered w-full",
+                                    "input-error": @talk.errors[:title].any?,
+                                  ),
+                                placeholder: "e.g., Introducing Type Guard to Steep" %>
                 <% if @talk.errors[:title].any? %>
                   <div class="label">
                     <span class="label-text-alt text-error"><%= @talk.errors[:title].join(", ") %></span>
@@ -31,12 +31,12 @@
               <div class="form-control">
                 <%= form.label :event_name, "Event Name *", class: "label" %>
                 <%= form.text_field :event_name,
-                      class:
-                        class_names(
-                          "input input-bordered w-full",
-                          "input-error": @talk.errors[:event_name].any?
-                        ),
-                      placeholder: "e.g., RubyKaigi 2025" %>
+                                class:
+                                  class_names(
+                                    "input input-bordered w-full",
+                                    "input-error": @talk.errors[:event_name].any?,
+                                  ),
+                                placeholder: "e.g., RubyKaigi 2025" %>
                 <% if @talk.errors[:event_name].any? %>
                   <div class="label">
                     <span class="label-text-alt text-error"><%= @talk.errors[:event_name].join(", ") %></span>
@@ -47,11 +47,11 @@
               <div class="form-control">
                 <%= form.label :date, "Date *", class: "label" %>
                 <%= form.date_field :date,
-                      class:
-                        class_names(
-                          "input input-bordered w-full",
-                          "input-error": @talk.errors[:date].any?
-                        ) %>
+                                class:
+                                  class_names(
+                                    "input input-bordered w-full",
+                                    "input-error": @talk.errors[:date].any?,
+                                  ) %>
                 <% if @talk.errors[:date].any? %>
                   <div class="label">
                     <span class="label-text-alt text-error"><%= @talk.errors[:date].join(", ") %></span>
@@ -61,20 +61,21 @@
 
               <div class="form-control">
                 <%= form.label :speakers, "Speakers", class: "label" %>
-                <%= text_field_tag :speakers,
-                      "",
-                      class: "input input-bordered w-full",
-                      placeholder: "Comma-separated, e.g., Takeshi KOMIYA, Jane Doe",
-                      autocomplete: "on" %>
+                <%= form.combobox :speakers,
+                              speakers_search_templates_path,
+                              multiselect_chip_src: speakers_search_chips_templates_path,
+                              name_when_new: "template[speakers]",
+                              free_text: true,
+                              class: "w-full" %>
               </div>
             </div>
 
             <div class="form-control">
               <%= form.label :description, "Description", class: "label" %>
               <%= form.text_area :description,
-                    class: "textarea textarea-bordered w-full",
-                    rows: 3,
-                    placeholder: "Talk or event description..." %>
+                             class: "textarea textarea-bordered w-full",
+                             rows: 3,
+                             placeholder: "Talk or event description..." %>
             </div>
           </div>
         </div>
@@ -89,9 +90,9 @@
               <div class="form-control">
                 <%= form.label :raw_title, "Raw Title", class: "label" %>
                 <%= form.text_field :raw_title,
-                      class: "input input-bordered w-full",
-                      placeholder:
-                        "e.g., [JA] Introducing Type Guard to Steep / Takeshi KOMIYA @tk0miya" %>
+                                class: "input input-bordered w-full",
+                                placeholder:
+                                  "e.g., [JA] Introducing Type Guard to Steep / Takeshi KOMIYA @tk0miya" %>
               </div>
 
               <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -110,59 +111,59 @@
                 <div class="form-control">
                   <%= form.label :language, "Language", class: "label" %>
                   <%= form.select :language,
-                        [
-                          %w[English english],
-                          %w[Japanese japanese],
-                          %w[Spanish spanish],
-                          %w[French french],
-                          %w[German german]
-                        ],
-                        {prompt: "Select language..."},
-                        {class: "select select-bordered w-full"} %>
+                              [
+                                %w[English english],
+                                %w[Japanese japanese],
+                                %w[Spanish spanish],
+                                %w[French french],
+                                %w[German german],
+                              ],
+                              { prompt: "Select language..." },
+                              { class: "select select-bordered w-full" } %>
                 </div>
 
                 <div class="form-control">
                   <%= form.label :track, "Track/Room", class: "label" %>
                   <%= form.text_field :track,
-                        class: "input input-bordered w-full",
-                        placeholder: "e.g., Main Stage, Room A" %>
+                                  class: "input input-bordered w-full",
+                                  placeholder: "e.g., Main Stage, Room A" %>
                 </div>
               </div>
 
               <div class="form-control">
                 <%= form.label :slides_url, "Slides URL", class: "label" %>
                 <%= form.url_field :slides_url,
-                      class: "input input-bordered w-full",
-                      placeholder: "https://..." %>
+                               class: "input input-bordered w-full",
+                               placeholder: "https://..." %>
               </div>
 
               <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div class="form-control">
                   <%= form.label :thumbnail_xs, "Thumbnail XS", class: "label" %>
                   <%= form.url_field :thumbnail_xs,
-                        class: "input input-bordered w-full",
-                        placeholder: "https://..." %>
+                                 class: "input input-bordered w-full",
+                                 placeholder: "https://..." %>
                 </div>
 
                 <div class="form-control">
                   <%= form.label :thumbnail_sm, "Thumbnail SM", class: "label" %>
                   <%= form.url_field :thumbnail_sm,
-                        class: "input input-bordered w-full",
-                        placeholder: "https://..." %>
+                                 class: "input input-bordered w-full",
+                                 placeholder: "https://..." %>
                 </div>
 
                 <div class="form-control">
                   <%= form.label :thumbnail_md, "Thumbnail MD", class: "label" %>
                   <%= form.url_field :thumbnail_md,
-                        class: "input input-bordered w-full",
-                        placeholder: "https://..." %>
+                                 class: "input input-bordered w-full",
+                                 placeholder: "https://..." %>
                 </div>
 
                 <div class="form-control">
                   <%= form.label :thumbnail_lg, "Thumbnail LG", class: "label" %>
                   <%= form.url_field :thumbnail_lg,
-                        class: "input input-bordered w-full",
-                        placeholder: "https://..." %>
+                                 class: "input input-bordered w-full",
+                                 placeholder: "https://..." %>
                 </div>
               </div>
             </div>
@@ -180,16 +181,16 @@
                 <div class="form-control">
                   <%= form.label :video_provider, "Video Provider", class: "label" %>
                   <%= form.select :video_provider,
-                        ::Template::VIDEO_PROVIDERS.map { [it, it.squish.underscore] },
-                        {prompt: "Select provider..."},
-                        {class: "select select-bordered w-full"} %>
+                              ::Template::VIDEO_PROVIDERS.map { [it, it.squish.underscore] },
+                              { prompt: "Select provider..." },
+                              { class: "select select-bordered w-full" } %>
                 </div>
 
                 <div class="form-control">
                   <%= form.label :video_id, "Video ID", class: "label" %>
                   <%= form.text_field :video_id,
-                        class: "input input-bordered w-full",
-                        placeholder: "e.g., kp_jeGkUmhY" %>
+                                  class: "input input-bordered w-full",
+                                  placeholder: "e.g., kp_jeGkUmhY" %>
                 </div>
               </div>
 
@@ -197,15 +198,15 @@
                 <div class="form-control">
                   <%= form.label :start_cue, "Start Time", class: "label" %>
                   <%= form.time_field :start_cue,
-                        class: "input input-bordered w-full",
-                        placeholder: "e.g., 02:00" %>
+                                  class: "input input-bordered w-full",
+                                  placeholder: "e.g., 02:00" %>
                 </div>
 
                 <div class="form-control">
                   <%= form.label :end_cue, "End Time", class: "label" %>
                   <%= form.time_field :end_cue,
-                        class: "input input-bordered w-full",
-                        placeholder: "e.g., 30:00" %>
+                                  class: "input input-bordered w-full",
+                                  placeholder: "e.g., 30:00" %>
                 </div>
               </div>
 
@@ -219,8 +220,8 @@
               <div class="form-control">
                 <%= form.label :external_player_url, "External Player URL", class: "label" %>
                 <%= form.url_field :external_player_url,
-                      class: "input input-bordered w-full",
-                      placeholder: "https://..." %>
+                               class: "input input-bordered w-full",
+                               placeholder: "https://..." %>
               </div>
             </div>
           </div>
@@ -241,12 +242,12 @@
             </div>
 
             <%= link_to "Add Talk",
-                  new_child_templates_path,
-                  data: {
-                    turbo_method: :get,
-                    turbo_stream: true
-                  },
-                  class: "btn btn-outline btn-lg w-full" %>
+            new_child_templates_path,
+            data: {
+              turbo_method: :get,
+              turbo_stream: true,
+            },
+            class: "btn btn-outline btn-lg w-full" %>
           </div>
         </div>
 
@@ -266,21 +267,24 @@
                 <div
                   class="relative"
                   data-controller="copy-to-clipboard"
-                  data-copy-to-clipboard-success-class="scale-95">
+                  data-copy-to-clipboard-success-class="scale-95"
+                >
                   <button
                     class="
                       btn btn-sm btn-outline absolute top-1 right-1 transition-transform duration-150
                       ease-in-out
                     "
                     data-action="click->copy-to-clipboard#copy"
-                    data-copy-to-clipboard-target="button">
+                    data-copy-to-clipboard-target="button"
+                  >
                     Copy
                   </button>
                   <pre
                     class="
                       text-sm font-mono text-gray-800 whitespace-pre-wrap break-words
                     "
-                    data-copy-to-clipboard-target="source"><%= @yaml %></pre>
+                    data-copy-to-clipboard-target="source"
+                  ><%= @yaml %></pre>
                 </div>
               <% else %>
                 <div class="text-sm font-mono text-gray-500">

--- a/app/views/templates/new.html.erb
+++ b/app/views/templates/new.html.erb
@@ -15,12 +15,12 @@
               <div class="form-control">
                 <%= form.label :title, "Title *", class: "label" %>
                 <%= form.text_field :title,
-                                class:
-                                  class_names(
-                                    "input input-bordered w-full",
-                                    "input-error": @talk.errors[:title].any?,
-                                  ),
-                                placeholder: "e.g., Introducing Type Guard to Steep" %>
+                      class:
+                        class_names(
+                          "input input-bordered w-full",
+                          "input-error": @talk.errors[:title].any?
+                        ),
+                      placeholder: "e.g., Introducing Type Guard to Steep" %>
                 <% if @talk.errors[:title].any? %>
                   <div class="label">
                     <span class="label-text-alt text-error"><%= @talk.errors[:title].join(", ") %></span>
@@ -31,12 +31,12 @@
               <div class="form-control">
                 <%= form.label :event_name, "Event Name *", class: "label" %>
                 <%= form.text_field :event_name,
-                                class:
-                                  class_names(
-                                    "input input-bordered w-full",
-                                    "input-error": @talk.errors[:event_name].any?,
-                                  ),
-                                placeholder: "e.g., RubyKaigi 2025" %>
+                      class:
+                        class_names(
+                          "input input-bordered w-full",
+                          "input-error": @talk.errors[:event_name].any?
+                        ),
+                      placeholder: "e.g., RubyKaigi 2025" %>
                 <% if @talk.errors[:event_name].any? %>
                   <div class="label">
                     <span class="label-text-alt text-error"><%= @talk.errors[:event_name].join(", ") %></span>
@@ -47,11 +47,11 @@
               <div class="form-control">
                 <%= form.label :date, "Date *", class: "label" %>
                 <%= form.date_field :date,
-                                class:
-                                  class_names(
-                                    "input input-bordered w-full",
-                                    "input-error": @talk.errors[:date].any?,
-                                  ) %>
+                      class:
+                        class_names(
+                          "input input-bordered w-full",
+                          "input-error": @talk.errors[:date].any?
+                        ) %>
                 <% if @talk.errors[:date].any? %>
                   <div class="label">
                     <span class="label-text-alt text-error"><%= @talk.errors[:date].join(", ") %></span>
@@ -62,20 +62,20 @@
               <div class="form-control">
                 <%= form.label :speakers, "Speakers", class: "label" %>
                 <%= form.combobox :speakers,
-                              speakers_search_templates_path,
-                              multiselect_chip_src: speakers_search_chips_templates_path,
-                              name_when_new: "template[speakers]",
-                              free_text: true,
-                              class: "w-full" %>
+                      speakers_search_templates_path,
+                      multiselect_chip_src: speakers_search_chips_templates_path,
+                      name_when_new: "template[speakers]",
+                      free_text: true,
+                      class: "w-full" %>
               </div>
             </div>
 
             <div class="form-control">
               <%= form.label :description, "Description", class: "label" %>
               <%= form.text_area :description,
-                             class: "textarea textarea-bordered w-full",
-                             rows: 3,
-                             placeholder: "Talk or event description..." %>
+                    class: "textarea textarea-bordered w-full",
+                    rows: 3,
+                    placeholder: "Talk or event description..." %>
             </div>
           </div>
         </div>
@@ -90,9 +90,9 @@
               <div class="form-control">
                 <%= form.label :raw_title, "Raw Title", class: "label" %>
                 <%= form.text_field :raw_title,
-                                class: "input input-bordered w-full",
-                                placeholder:
-                                  "e.g., [JA] Introducing Type Guard to Steep / Takeshi KOMIYA @tk0miya" %>
+                      class: "input input-bordered w-full",
+                      placeholder:
+                        "e.g., [JA] Introducing Type Guard to Steep / Takeshi KOMIYA @tk0miya" %>
               </div>
 
               <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -111,59 +111,59 @@
                 <div class="form-control">
                   <%= form.label :language, "Language", class: "label" %>
                   <%= form.select :language,
-                              [
-                                %w[English english],
-                                %w[Japanese japanese],
-                                %w[Spanish spanish],
-                                %w[French french],
-                                %w[German german],
-                              ],
-                              { prompt: "Select language..." },
-                              { class: "select select-bordered w-full" } %>
+                        [
+                          %w[English english],
+                          %w[Japanese japanese],
+                          %w[Spanish spanish],
+                          %w[French french],
+                          %w[German german]
+                        ],
+                        {prompt: "Select language..."},
+                        {class: "select select-bordered w-full"} %>
                 </div>
 
                 <div class="form-control">
                   <%= form.label :track, "Track/Room", class: "label" %>
                   <%= form.text_field :track,
-                                  class: "input input-bordered w-full",
-                                  placeholder: "e.g., Main Stage, Room A" %>
+                        class: "input input-bordered w-full",
+                        placeholder: "e.g., Main Stage, Room A" %>
                 </div>
               </div>
 
               <div class="form-control">
                 <%= form.label :slides_url, "Slides URL", class: "label" %>
                 <%= form.url_field :slides_url,
-                               class: "input input-bordered w-full",
-                               placeholder: "https://..." %>
+                      class: "input input-bordered w-full",
+                      placeholder: "https://..." %>
               </div>
 
               <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div class="form-control">
                   <%= form.label :thumbnail_xs, "Thumbnail XS", class: "label" %>
                   <%= form.url_field :thumbnail_xs,
-                                 class: "input input-bordered w-full",
-                                 placeholder: "https://..." %>
+                        class: "input input-bordered w-full",
+                        placeholder: "https://..." %>
                 </div>
 
                 <div class="form-control">
                   <%= form.label :thumbnail_sm, "Thumbnail SM", class: "label" %>
                   <%= form.url_field :thumbnail_sm,
-                                 class: "input input-bordered w-full",
-                                 placeholder: "https://..." %>
+                        class: "input input-bordered w-full",
+                        placeholder: "https://..." %>
                 </div>
 
                 <div class="form-control">
                   <%= form.label :thumbnail_md, "Thumbnail MD", class: "label" %>
                   <%= form.url_field :thumbnail_md,
-                                 class: "input input-bordered w-full",
-                                 placeholder: "https://..." %>
+                        class: "input input-bordered w-full",
+                        placeholder: "https://..." %>
                 </div>
 
                 <div class="form-control">
                   <%= form.label :thumbnail_lg, "Thumbnail LG", class: "label" %>
                   <%= form.url_field :thumbnail_lg,
-                                 class: "input input-bordered w-full",
-                                 placeholder: "https://..." %>
+                        class: "input input-bordered w-full",
+                        placeholder: "https://..." %>
                 </div>
               </div>
             </div>
@@ -181,16 +181,16 @@
                 <div class="form-control">
                   <%= form.label :video_provider, "Video Provider", class: "label" %>
                   <%= form.select :video_provider,
-                              ::Template::VIDEO_PROVIDERS.map { [it, it.squish.underscore] },
-                              { prompt: "Select provider..." },
-                              { class: "select select-bordered w-full" } %>
+                        ::Template::VIDEO_PROVIDERS.map { [it, it.squish.underscore] },
+                        {prompt: "Select provider..."},
+                        {class: "select select-bordered w-full"} %>
                 </div>
 
                 <div class="form-control">
                   <%= form.label :video_id, "Video ID", class: "label" %>
                   <%= form.text_field :video_id,
-                                  class: "input input-bordered w-full",
-                                  placeholder: "e.g., kp_jeGkUmhY" %>
+                        class: "input input-bordered w-full",
+                        placeholder: "e.g., kp_jeGkUmhY" %>
                 </div>
               </div>
 
@@ -198,15 +198,15 @@
                 <div class="form-control">
                   <%= form.label :start_cue, "Start Time", class: "label" %>
                   <%= form.time_field :start_cue,
-                                  class: "input input-bordered w-full",
-                                  placeholder: "e.g., 02:00" %>
+                        class: "input input-bordered w-full",
+                        placeholder: "e.g., 02:00" %>
                 </div>
 
                 <div class="form-control">
                   <%= form.label :end_cue, "End Time", class: "label" %>
                   <%= form.time_field :end_cue,
-                                  class: "input input-bordered w-full",
-                                  placeholder: "e.g., 30:00" %>
+                        class: "input input-bordered w-full",
+                        placeholder: "e.g., 30:00" %>
                 </div>
               </div>
 
@@ -220,8 +220,8 @@
               <div class="form-control">
                 <%= form.label :external_player_url, "External Player URL", class: "label" %>
                 <%= form.url_field :external_player_url,
-                               class: "input input-bordered w-full",
-                               placeholder: "https://..." %>
+                      class: "input input-bordered w-full",
+                      placeholder: "https://..." %>
               </div>
             </div>
           </div>
@@ -242,12 +242,12 @@
             </div>
 
             <%= link_to "Add Talk",
-            new_child_templates_path,
-            data: {
-              turbo_method: :get,
-              turbo_stream: true,
-            },
-            class: "btn btn-outline btn-lg w-full" %>
+                  new_child_templates_path,
+                  data: {
+                    turbo_method: :get,
+                    turbo_stream: true
+                  },
+                  class: "btn btn-outline btn-lg w-full" %>
           </div>
         </div>
 
@@ -267,24 +267,21 @@
                 <div
                   class="relative"
                   data-controller="copy-to-clipboard"
-                  data-copy-to-clipboard-success-class="scale-95"
-                >
+                  data-copy-to-clipboard-success-class="scale-95">
                   <button
                     class="
                       btn btn-sm btn-outline absolute top-1 right-1 transition-transform duration-150
                       ease-in-out
                     "
                     data-action="click->copy-to-clipboard#copy"
-                    data-copy-to-clipboard-target="button"
-                  >
+                    data-copy-to-clipboard-target="button">
                     Copy
                   </button>
                   <pre
                     class="
                       text-sm font-mono text-gray-800 whitespace-pre-wrap break-words
                     "
-                    data-copy-to-clipboard-target="source"
-                  ><%= @yaml %></pre>
+                    data-copy-to-clipboard-target="source"><%= @yaml %></pre>
                 </div>
               <% else %>
                 <div class="text-sm font-mono text-gray-500">

--- a/app/views/templates/speakers_search.turbo_stream.erb
+++ b/app/views/templates/speakers_search.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= async_combobox_options @speakers, value: proc { |element| element.name } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,8 @@ Rails.application.routes.draw do
     collection do
       get :new_child
       delete :delete_child
+      get :speakers_search
+      post :speakers_search_chips
     end
   end
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@hotwired/hotwire-native-bridge": "^1.1.0",
     "@hotwired/stimulus": "^3.2.1",
     "@hotwired/turbo-rails": "^8.0.4",
+    "@josefarias/hotwire_combobox": "^0.4.0",
     "@rails/request.js": "^0.0.11",
     "@splidejs/splide": "^4.1.4",
     "@tailwindcss/forms": "^0.5.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -245,6 +245,11 @@
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
+"@josefarias/hotwire_combobox@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@josefarias/hotwire_combobox/-/hotwire_combobox-0.4.0.tgz#9dc7040b4a107e797ad598e54773c1031cab960c"
+  integrity sha512-NcFKEfHYrL/2iQkqCy3z+PVJ+08roD1TM6I2M4/fUaoU0tE7g+LScbSzBu/76pNUxbRLg3qppqNvSGauu1yFNw==
+
 "@jridgewell/gen-mapping@^0.3.2":
   version "0.3.8"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz#4f0e06362e01362f823d348f1872b08f666d8142"
@@ -2774,7 +2779,16 @@ stimulus-vite-helpers@^3.0.0, stimulus-vite-helpers@^3.1.0:
   resolved "https://registry.yarnpkg.com/stimulus-vite-helpers/-/stimulus-vite-helpers-3.1.0.tgz#9216d703ac8d74befece4499ea738c18de408842"
   integrity sha512-qy9vnNnu6e/1PArEndp456BuSKLQkBgc+vX2pedOHT0N4GSLQY0l5fuQ4ft56xZ8xSWqrfuYSR+GXXIPtoESww==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2851,7 +2865,14 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
This is an improvement for #811 as suggested by @adrienpoly. Using [hotwire combobox](https://hotwirecombobox.com/) speaker names are not auto-suggested on typing.

![image](https://github.com/user-attachments/assets/fcd86ebd-cd87-4d89-b53f-8f4253faf697)

- Search uses the existing speaker search queries
- Multi-select and custom input (new speaker names) are supported
- Using names instead of IDs to generate the YAML