### PR TITLE
fix migration

### DIFF
--- a/db/migrate/20250605203429_add_start_and_end_date_to_event.rb
+++ b/db/migrate/20250605203429_add_start_and_end_date_to_event.rb
@@ -2,9 +2,5 @@ class AddStartAndEndDateToEvent < ActiveRecord::Migration[8.0]
   def change
     add_column :events, :start_date, :date
     add_column :events, :end_date, :date
-
-    Event.all.each do |event|
-      event.update(start_date: event.static_metadata.start_date, end_date: event.static_metadata.end_date)
-    end
   end
 end

--- a/db/migrate/20250614131810_add_kind_to_event.rb
+++ b/db/migrate/20250614131810_add_kind_to_event.rb
@@ -2,18 +2,6 @@ class AddKindToEvent < ActiveRecord::Migration[8.0]
   def up
     add_column :events, :kind, :string, default: "event", null: false
     add_index :events, :kind
-
-    Event.find_in_batches.each do |events|
-      events.each do |event|
-        if event.static_metadata.meetup?
-          event.update!(kind: "meetup")
-        elsif event.static_metadata.conference?
-          event.update!(kind: "conference")
-        else
-          event.update!(kind: "event")
-        end
-      end
-    end
   end
 
   def down

--- a/db/migrate/20250617115359_add_date_precision_to_events.rb
+++ b/db/migrate/20250617115359_add_date_precision_to_events.rb
@@ -3,5 +3,21 @@
 class AddDatePrecisionToEvents < ActiveRecord::Migration[8.0]
   def change
     add_column :events, :date_precision, :string, null: false, default: "day"
+
+    Event.all.each do |event|
+      event.update(start_date: event.static_metadata.start_date, end_date: event.static_metadata.end_date)
+    end
+
+    Event.find_in_batches.each do |events|
+      events.each do |event|
+        if event.static_metadata.meetup?
+          event.update!(kind: "meetup")
+        elsif event.static_metadata.conference?
+          event.update!(kind: "conference")
+        else
+          event.update!(kind: "event")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
I think this is related to #833 where some user are experiencing an error message 

```
Undeclared attribute type for enum 'kind' in Talk. Enums must be backed by a database column or declared with an explicit type via attribute.
```

I could reproduce this error on a older db that wasn't migrated for a long time but already had some content as we are iterating over the Event in a migration before defining the enum this triggers this error.

This PR move those iteration in later migration so that the enum is already defined 

It doesn't really explain why this error occured on fresh installs