### PR TITLE
Update Twitter button icon and hover colour in speaker socials partial

### DIFF
--- a/app/views/speakers/_socials.html.erb
+++ b/app/views/speakers/_socials.html.erb
@@ -7,8 +7,8 @@
     <% end %>
 
     <% if speaker.twitter.present? %>
-      <%= ui_button url: "https://www.x.com/#{speaker.twitter}", kind: :circle, size: :sm, target: "_blank", class: "hover:bg-[#74C0FC] hover:fill-white border-base-200" do %>
-        <%= fab("twitter", size: :md) %>
+      <%= ui_button url: "https://www.x.com/#{speaker.twitter}", kind: :circle, size: :sm, target: "_blank", class: "hover:bg-black hover:fill-white border-base-200" do %>
+        <%= fab("x-twitter", size: :md) %>
       <% end %>
     <% end %>
 


### PR DESCRIPTION
This PR updates the Twitter button in the speaker socials partial to reflect the latest Twitter/X branding:

Icon: Changed from `fab("twitter")` to `fab("x-twitter")`

Hover colour: Updated from `hover:bg-[#74C0FC]` to `hover:bg-black` for better alignment with X’s current branding

No functionality changes - just a minor UI/UX improvement to stay visually up to date.


https://github.com/user-attachments/assets/e0fc7763-b2c7-4b23-9c7c-7e52b1eb5607



