### PR TITLE
Force response type for template actions

### DIFF
--- a/app/controllers/concerns/remote_modal.rb
+++ b/app/controllers/concerns/remote_modal.rb
@@ -1,6 +1,6 @@
 module RemoteModal
   extend ActiveSupport::Concern
-  include Turbo::ForceFrameResponse
+  include Turbo::ForceResponse
 
   included do
     layout :define_layout

--- a/app/controllers/concerns/turbo/force_response.rb
+++ b/app/controllers/concerns/turbo/force_response.rb
@@ -1,17 +1,27 @@
 # frozen_string_literal: true
 
 module Turbo
-  module ForceFrameResponse
+  module ForceResponse
     extend ActiveSupport::Concern
 
     class_methods do
       def force_frame_response(options = {})
         before_action :force_frame_response, **options
       end
+
+      def force_stream_response(options = {})
+        before_action :force_stream_response, **options
+      end
     end
 
     def force_frame_response
       return if turbo_frame_request?
+
+      redirect_back(fallback_location: root_path)
+    end
+
+    def force_stream_response
+      return if request.format.turbo_stream?
 
       redirect_back(fallback_location: root_path)
     end

--- a/app/controllers/contributions_controller.rb
+++ b/app/controllers/contributions_controller.rb
@@ -1,5 +1,5 @@
 class ContributionsController < ApplicationController
-  include Turbo::ForceFrameResponse
+  include Turbo::ForceResponse
   force_frame_response only: %i[show]
   skip_before_action :authenticate_user!, only: %i[index show]
 

--- a/app/controllers/talks/slides_controller.rb
+++ b/app/controllers/talks/slides_controller.rb
@@ -1,5 +1,5 @@
 class Talks::SlidesController < ApplicationController
-  include Turbo::ForceFrameResponse
+  include Turbo::ForceResponse
   force_frame_response
 
   skip_before_action :authenticate_user!

--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -1,5 +1,9 @@
 class TemplatesController < ApplicationController
+  include Turbo::ForceResponse
+
   skip_before_action :authenticate_user!
+  force_frame_response only: [:new_child, :delete_child]
+  force_stream_response only: [:speakers_search]
 
   def new
     @talk = Template.new

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,6 +4,9 @@
 
 import { application } from "./application"
 
+import HwComboboxController from "@josefarias/hotwire_combobox"
+application.register("hw-combobox", HwComboboxController)
+
 import AutoClickController from "./auto-click_controller"
 application.register("auto-click", AutoClickController)
 


### PR DESCRIPTION
This fixes #934 by appropriating the existing `ForceFrameResponse`. 

I adapted it to also apply to the `search_speakers` action, forcing a `turbo_stream` response. 

While working on this, I found that #853 removed the HWComboboxController, which broke the Hotwire Combobox. Whoops. Happy little accident, I'm guessing :lady_beetle: 