### PR TITLE
replace strftime by i18n localize

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -149,22 +149,19 @@ class Event < ApplicationRecord
     when "month"
       start_date.strftime("%B %Y")
     when "day"
-      return start_date.strftime("%B %d, %Y") if start_date == end_date
+      return I18n.l(start_date, default: "unknown") if start_date == end_date
 
       if start_date.strftime("%Y-%m") == end_date.strftime("%Y-%m")
         return "#{start_date.strftime("%B %d")}-#{end_date.strftime("%d, %Y")}"
       end
 
       if start_date.strftime("%Y") == end_date.strftime("%Y")
-        return "#{start_date.strftime("%B %d")} - #{end_date.strftime("%B %d, %Y")}"
+        return "#{I18n.l(start_date, format: :month_day, default: "unknown")} - #{I18n.l(end_date, default: "unknown")}"
       end
 
-      "#{start_date.strftime("%b %d, %Y")} - #{end_date.strftime("%b %d, %Y")}"
+      "#{I18n.l(start_date, format: :medium,
+        default: "unknown")} - #{I18n.l(end_date, format: :medium, default: "unknown")}"
     end
-  rescue => _e
-    # TODO: notify to error tracking
-
-    "Unknown"
   end
 
   def country_name

--- a/app/models/event/cfp.rb
+++ b/app/models/event/cfp.rb
@@ -70,10 +70,10 @@ class Event::CFP < ActiveRecord::AssociatedObject
   end
 
   def formatted_open_date
-    open_date&.strftime("%B %d, %Y")
+    I18n.l(open_date, default: "unknown")
   end
 
   def formatted_close_date
-    close_date&.strftime("%B %d, %Y")
+    I18n.l(close_date, default: "unknown")
   end
 end

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -407,11 +407,7 @@ class Talk < ApplicationRecord
   end
 
   def formatted_date
-    date.strftime("%B %d, %Y")
-  rescue => _e
-    # TODO: notify to error tracking
-
-    "Unknown"
+    I18n.l(date, default: "unknown")
   end
 
   def formatted_duration

--- a/app/views/events/events/index.html.erb
+++ b/app/views/events/events/index.html.erb
@@ -11,9 +11,9 @@
             <div class="w-full sm:w-[10rem] mt-2 flex-shrink-0">
               <time datetime="<%= talk.date.iso8601 %>" class="text-black font-medium text-lg">
                 <% if talk.date.year == Date.today.year %>
-                  <%= talk.date.strftime("%b %d") %>
+                  <%= l(talk.date, format: :month_day, default: "unknown") %>
                 <% else %>
-                  <%= talk.date.strftime("%b %d, %Y") %>
+                  <%= l(talk.date, format: :medium, default: "unknown") %>
                 <% end %>
               </time>
               <div class="text-gray-400 font-normal">
@@ -42,7 +42,7 @@
                   </div>
 
                   <div>
-                    <%= talk.date.strftime("%B %d, %Y") %>
+                    <%= l(talk.date, default: "unknown") %>
                   </div>
 
                   <div class="mt-3">

--- a/app/views/talks/_talk.html.erb
+++ b/app/views/talks/_talk.html.erb
@@ -264,11 +264,11 @@
           </p>
 
           <p>
-            Date: <% if talk.date %> <%= talk.formatted_date %> <% else %> unknown<% end %><br>
+            Date: <%= talk.formatted_date %><br>
 
             <span class="text-gray-400">
-              Published: <% if talk.published_at %><%= talk.published_at.strftime("%B %d, %Y") %><% elsif talk.published? %> unknown <% else %> not published <% end %><br>
-              Announced: <% if talk.announced_at %><%= talk.announced_at.strftime("%B %d, %Y") %><% else %> unknown<% end %>
+              Published: <% if talk.published_at %><%= l(talk.published_at, default: "unknown") %><% elsif talk.published? %> unknown <% else %> not published <% end %><br>
+              Announced: <%= l(talk.announced_at, default: "unknown") %>
             </span>
           </p>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,8 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  date:
+    formats:
+      default: "%B %d, %Y"
+      medium: "%b %d, %Y"
+      month_day: "%B %d"


### PR DESCRIPTION
looking at #863, I realized that we use quite a lot of strftime in the code base. 

I prefer to use I18n built in localisation as I usually find it hard to write strftime and we can more easily control the different date formats available in the app