### PR TITLE
Enhancement: Indication that an event series is not active anymore.

### DIFF
--- a/app/models/event/static_metadata.rb
+++ b/app/models/event/static_metadata.rb
@@ -84,6 +84,10 @@ class Event::StaticMetadata < ActiveRecord::AssociatedObject
     Country.find(location.to_s.split(",").last&.strip)
   end
 
+  def last_edition?
+    static_repository&.last_edition || false
+  end
+
   private
 
   def static_repository

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -36,6 +36,7 @@ class Organisation < ApplicationRecord
   # associations
   has_many :events, dependent: :destroy, inverse_of: :organisation, foreign_key: :organisation_id, strict_loading: true
   has_many :talks, through: :events
+  has_object :static_metadata
 
   # validations
   validates :name, presence: true

--- a/app/models/organisation/static_metadata.rb
+++ b/app/models/organisation/static_metadata.rb
@@ -1,0 +1,11 @@
+class Organisation::StaticMetadata < ActiveRecord::AssociatedObject
+  def ended?
+    static_repository&.ended || false
+  end
+
+  private
+
+  def static_repository
+    @static_repository ||= Static::Organisation.find_by(slug: organisation.slug)
+  end
+end

--- a/app/views/events/_card.html.erb
+++ b/app/views/events/_card.html.erb
@@ -1,14 +1,21 @@
 <%= link_to event_path(event), class: "flex w-full" do %>
   <div class="card card-compact bg-white border w-full">
     <%= image_tag image_path(event.card_image_path), class: "w-full object-cover rounded-t-xl border-b", alt: event.name, width: 300, height: 175 %>
-    <div class="card-body flex flex-col items-center justify-center">
+    <div class="card-body flex flex-col items-center justify-center min-h-[120px]">
         <div class="text-xl font-semibold text-center line-clamp-1"><%= event.name %></div>
-        <div class="text-gray-500 text-center">
+        <div class="text-gray-500 text-center flex-grow flex flex-col">
           <% if event.static_metadata && event.static_metadata.location != "Earth" %>
             <%= event.static_metadata.location %><br>
           <% end %>
 
         <%= event.formatted_dates %>
+
+        <% if event.static_metadata.last_edition? %>
+            <div class="flex items-center justify-center mt-auto -mb-0.5 text-gray-400">
+              <%= heroicon "archive-box", size: :sm %>
+              <span class="text-sm">Final Edition</span>
+            </div>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/events/_card.html.erb
+++ b/app/views/events/_card.html.erb
@@ -1,7 +1,7 @@
 <%= link_to event_path(event), class: "flex w-full" do %>
   <div class="card card-compact bg-white border w-full">
     <%= image_tag image_path(event.card_image_path), class: "w-full object-cover rounded-t-xl border-b", alt: event.name, width: 300, height: 175 %>
-    <div class="card-body flex flex-col items-center justify-center min-h-[120px]">
+    <div class="card-body flex flex-col items-center justify-center min-h-[130px]">
         <div class="text-xl font-semibold text-center line-clamp-1"><%= event.name %></div>
         <div class="text-gray-500 text-center flex-grow flex flex-col">
           <% if event.static_metadata && event.static_metadata.location != "Earth" %>
@@ -13,7 +13,7 @@
         <% if event.static_metadata.last_edition? %>
             <div class="flex items-center justify-center mt-auto -mb-0.5 text-gray-400">
               <%= heroicon "archive-box", size: :sm %>
-              <span class="text-sm">Final Edition</span>
+              <span class="text-sm mt-0.5 ml-1">Final Edition</span>
             </div>
         <% end %>
       </div>

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -19,9 +19,16 @@
     </div>
   </div>
 
-  <p class="mt-3 md:mt-9 mb-6 text-[#636B74] max-w-[700px]">
+  <p class="mt-3 md:mt-9 mb-3 text-[#636B74] max-w-[700px]">
     <%= @organisation.description %>
   </p>
+
+  <% if @organisation.static_metadata.ended? %>
+    <div class="flex -mt-0.5 mb-4 text-gray-400">
+      <%= heroicon "archive-box", size: :sm, class: "mt-0.5" %>
+      <span class="text-sm mt-0.5 ml-0.5">This event series is not active anymore.</span>
+    </div>
+  <% end %>
 
   <% if (featured_event = @events.find { |event| event.featurable? }) %>
     <div class="hidden lg:block">

--- a/data/organisations.yml
+++ b/data/organisations.yml
@@ -9,6 +9,7 @@
   slug: railsconf
   language: english
   youtube_channel_id: UCWnPjmqvljcafA0z2U1fwKQ
+  ended: true
 
 - name: RailsConf Europe
   website: http://www.railsconfeurope.com/

--- a/data/railsconf/playlists.yml
+++ b/data/railsconf/playlists.yml
@@ -297,3 +297,4 @@
   featured_background: "#FFFFFA"
   featured_color: "000000"
   website: https://ti.to/railsconf/2025?ref=rubyevents.org
+  last_edition: true


### PR DESCRIPTION
For events that ended, for example Rails Conf whose last edition was July 2025, this change allows us to display a hero icon as part of the event card to signify that the event in question was the final edition of that particular conference. 

Fixes #773 
<img width="1318" height="637" alt="image" src="https://github.com/user-attachments/assets/682a0951-b0a9-47d9-b7ad-1d6bf0eb9d36" />
