### PR TITLE
remove annotate warnings and comments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,7 @@ GEM
     active_link_to (1.0.5)
       actionpack
       addressable
-    active_record-associated_object (0.9.1)
+    active_record-associated_object (0.9.2)
       activerecord (>= 6.1)
     activejob (8.0.2)
       activesupport (= 8.0.2)
@@ -85,7 +85,7 @@ GEM
       activesupport (>= 7.1)
       device_detector (>= 1)
       safely_block (>= 0.4)
-    annotaterb (4.17.0)
+    annotaterb (4.18.0)
       activerecord (>= 6.0.0)
       activesupport (>= 6.0.0)
     appsignal (4.5.17)

--- a/app/models/event/cfp.rb
+++ b/app/models/event/cfp.rb
@@ -1,5 +1,3 @@
-# -*- SkipSchemaAnnotations
-
 class Event::CFP < ActiveRecord::AssociatedObject
   def open?
     return false if closed?

--- a/app/models/event/schedule.rb
+++ b/app/models/event/schedule.rb
@@ -1,4 +1,3 @@
-# -*- SkipSchemaAnnotations
 class Event::Schedule < ActiveRecord::AssociatedObject
   def file_path
     event.data_folder.join("schedule.yml")

--- a/app/models/event/static_metadata.rb
+++ b/app/models/event/static_metadata.rb
@@ -1,5 +1,3 @@
-# -*- SkipSchemaAnnotations
-
 class Event::StaticMetadata < ActiveRecord::AssociatedObject
   delegate :published_date, :home_sort_date, to: :static_repository, allow_nil: true
 

--- a/app/models/organisation/static_metadata.rb
+++ b/app/models/organisation/static_metadata.rb
@@ -1,5 +1,3 @@
-# -*- SkipSchemaAnnotations
-
 class Organisation::StaticMetadata < ActiveRecord::AssociatedObject
   def ended?
     static_repository&.ended || false

--- a/app/models/speaker/profiles.rb
+++ b/app/models/speaker/profiles.rb
@@ -1,4 +1,3 @@
-# -*- SkipSchemaAnnotations
 class Speaker::Profiles < ActiveRecord::AssociatedObject
   performs(retries: 3) { limits_concurrency key: -> { it.id } }
 

--- a/app/models/talk/agents.rb
+++ b/app/models/talk/agents.rb
@@ -1,4 +1,3 @@
-# -*- SkipSchemaAnnotations
 class Talk::Agents < ActiveRecord::AssociatedObject
   performs retries: 3 do
     # this is to comply to the rate limit of openai 60 000 tokens per minute

--- a/app/models/talk/downloader.rb
+++ b/app/models/talk/downloader.rb
@@ -1,5 +1,3 @@
-# -*- SkipSchemaAnnotations
-
 class Talk::Downloader < ActiveRecord::AssociatedObject
   def download_path
     Rails.root / "tmp" / "videos" / talk.video_provider / "#{talk.video_id}.mp4"

--- a/app/models/talk/thumbnails.rb
+++ b/app/models/talk/thumbnails.rb
@@ -1,5 +1,3 @@
-# -*- SkipSchemaAnnotations
-
 class Talk::Thumbnails < ActiveRecord::AssociatedObject
   def path
     directory / "#{talk.video_id}.webp"


### PR DESCRIPTION
following to https://github.com/drwl/annotaterb/issues/172 this PR removes teh magic comment required in associated objects to silence the annotations warnings

Normally the problem should be fix with the new `annotaterb` gem and `active_record-associated-object` but at the time of this writing when I run the command I still have those warnings

```
❯ bundle exec annotaterb models
Annotating models
Unable to process app/models/event/cfp.rb: undefined method 'cfp' for true
Unable to process app/models/event/schedule.rb: undefined method 'schedule' for true
Unable to process app/models/event/static_metadata.rb: undefined method 'static_metadata' for true
Unable to process app/models/organisation/static_metadata.rb: undefined method 'static_metadata' for true
Unable to process app/models/speaker/profiles.rb: undefined method 'profiles' for true
Unable to process app/models/talk/agents.rb: undefined method 'agents' for true
Unable to process app/models/talk/downloader.rb: undefined method 'downloader' for true
Unable to process app/models/talk/thumbnails.rb: undefined method 'thumbnails' for true
Model files unchanged.
```
