### PR TITLE
fit content for the navbar logo

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,5 +1,5 @@
 <div class="navbar relative z-50 bg-transparent">
-  <div class="container grid grid-cols-2 lg:grid-cols-3 justify-between items-center">
+  <div class="container grid grid-cols-2 lg:grid-cols-[1fr_auto_1fr] justify-between items-center">
     <div class="items-center gap-6 hidden lg:flex">
       <ul class="desktop-menu">
         <%= render "shared/navbar/link", link_title: "Events", path: events_path %>


### PR DESCRIPTION
with some resolution we could barely click on the CFP link the the navbar. The reason is that the logo grid cell would overlap with the links. 

This PR auto size the central cell with the logo to give as much spaces for the links