### PR TITLE
move playing video to bottom right when scrolling down

### DIFF
--- a/app/assets/stylesheets/components/video.css
+++ b/app/assets/stylesheets/components/video.css
@@ -17,9 +17,17 @@
   .v-bigPlay {
     opacity: 0.5 !important;
   }
-  
+
   .v-openInYouTube.v-controlButton svg {
     width: 65%;
     fill: var(--vlite-controlsColor);
+  }
+
+  /* Picture in picture styling */
+  .picture-in-picture .picture-in-picture-container {
+    @apply sm:fixed sm:bottom-4 sm:right-4 sm:z-10 sm:h-auto sm:w-full sm:max-w-sm sm:rounded-xl xl:max-w-lg;
+    .v-video {
+      @apply rounded-xl;
+    }
   }
 }

--- a/app/javascript/controllers/video_player_controller.js
+++ b/app/javascript/controllers/video_player_controller.js
@@ -31,6 +31,7 @@ export default class extends Controller {
   // methods
 
   init () {
+    if (this.isPreview) return
     if (!this.hasPlayerTarget) return
 
     this.player = new Vlitejs(this.playerTarget, this.options)
@@ -68,10 +69,12 @@ export default class extends Controller {
   // callbacks
 
   appear () {
+    if (!this.ready) return
     this.#togglePictureInPicturePlayer(false)
   }
 
   disappear () {
+    if (!this.ready) return
     this.#togglePictureInPicturePlayer(true)
   }
 
@@ -166,5 +169,9 @@ export default class extends Controller {
     }
 
     return !this.player.isPaused
+  }
+
+  get isPreview () {
+    return document.documentElement.hasAttribute('data-turbo-preview')
   }
 }

--- a/app/javascript/controllers/video_player_controller.js
+++ b/app/javascript/controllers/video_player_controller.js
@@ -68,11 +68,11 @@ export default class extends Controller {
   // callbacks
 
   appear () {
-    this.#togglePictureInPictureplayer(false)
+    this.#togglePictureInPicturePlayer(false)
   }
 
   disappear () {
-    this.#togglePictureInPictureplayer(true)
+    this.#togglePictureInPicturePlayer(true)
   }
 
   handlePlayerReady (player) {
@@ -140,7 +140,7 @@ export default class extends Controller {
     return anchorTag
   }
 
-  #togglePictureInPictureplayer (enabled) {
+  #togglePictureInPicturePlayer (enabled) {
     const toggleClasses = () => {
       if (enabled && this.isPlaying) {
         this.playerWrapperTarget.classList.add('picture-in-picture')

--- a/app/javascript/controllers/video_player_controller.js
+++ b/app/javascript/controllers/video_player_controller.js
@@ -147,8 +147,10 @@ export default class extends Controller {
     const toggleClasses = () => {
       if (enabled && this.isPlaying) {
         this.playerWrapperTarget.classList.add('picture-in-picture')
+        this.playerWrapperTarget.querySelector('.v-controlBar').classList.add('v-hidden')
       } else {
         this.playerWrapperTarget.classList.remove('picture-in-picture')
+        this.playerWrapperTarget.querySelector('.v-controlBar').classList.remove('v-hidden')
       }
     }
 

--- a/app/views/talks/_explore_event.html.erb
+++ b/app/views/talks/_explore_event.html.erb
@@ -1,4 +1,4 @@
-<%= link_to event_path(event), id: "explore-event", class: "card group bg-gray-100 border hover:bg-gray-200/50 transition-bg duration-300 ease-in-out w-full flex flex-row px-6 py-6 gap-8 mt-4 overflow-hidden", style: "background: #{event.static_metadata.featured_background}; color: #{event.static_metadata.featured_color}" do %>
+<%= link_to event_path(event), id: "explore-event", class: "rounded-xl group bg-gray-100 border hover:bg-gray-200/50 transition-bg duration-300 ease-in-out w-full flex flex-row px-6 py-6 gap-8 mt-4 overflow-hidden", style: "background: #{event.static_metadata.featured_background}; color: #{event.static_metadata.featured_color}" do %>
   <div class="aspect-video hidden md:block">
     <%= image_tag image_path(event.featured_image_path), id: dom_id(event, "explore-card-image"), alt: "explore all talks recorded at #{event.name}", class: "h-24 aspect-video rounded-xl group-hover:scale-105 transition ease-in-out duration-300" %>
   </div>

--- a/app/views/talks/_talk.html.erb
+++ b/app/views/talks/_talk.html.erb
@@ -28,7 +28,7 @@
   <div class="aspect-video banner-img card-horizontal-img relative rounded-xl overflow-hidden outline outline-1 bg-gray-300 outline-gray-300">
     <% if talk.external_player %>
       <%= link_to talk.external_player_url, target: "_blank", class: "relative w-full h-full block" do %>
-        <%= image_tag talk.thumbnail_xl, class: "w-full h-full object-cover rounded-xl" %>
+        <%= image_tag talk.thumbnail_xl, class: "w-full h-full object-cover rounded-xl", style: "view-transition-name: #{dom_id(talk, :image)}" %>
 
         <div class="absolute inset-0 text-center text-white bg-black/80 flex flex-col gap-6 justify-center items-center font-bold text-xl rounded-xl p-6">
           This talk is available to watch on <%= URI.parse(talk.external_player_url).host %>

--- a/app/views/talks/_talk.html.erb
+++ b/app/views/talks/_talk.html.erb
@@ -25,7 +25,7 @@
         video_player_end_seconds_value: talk.end_seconds
       } do %>
 
-  <div class="aspect-video banner-img card-horizontal-img relative rounded-xl overflow-hidden outline outline-1 bg-gray-300 outline-gray-300" style="view-transition-name: <%= dom_id(talk, :image) %>">
+  <div class="aspect-video banner-img card-horizontal-img relative rounded-xl overflow-hidden outline outline-1 bg-gray-300 outline-gray-300">
     <% if talk.external_player %>
       <%= link_to talk.external_player_url, target: "_blank", class: "relative w-full h-full block" do %>
         <%= image_tag talk.thumbnail_xl, class: "w-full h-full object-cover rounded-xl" %>

--- a/app/views/talks/video_providers/_mp4.html.erb
+++ b/app/views/talks/video_providers/_mp4.html.erb
@@ -1,1 +1,5 @@
-<video id="player" class="rounded-xl" data-video-player-target="player" src="<%= talk.provider_url %>"></video>
+<div data-video-player-target="playerWrapper">
+  <div class="picture-in-picture-container" style="view-transition-name: <%= dom_id(talk, :image) %>">
+    <video id="player" class="rounded-xl" data-video-player-target="player" src="<%= talk.provider_url %>"></video>
+  </div>
+</div>

--- a/app/views/talks/video_providers/_vimeo.html.erb
+++ b/app/views/talks/video_providers/_vimeo.html.erb
@@ -1,7 +1,12 @@
-<div
-  class="image rounded-xl"
-  id="<%= dom_id(talk, :vimeo) %>"
-  data-video-player-target="player"
-  data-vimeo-id="<%= video_id %>"
-  data-vimeo-start-time="<%= talk.start_seconds %>"
-  data-vimeo-end-time="<%= talk.end_seconds %>"></div>
+<div data-video-player-target="playerWrapper">
+  <div class="picture-in-picture-container" style="view-transition-name: <%= dom_id(talk, :image) %>">
+    <div
+      class="image rounded-xl"
+      id="<%= dom_id(talk, :vimeo) %>"
+      data-video-player-target="player"
+      data-vimeo-id="<%= video_id %>"
+      data-vimeo-start-time="<%= talk.start_seconds %>"
+      data-vimeo-end-time="<%= talk.end_seconds %>">
+    </div>
+  </div>
+</div>

--- a/app/views/talks/video_providers/_youtube.html.erb
+++ b/app/views/talks/video_providers/_youtube.html.erb
@@ -1,7 +1,10 @@
-<div
-  class="image rounded-xl"
-  id="<%= dom_id(talk, :youtube) %>"
-  data-video-player-target="player"
-  data-youtube-id="<%= video_id %>">
-
+<div data-video-player-target="playerWrapper">
+  <div class="picture-in-picture-container" style="view-transition-name: <%= dom_id(talk, :image) %>">
+    <div
+      class="image rounded-xl"
+      id="<%= dom_id(talk, :youtube) %>"
+      data-video-player-target="player"
+      data-youtube-id="<%= video_id %>">
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
largely inspired by the UX from https://highleveragerails.com/ and TailwindPlus [Compass Template](https://tailwindcss.com/plus/templates/compass)

The main advantage from a UX point of view is that on larger screen you keep the video visible while being able to read the transcript or read the description 
 
https://github.com/user-attachments/assets/1ee1a555-07a8-4fca-8656-c830905feee2

