### PR TITLE
Add uniqueness constraint to EventSponsor model

### DIFF
--- a/app/models/event_sponsor.rb
+++ b/app/models/event_sponsor.rb
@@ -4,16 +4,17 @@
 #
 #  id         :integer          not null, primary key
 #  badge      :string
-#  tier       :string
+#  tier       :string           uniquely indexed => [event_id, sponsor_id]
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  event_id   :integer          not null, indexed
-#  sponsor_id :integer          not null, indexed
+#  event_id   :integer          not null, indexed, uniquely indexed => [sponsor_id, tier]
+#  sponsor_id :integer          not null, uniquely indexed => [event_id, tier], indexed
 #
 # Indexes
 #
-#  index_event_sponsors_on_event_id    (event_id)
-#  index_event_sponsors_on_sponsor_id  (sponsor_id)
+#  index_event_sponsors_on_event_id                   (event_id)
+#  index_event_sponsors_on_event_sponsor_tier_unique  (event_id,sponsor_id,tier) UNIQUE
+#  index_event_sponsors_on_sponsor_id                 (sponsor_id)
 #
 # Foreign Keys
 #

--- a/app/models/event_sponsor.rb
+++ b/app/models/event_sponsor.rb
@@ -25,7 +25,7 @@ class EventSponsor < ApplicationRecord
   belongs_to :event
   belongs_to :sponsor
 
-  validates :sponsor_id, uniqueness: { scope: [:event_id, :tier], message: "is already associated with this event for the same tier" }
+  validates :sponsor_id, uniqueness: {scope: [:event_id, :tier], message: "is already associated with this event for the same tier"}
 
   before_validation :normalize_tier
 

--- a/app/models/event_sponsor.rb
+++ b/app/models/event_sponsor.rb
@@ -24,4 +24,14 @@
 class EventSponsor < ApplicationRecord
   belongs_to :event
   belongs_to :sponsor
+
+  validates :sponsor_id, uniqueness: { scope: [:event_id, :tier], message: "is already associated with this event for the same tier" }
+
+  before_validation :normalize_tier
+
+  private
+
+  def normalize_tier
+    self.tier = nil if tier.blank?
+  end
 end

--- a/db/migrate/20250822175423_add_unique_index_to_event_sponsors.rb
+++ b/db/migrate/20250822175423_add_unique_index_to_event_sponsors.rb
@@ -1,11 +1,11 @@
 class AddUniqueIndexToEventSponsors < ActiveRecord::Migration[8.1]
   def up
     add_index :event_sponsors, [:event_id, :sponsor_id, :tier],
-              unique: true,
-              name: 'index_event_sponsors_on_event_sponsor_tier_unique'
+      unique: true,
+      name: "index_event_sponsors_on_event_sponsor_tier_unique"
   end
 
   def down
-    remove_index :event_sponsors, name: 'index_event_sponsors_on_event_sponsor_tier_unique'
+    remove_index :event_sponsors, name: "index_event_sponsors_on_event_sponsor_tier_unique"
   end
 end

--- a/db/migrate/20250822175423_add_unique_index_to_event_sponsors.rb
+++ b/db/migrate/20250822175423_add_unique_index_to_event_sponsors.rb
@@ -1,0 +1,11 @@
+class AddUniqueIndexToEventSponsors < ActiveRecord::Migration[8.1]
+  def up
+    add_index :event_sponsors, [:event_id, :sponsor_id, :tier],
+              unique: true,
+              name: 'index_event_sponsors_on_event_sponsor_tier_unique'
+  end
+
+  def down
+    remove_index :event_sponsors, name: 'index_event_sponsors_on_event_sponsor_tier_unique'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_08_17_223427) do
+ActiveRecord::Schema[8.1].define(version: 2025_08_22_175423) do
   create_table "_litestream_lock", id: false, force: :cascade do |t|
     t.integer "id"
   end
@@ -86,6 +86,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_08_17_223427) do
     t.integer "sponsor_id", null: false
     t.string "tier"
     t.datetime "updated_at", null: false
+    t.index ["event_id", "sponsor_id", "tier"], name: "index_event_sponsors_on_event_sponsor_tier_unique", unique: true
     t.index ["event_id"], name: "index_event_sponsors_on_event_id"
     t.index ["sponsor_id"], name: "index_event_sponsors_on_sponsor_id"
   end

--- a/test/fixtures/event_sponsors.yml
+++ b/test/fixtures/event_sponsors.yml
@@ -6,16 +6,17 @@
 #
 #  id         :integer          not null, primary key
 #  badge      :string
-#  tier       :string
+#  tier       :string           uniquely indexed => [event_id, sponsor_id]
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  event_id   :integer          not null, indexed
-#  sponsor_id :integer          not null, indexed
+#  event_id   :integer          not null, indexed, uniquely indexed => [sponsor_id, tier]
+#  sponsor_id :integer          not null, uniquely indexed => [event_id, tier], indexed
 #
 # Indexes
 #
-#  index_event_sponsors_on_event_id    (event_id)
-#  index_event_sponsors_on_sponsor_id  (sponsor_id)
+#  index_event_sponsors_on_event_id                   (event_id)
+#  index_event_sponsors_on_event_sponsor_tier_unique  (event_id,sponsor_id,tier) UNIQUE
+#  index_event_sponsors_on_sponsor_id                 (sponsor_id)
 #
 # Foreign Keys
 #

--- a/test/models/event_sponsor_test.rb
+++ b/test/models/event_sponsor_test.rb
@@ -1,7 +1,54 @@
 require "test_helper"
 
 class EventSponsorTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  def setup
+    @event = events(:railsconf_2017)
+    @sponsor = sponsors(:one)
+  end
+
+  test "allows same sponsor for same event with different tiers" do
+    EventSponsor.create!(event: @event, sponsor: @sponsor, tier: "gold")
+
+    assert_nothing_raised do
+      EventSponsor.create!(event: @event, sponsor: @sponsor, tier: "silver")
+    end
+  end
+
+  test "prevents duplicate sponsor for same event and tier" do
+    EventSponsor.create!(event: @event, sponsor: @sponsor, tier: "gold")
+
+    duplicate = EventSponsor.new(event: @event, sponsor: @sponsor, tier: "gold")
+
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:sponsor_id],
+                   "is already associated with this event for the same tier"
+  end
+
+  test "allows same sponsor for different events with same tier" do
+    other_event = events(:rubyconfth_2022)
+
+    EventSponsor.create!(event: @event, sponsor: @sponsor, tier: "gold")
+
+    assert_nothing_raised do
+      EventSponsor.create!(event: other_event, sponsor: @sponsor, tier: "gold")
+    end
+  end
+
+  test "handles nil tiers correctly" do
+    EventSponsor.create!(event: @event, sponsor: @sponsor, tier: nil)
+
+    duplicate = EventSponsor.new(event: @event, sponsor: @sponsor, tier: nil)
+
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:sponsor_id],
+                   "is already associated with this event for the same tier"
+  end
+
+  test "treats empty string tier as nil" do
+    EventSponsor.create!(event: @event, sponsor: @sponsor, tier: "")
+
+    duplicate = EventSponsor.new(event: @event, sponsor: @sponsor, tier: nil)
+
+    assert_not duplicate.valid?
+  end
 end

--- a/test/models/event_sponsor_test.rb
+++ b/test/models/event_sponsor_test.rb
@@ -21,7 +21,7 @@ class EventSponsorTest < ActiveSupport::TestCase
 
     assert_not duplicate.valid?
     assert_includes duplicate.errors[:sponsor_id],
-                   "is already associated with this event for the same tier"
+      "is already associated with this event for the same tier"
   end
 
   test "allows same sponsor for different events with same tier" do
@@ -41,7 +41,7 @@ class EventSponsorTest < ActiveSupport::TestCase
 
     assert_not duplicate.valid?
     assert_includes duplicate.errors[:sponsor_id],
-                   "is already associated with this event for the same tier"
+      "is already associated with this event for the same tier"
   end
 
   test "treats empty string tier as nil" do


### PR DESCRIPTION
Implements Option 2 from [GitHub Issue #905] to prevent duplicate event-sponsor associations while maintaining flexibility for sponsors with different tiers at the same event.

## Problem
Currently, the application allows creating duplicate associations between the same `Event` and `Sponsor` in the `event_sponsors` table, which can lead to:
- Data Integrity Issues: Duplicate associations create inconsistent data representation
- UI Problems: Frontend may display the same sponsor multiple times for an event

## Solution
Added flexible uniqueness constraint that:
- Prevents true duplicates: Same event + sponsor + tier combinations
- Allows flexibility: Same sponsor can have multiple tiers at the same event
- Maintains data integrity: Both database and model-level validations