### PR TITLE
Enhance Sponsor Avatar and Logo Handling with Fallbacks

### DIFF
--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -61,11 +61,21 @@ class Sponsor < ApplicationRecord
   end
 
   def avatar_image_path
-    sponsor_image_or_default_for("avatar.webp")
+    if sponsor_image_for("avatar.webp")
+      sponsor_image_or_default_for("avatar.webp")
+    else
+      generate_avatar_url
+    end
   end
 
   def banner_image_path
     sponsor_image_or_default_for("banner.webp")
+  end
+
+  def generate_avatar_url(size: 200)
+    url_safe_initials = name.split(" ").map(&:first).join("")
+
+    "https://ui-avatars.com/api/?name=#{url_safe_initials}&size=#{size}&background=f3f4f6&color=4b5563&font-size=0.4&length=2"
   end
 
   def logo_image_path

--- a/app/views/sponsors/_card.html.erb
+++ b/app/views/sponsors/_card.html.erb
@@ -21,8 +21,8 @@
           </div>
         </div>
       <% else %>
-        <div class="<%= image_size_class %> flex items-center justify-center">
-          <span class="text-lg font-semibold text-gray-700 text-center line-clamp-3"><%= sponsor.name %></span>
+        <div class="bg-gray-100 rounded-lg p-2 border border-gray-200">
+          <%= image_tag image_path(sponsor.avatar_image_path), class: "#{image_size_class} object-contain", loading: "lazy" %>
         </div>
       <% end %>
     </figure>

--- a/app/views/sponsors/_header.html.erb
+++ b/app/views/sponsors/_header.html.erb
@@ -30,17 +30,12 @@
             <span class="text-4xl md:text-6xl font-bold text-gray-600"><%= sponsor.name.first %></span>
           </div>
         </div>
-      <% elsif sponsor.sponsor_image_for("avatar.webp") %>
+      <% else %>
         <%= image_tag image_path(sponsor.avatar_image_path),
               class: "rounded-lg border border-[#D9DFE3] size-24 md:size-36",
               alt: "#{sponsor.name} Avatar",
               style: "view-transition-name: avatar",
               loading: :lazy %>
-      <% else %>
-        <div class="rounded-lg border border-[#D9DFE3] size-24 md:size-36 bg-gray-100 flex items-center justify-center"
-             style="view-transition-name: avatar">
-          <span class="text-4xl md:text-6xl font-bold text-gray-600"><%= sponsor.name.first %></span>
-        </div>
       <% end %>
 
       <div class="flex-col flex justify-center break-all">

--- a/app/views/sponsors/_header.html.erb
+++ b/app/views/sponsors/_header.html.erb
@@ -24,11 +24,7 @@
           <%= image_tag sponsor.logo_image_path,
                 class: "w-full h-full object-contain",
                 alt: "#{sponsor.name} Logo",
-                loading: :lazy,
-                onerror: "this.style.display='none'; this.nextElementSibling.style.display='flex';" %>
-          <div class="w-full h-full bg-gray-100 items-center justify-center hidden">
-            <span class="text-4xl md:text-6xl font-bold text-gray-600"><%= sponsor.name.first %></span>
-          </div>
+                loading: :lazy %>
         </div>
       <% else %>
         <%= image_tag image_path(sponsor.avatar_image_path),

--- a/app/views/sponsors/_sponsor.html.erb
+++ b/app/views/sponsors/_sponsor.html.erb
@@ -13,14 +13,8 @@
           </div>
         </div>
       </div>
-    <% elsif sponsor.sponsor_image_for("avatar.webp") %>
-      <%= image_tag image_path(sponsor.avatar_image_path), class: "size-8 rounded border border-[#D9DFE3]", loading: "lazy" %>
     <% else %>
-      <div class="avatar placeholder">
-        <div class="size-8 rounded bg-gray-100 text-gray-600 border border-[#D9DFE3] flex items-center justify-center">
-          <span class="text-sm font-bold"><%= sponsor.name.split(" ").map(&:first).join.first(2) %></span>
-        </div>
-      </div>
+      <%= image_tag image_path(sponsor.avatar_image_path), class: "size-8 rounded border border-[#D9DFE3]", loading: "lazy" %>
     <% end %>
 
     <span class="line-clamp-1"><%= sponsor.name %></span>

--- a/test/models/sponsor_test.rb
+++ b/test/models/sponsor_test.rb
@@ -64,4 +64,37 @@ class SponsorTest < ActiveSupport::TestCase
     sponsor = Sponsor.create!(name: "Coerce Corp", website: "example.com/?utm_campaign=abc#top")
     assert_equal "https://example.com/", sponsor.website
   end
+
+  test "should generate avatar URL with ui-avatars when no local image or logo" do
+    sponsor = Sponsor.create!(name: "Test Corp")
+    expected_url = "https://ui-avatars.com/api/?name=TC&size=200&background=f3f4f6&color=4b5563&font-size=0.4&length=2"
+    assert_equal expected_url, sponsor.generate_avatar_url
+  end
+
+  test "should generate avatar URL with custom size" do
+    sponsor = Sponsor.create!(name: "Test Corp")
+    expected_url = "https://ui-avatars.com/api/?name=TC&size=100&background=f3f4f6&color=4b5563&font-size=0.4&length=2"
+    assert_equal expected_url, sponsor.generate_avatar_url(size: 100)
+  end
+
+  test "should return ui-avatars URL when no local image or logo" do
+    sponsor = Sponsor.create!(name: "Test Corp")
+    expected_url = "https://ui-avatars.com/api/?name=TC&size=200&background=f3f4f6&color=4b5563&font-size=0.4&length=2"
+    assert_equal expected_url, sponsor.avatar_image_path
+  end
+
+  test "should return local avatar image when present" do
+    sponsor = Sponsor.create!(name: "Test Corp")
+
+    avatar_dir = Rails.root.join("app", "assets", "images", "sponsors", sponsor.slug)
+    avatar_dir.mkpath
+    avatar_file = avatar_dir.join("avatar.webp")
+
+    File.write(avatar_file, "fake webp content")
+
+    assert_equal "sponsors/#{sponsor.slug}/avatar.webp", sponsor.avatar_image_path
+
+    avatar_file.delete
+    avatar_dir.rmdir
+  end
 end

--- a/test/models/sponsor_test.rb
+++ b/test/models/sponsor_test.rb
@@ -65,7 +65,7 @@ class SponsorTest < ActiveSupport::TestCase
     assert_equal "https://example.com/", sponsor.website
   end
 
-  test "should generate avatar URL with ui-avatars when no local image or logo" do
+  test "should generate avatar URL with ui-avatars" do
     sponsor = Sponsor.create!(name: "Test Corp")
     expected_url = "https://ui-avatars.com/api/?name=TC&size=200&background=f3f4f6&color=4b5563&font-size=0.4&length=2"
     assert_equal expected_url, sponsor.generate_avatar_url


### PR DESCRIPTION
Overview

This PR improves the visual consistency and reliability of sponsor displays by implementing fallback systems for both avatars and logos. It addresses cases where external logo URLs become inaccessible and ensures all sponsors have proper visual representation.

## What Changed

### Enhanced Avatar System
- **UI Avatars Integration**: Added `generate_avatar_url` method that creates dynamic avatars using [ui-avatars.com](https://ui-avatars.com) API
- **Smart Avatar Fallback**: Modified `avatar_image_path` to fallback to generated avatars when local images aren't available
- **Priority System**: Local images > logo fallback > generated avatars

### Robust Logo URL Handling
- **URL Accessibility Validation**: Added `logo_url_accessible?` method that checks if external logo URLs are actually reachable
- **Network Resilience**: Implements timeout handling (5s open, 10s read) and graceful error handling
- **Logo Fallback**: When logo URLs are inaccessible, automatically falls back to avatar images instead of broken links

## Future enhancement

I was thinking that for the `logos_url` that are inaccessible, we could mark them someway (maybe with a boolean) as inaccessible in a way that the next time we the app go through the `logo_url_accessible?` can see that boolean and does not have to do a HTTP request to see if it is accessible. 

We would have to take into consideration if we implement that, that maybe the `logo_url` was momentarily inaccessible and then became accessible again, so periodically the app should try again to access the `logo_url`

Even if we do not merge this PR, I would like to set the record that we should somehow manage inaccessible logo_url in the backend, not only in the views