### PR TITLE
fix: redirect issue in events search results.

### DIFF
--- a/app/views/spotlight/events/index.turbo_stream.erb
+++ b/app/views/spotlight/events/index.turbo_stream.erb
@@ -3,7 +3,7 @@
     <h2>Events</h2>
     <% if @events.size.positive? %>
       <span class="text-sm text-gray-500">(<%= @events.size %> of <%= @events_count %>)</span>
-      <%= link_to events_path(s: search_query), class: "link text-sm text-gray-500", target: "_top" do %>
+      <%= link_to archive_events_path(s: search_query), class: "link text-sm text-gray-500", target: "_top" do %>
         see results
       <% end %>
     <% end %>


### PR DESCRIPTION
Hi @marcoroth, when I was searching for events happened in a year, the searched results are not shown in a page via  `see results` link. 

Wrong url for events `see results` link. So, I have updated it properly to redirect it to the events archive page.

Hoping this is the right fix.✌️

Before:

https://github.com/user-attachments/assets/1058d3dd-9043-4f4b-85ad-acc00e2733d5


After:

https://github.com/user-attachments/assets/e2b4168e-1d43-424c-8cba-cc108190905a

