### PR TITLE
Update NoRuKo website address

### DIFF
--- a/data/euruko/noruko-2020/videos.yml
+++ b/data/euruko/noruko-2020/videos.yml
@@ -24,7 +24,7 @@
     #NoRuKo playlist with all talks and panels: https://www.youtube.com/playlist?list=PL9_A7olkztLlmJIAc567KQgKcMi7-qnjg
 
     Recorded 21th of August, 2020.
-    NoRuKo website: https://noruko.org/
+    NoRuKo website: https://noruko.rubynl.org/
     Stichting Ruby NL website: https://rubynl.org/
   track: ""
   video_provider: "youtube"
@@ -47,7 +47,7 @@
     #NoRuKo playlist with all talks and panels: https://www.youtube.com/playlist?list=PL9_A7olkztLlmJIAc567KQgKcMi7-qnjg
 
     Recorded 21th of August, 2020.
-    NoRuKo website: https://noruko.org/
+    NoRuKo website: https://noruko.rubynl.org/
     Stichting Ruby NL website: https://rubynl.org/
   track: ""
   video_provider: "youtube"
@@ -70,7 +70,7 @@
     #NoRuKo playlist with all talks and panels: https://www.youtube.com/playlist?list=PL9_A7olkztLlmJIAc567KQgKcMi7-qnjg
 
     Recorded 21th of August, 2020.
-    NoRuKo website: https://noruko.org/
+    NoRuKo website: https://noruko.rubynl.org/
     Stichting Ruby NL website: https://rubynl.org/
   track: "Main"
   video_provider: "youtube"
@@ -93,7 +93,7 @@
     #NoRuKo playlist with all talks and panels: https://www.youtube.com/playlist?list=PL9_A7olkztLlmJIAc567KQgKcMi7-qnjg
 
     Recorded 21th of August, 2020.
-    NoRuKo website: https://noruko.org/
+    NoRuKo website: https://noruko.rubynl.org/
     Stichting Ruby NL website: https://rubynl.org/
   track: "Community Track"
   video_provider: "youtube"
@@ -116,7 +116,7 @@
     #NoRuKo playlist with all talks and panels: https://www.youtube.com/playlist?list=PL9_A7olkztLlmJIAc567KQgKcMi7-qnjg
 
     Recorded 21th of August, 2020.
-    NoRuKo website: https://noruko.org/
+    NoRuKo website: https://noruko.rubynl.org/
     Stichting Ruby NL website: https://rubynl.org/
   track: "Main"
   video_provider: "youtube"
@@ -139,7 +139,7 @@
     #NoRuKo playlist with all talks and panels: https://www.youtube.com/playlist?list=PL9_A7olkztLlmJIAc567KQgKcMi7-qnjg
 
     Recorded 21th of August, 2020.
-    NoRuKo website: https://noruko.org/
+    NoRuKo website: https://noruko.rubynl.org/
     Stichting Ruby NL website: https://rubynl.org/
   track: "Community Track"
   video_provider: "youtube"
@@ -166,7 +166,7 @@
     #NoRuKo playlist with all talks and panels: https://www.youtube.com/playlist?list=PL9_A7olkztLlmJIAc567KQgKcMi7-qnjg
 
     Recorded 21th of August, 2020.
-    NoRuKo website: https://noruko.org/
+    NoRuKo website: https://noruko.rubynl.org/
     Stichting Ruby NL website: https://rubynl.org/
   track: "Main"
   video_provider: "youtube"
@@ -189,7 +189,7 @@
     #NoRuKo playlist with all talks and panels: https://www.youtube.com/playlist?list=PL9_A7olkztLlmJIAc567KQgKcMi7-qnjg
 
     Recorded 21th of August, 2020.
-    NoRuKo website: https://noruko.org/
+    NoRuKo website: https://noruko.rubynl.org/
     Stichting Ruby NL website: https://rubynl.org/
   track: "Community Track"
   video_provider: "youtube"
@@ -208,7 +208,7 @@
 
     ### Event
 
-    NoRuKo 2020, https://noruko.org
+    NoRuKo 2020, https://noruko.rubynl.org/
 
     ###  Artists
     \
@@ -240,7 +240,7 @@
     #NoRuKo playlist with all talks and panels: https://www.youtube.com/playlist?list=PL9_A7olkztLlmJIAc567KQgKcMi7-qnjg
 
     Recorded 21th of August, 2020.
-    NoRuKo website: https://noruko.org/
+    NoRuKo website: https://noruko.rubynl.org/
     Stichting Ruby NL website: https://rubynl.org/
   track: "Main"
   video_provider: "youtube"
@@ -263,7 +263,7 @@
     #NoRuKo playlist with all talks and panels: https://www.youtube.com/playlist?list=PL9_A7olkztLlmJIAc567KQgKcMi7-qnjg
 
     Recorded 21th of August, 2020.
-    NoRuKo website: https://noruko.org/
+    NoRuKo website: https://noruko.rubynl.org/
     Stichting Ruby NL website: https://rubynl.org/
   track: "Community Track"
   video_provider: "youtube"
@@ -286,7 +286,7 @@
     #NoRuKo playlist with all talks and panels: https://www.youtube.com/playlist?list=PL9_A7olkztLlmJIAc567KQgKcMi7-qnjg
 
     Recorded 21th of August, 2020.
-    NoRuKo website: https://noruko.org/
+    NoRuKo website: https://noruko.rubynl.org/
     Stichting Ruby NL website: https://rubynl.org/
   track: "Main"
   video_provider: "youtube"
@@ -309,7 +309,7 @@
     #NoRuKo playlist with all talks and panels: https://www.youtube.com/playlist?list=PL9_A7olkztLlmJIAc567KQgKcMi7-qnjg
 
     Recorded 21th of August, 2020.
-    NoRuKo website: https://noruko.org/
+    NoRuKo website: https://noruko.rubynl.org/
     Stichting Ruby NL website: https://rubynl.org/
   track: "Community Track"
   video_provider: "youtube"
@@ -334,7 +334,7 @@
     #NoRuKo playlist with all talks and panels: https://www.youtube.com/playlist?list=PL9_A7olkztLlmJIAc567KQgKcMi7-qnjg
 
     Recorded 21th of August, 2020.
-    NoRuKo website: https://noruko.org/
+    NoRuKo website: https://noruko.rubynl.org/
     Stichting Ruby NL website: https://rubynl.org/
   track: "Main"
   video_provider: "youtube"
@@ -357,7 +357,7 @@
     #NoRuKo playlist with all talks and panels: https://www.youtube.com/playlist?list=PL9_A7olkztLlmJIAc567KQgKcMi7-qnjg
 
     Recorded 21th of August, 2020.
-    NoRuKo website: https://noruko.org/
+    NoRuKo website: https://noruko.rubynl.org/
     Stichting Ruby NL website: https://rubynl.org/
   track: "Community Track"
   video_provider: "youtube"
@@ -386,7 +386,7 @@
     #NoRuKo playlist with all talks and panels: https://www.youtube.com/playlist?list=PL9_A7olkztLlmJIAc567KQgKcMi7-qnjg
 
     Recorded 21th of August, 2020.
-    NoRuKo website: https://noruko.org/
+    NoRuKo website: https://noruko.rubynl.org/
     Stichting Ruby NL website: https://rubynl.org/
   track: ""
   video_provider: "youtube"

--- a/data/euruko/playlists.yml
+++ b/data/euruko/playlists.yml
@@ -252,6 +252,7 @@
   banner_background: "linear-gradient(170deg, #ffddfb 40%, #ffb3a1)"
   featured_background: "linear-gradient(170deg, #ffddfb 40%, #ffb3a1)"
   featured_color: "#000000"
+  website: https://noruko.rubynl.org
 
 - id: PLZW-kXE0oRyknRwEUrg5o491KomjkNU16
   title: EuRuKo 2021


### PR DESCRIPTION
The noruko.org domain redirects to this new address since the noruko.org domain will eventually expire. (I am the domain holder.) Update the links to the redirected address so they will continue to point to the event website.