### PR TITLE
reduce featured event count to fix mobile display

### DIFF
--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -30,7 +30,7 @@ class PageController < ApplicationController
       .select(&:featured?)
       .sort_by(&:home_sort_date)
       .reverse
-      .take(25)
+      .take(15)
       .map(&:slug)
 
     @featured_events = Event.distinct


### PR DESCRIPTION
On mobile the featured events display is a bit broken as we now have lots of them

<img width="830" height="670" alt="CleanShot 2025-08-11 at 06 59 36@2x" src="https://github.com/user-attachments/assets/f2dabcc6-efef-4c45-942b-411584c26543" />

This PR limits to 15 events in the featured sections (rather than 25)

<img width="750" height="646" alt="CleanShot 2025-08-11 at 07 00 00@2x" src="https://github.com/user-attachments/assets/f5326a6b-652f-4f67-a7bf-fda9a784f48b" />
