### PR TITLE
Add talks and schedule for Tropicalrb 2015

### DIFF
--- a/data/tropicalrb/playlists.yml
+++ b/data/tropicalrb/playlists.yml
@@ -8,7 +8,7 @@
   end_date: "2015-03-08"
   metadata_parser: YouTube::VideoMetadata
   slug: tropicalrb-2015
-  website: http://tropicalrb.com/
+  website: https://web.archive.org/web/20150428132714/http://tropicalrb.com/en/
   twitter: tropicalrb
   playlist: http://tropicalrb.com/en/videos/
 

--- a/data/tropicalrb/playlists.yml
+++ b/data/tropicalrb/playlists.yml
@@ -1,11 +1,11 @@
 ---
 - id: tropicalrb-2015
   title: Tropical.rb 2015
-  description: ''
+  description: "The Beach Ruby Conference - Enjoy amazing conversations, stunning landscapes and a superb nature. Come and talk with some of the best Rubyists in this tropical paradise."
   location: Porto de Galinhas, Brazil
   kind: conference
-  start_date: '2015-03-05'
-  end_date: '2015-03-08'
+  start_date: "2015-03-05"
+  end_date: "2015-03-08"
   metadata_parser: YouTube::VideoMetadata
   slug: tropicalrb-2015
   website: http://tropicalrb.com/

--- a/data/tropicalrb/tropicalrb-2015/schedule.yml
+++ b/data/tropicalrb/tropicalrb-2015/schedule.yml
@@ -1,0 +1,144 @@
+# Schedule: https://web.archive.org/web/20150428132714/http://tropicalrb.com/en/schedule/march-5
+
+days:
+  - name: "Day 1"
+    date: "2015-03-06"
+    grid:
+      - start_time: "08:00"
+        end_time: "11:00"
+        slots: 1
+        items:
+          - Buggy Ride
+
+      - start_time: "09:00"
+        end_time: "10:00"
+        slots: 1
+        items:
+          - Raft Boat Sail
+
+      - start_time: "11:30"
+        end_time: "13:00"
+        slots: 1
+        items:
+          - Registration
+
+      - start_time: "13:00"
+        end_time: "13:40"
+        slots: 1
+
+      - start_time: "13:40"
+        end_time: "14:10"
+        slots: 1
+
+      - start_time: "14:10"
+        end_time: "14:40"
+        slots: 1
+
+      - start_time: "14:40"
+        end_time: "15:10"
+        slots: 1
+
+      - start_time: "15:10"
+        end_time: "15:40"
+        slots: 1
+        items:
+          - Coffee Break
+
+      - start_time: "15:40"
+        end_time: "16:10"
+        slots: 1
+
+      - start_time: "16:10"
+        end_time: "16:40"
+        slots: 1
+
+      - start_time: "16:40"
+        end_time: "17:10"
+        slots: 1
+
+      - start_time: "17:10"
+        end_time: "17:50"
+        slots: 1
+
+      - start_time: "17:50"
+        end_time: "18:20"
+        slots: 1
+        items:
+          - Coffee Break
+
+      - start_time: "18:20"
+        end_time: "18:50"
+        slots: 1
+
+      - start_time: "18:50"
+        end_time: "19:20"
+        slots: 1
+
+  - name: "Day 2"
+    date: "2015-03-07"
+    grid:
+      - start_time: "08:00"
+        end_time: "11:00"
+        slots: 1
+        items:
+          - Scuba Diving
+
+      - start_time: "12:00"
+        end_time: "13:00"
+        slots: 1
+        items:
+          - Registration
+
+      - start_time: "13:00"
+        end_time: "13:40"
+        slots: 1
+
+      - start_time: "13:40"
+        end_time: "14:10"
+        slots: 1
+
+      - start_time: "14:10"
+        end_time: "14:50"
+        slots: 1
+
+      - start_time: "14:50"
+        end_time: "15:20"
+        slots: 1
+
+      - start_time: "15:20"
+        end_time: "15:50"
+        slots: 1
+        items:
+          - Coffee Break
+
+      - start_time: "15:50"
+        end_time: "16:20"
+        slots: 1
+
+      - start_time: "16:20"
+        end_time: "16:50"
+        slots: 1
+
+      - start_time: "16:50"
+        end_time: "17:20"
+        slots: 1
+
+      - start_time: "17:20"
+        end_time: "17:50"
+        slots: 1
+
+      - start_time: "17:50"
+        end_time: "18:20"
+        slots: 1
+        items:
+          - Coffee Break
+
+      - start_time: "18:20"
+        end_time: "18:50"
+        slots: 1
+
+      - start_time: "18:50"
+        end_time: "19:20"
+        slots: 1
+
+tracks: []

--- a/data/tropicalrb/tropicalrb-2015/videos.yml
+++ b/data/tropicalrb/tropicalrb-2015/videos.yml
@@ -1,6 +1,247 @@
-# TODO: Add talks and videos
-
 # Website: http://tropicalrb.com/
 # Videos: http://tropicalrb.com/en/videos/
 ---
-[]
+- title: "Keynote: See You On The Trail!"
+  raw_title: "Keynote: See You On The Trail!"
+  speakers:
+    - Nick Sutterer
+  event_name: "Tropical.rb 2015"
+  date: "2015-03-06"
+  video_provider:
+  video_id:
+  language: "english"
+  description: ""
+
+- title: "Maintaining a 5yo Ruby project"
+  raw_title: "Maintaining a 5yo Ruby project"
+  speakers:
+    - Simone Carletti
+  event_name: "Tropical.rb 2015"
+  date: "2015-03-06"
+  video_provider:
+  video_id:
+  language: "english"
+  slides_url: "https://speakerdeck.com/weppos/maintaining-a-5yo-ruby-project-shark-edition"
+  description: |-
+    Maintaining a young, small Ruby product is simple, but time passes and your code becomes harder to maintain day after day. This talk illustrates the development techniques, Ruby patterns and best practices we use at DNSimple to develop new features and ensure long-term maintainability of our codebase.
+
+- title: "Cryptography for Rails Developers"
+  raw_title: "Cryptography for Rails Developers"
+  speakers:
+    - Christopher Rigor
+  event_name: "Tropical.rb 2015"
+  date: "2015-03-06"
+  video_provider:
+  video_id:
+  language: "english"
+  description: |-
+    You know HTTPS keeps your website secure but do you know how? Ruby just released a new version to address a vulnerability with SSL but do you know your app might still be vulnerable? Cryptography is a hard and huge topic and this talk will give you a great introduction. You don't need a background on cryptography, just an open mind! You will learn about the public key cryptography, SSL/TLS and Ruby tips that will make your app secure.
+
+- title: "Frontend Choices"
+  raw_title: "Frontend Choices"
+  speakers:
+    - Alex Coles
+  event_name: "Tropical.rb 2015"
+  date: "2015-03-06"
+  video_provider:
+  video_id:
+  language: "english"
+  description: |-
+    Rails was born in 2004, the time of the "Ajax revolution". With the help of a little bit of prototype, Scriptaculous and RJS, Rails made its mark in part because it facilitated creating beautiful and highly interactive web user interfaces in no time at all. Fast forward to 2013. Frameworks like Meteor and Hoodie are capturing increasing mindshare. Are we now in the decade of JavaScript? Is the "Rails Way" still relevant to the frontend?
+
+- title: "Writing Your Own DSL Using Ruby"
+  raw_title: "Writing Your Own DSL Using Ruby"
+  speakers:
+    - Ricardo Nacif
+  event_name: "Tropical.rb 2015"
+  date: "2015-03-06"
+  video_provider:
+  video_id:
+  language: "portuguese"
+  description: |-
+    In this talk we'll go through some concepts on the Ruby language that will help us creating our own custom Domain Specific Language. It's a very hands-on talk. We'll play with dynamic classes, dynamic methods, blocks, procs and method chaining, but our main goal is to write (and learn how) our own Pizza Menu DSL.
+
+- title: "POROs to the Rescue"
+  raw_title: "POROs to the Rescue"
+  speakers:
+    - Marcelo De Polli
+  event_name: "Tropical.rb 2015"
+  date: "2015-03-06"
+  video_provider:
+  video_id:
+  language: "portuguese"
+  description: |-
+    Being tasked with rescuing an ancient codebase and turning it into something workable and manageable is a predicament most of us have already found ourselves in. In the 10 years since we began using Ruby to write Web applications, a lot has changed concerning architectures and design patterns. How do you take your code in a time travel from the olden days to more current practices such as POROs, lean models, presenters and decorators? This talk will walk you through some easy practices that can make that trip less bumpy and allow you to survive to tell the story.
+
+- title: "Concurrent-Ruby: Ruby in the Concurrent World"
+  raw_title: "Concurrent-Ruby: Ruby in the Concurrent World"
+  speakers:
+    - Lucas Allan
+  event_name: "Tropical.rb 2015"
+  date: "2015-03-06"
+  video_provider:
+  video_id:
+  language: "portuguese"
+  description: |-
+    Rumor has it that you can't write concurrent programs in Ruby. People once believed that the world was flat and we all know how that turned out. Between the native threads introduced in MRI 1.9 and the JVM threading available to JRuby, Ruby is now a valid platform for concurrent applications. What we've been missing — until now — are the advanced concurrency tools available to other languages like Clojure, Scala, Erlang, and Go.
+
+- title: "Object Oriented Design, Rails and Why You Should Think Twice Before Leaving the Rails Way"
+  raw_title: "Object Oriented Design, Rails and Why You Should Think Twice Before Leaving the Rails Way"
+  speakers:
+    - Rafael França
+  event_name: "Tropical.rb 2015"
+  date: "2015-03-06"
+  video_provider:
+  video_id:
+  language: "portuguese"
+  description: |-
+    The Ruby community has been bombarded by a plethora of discussions about software design best practices. Acronyms such as SOLID, DCI and SOA are up in the community and all them promise to materialize the ghost of maintainability. What few of these discussions present is that applying these principles and techniques fervently also impacts the software maintenance.
+
+    In this talk I will present some of these concepts and show the symptoms that they can cause in yours projects if applied incorrectly.
+
+- title: "25 Minutes of Semantic Web"
+  raw_title: "25 Minutes of Semantic Web"
+  speakers:
+    - Yasodara Córdova
+  event_name: "Tropical.rb 2015"
+  date: "2015-03-06"
+  video_provider:
+  video_id:
+  language: "portuguese"
+  description: |-
+    The promise is: you'll understand in 10 minutes why use Semantic Web. The following 15 minutes of the talk will be used to show 15 applications using the concepts of Semantic Web, one per minute :-)
+
+- title: "Panel: The Rails Way vs. Trailblazer"
+  raw_title: "Panel: The Rails Way vs. Trailblazer"
+  speakers:
+    - Rafael França
+    - Carlos Antonio
+    - Celso Fernandes
+    - Nick Sutterer
+  event_name: "Tropical.rb 2015"
+  date: "2015-03-06"
+  video_provider:
+  video_id:
+  language: "english"
+  description: |-
+    Organizing and structuring Rails applications has been an ongoing discussion for years in the community. While some find in necessary to introduce new abstraction layers, indirection and encapsulation for a sustainable architecture, others defend we shouldn't abandon the Rails Way for the sake of conventions and compatibility.
+
+    In this panel both members from Rails core as well as the creator of Trailblazer are gonna discuss both approaches, their point of views, why they choose their way, and why they still can be friends.
+
+- title: "Keynote: Better Programmers"
+  raw_title: "Keynote: Better Programmers"
+  speakers:
+    - Rodrigo Franco
+  event_name: "Tropical.rb 2015"
+  date: "2015-03-07"
+  video_provider:
+  video_id:
+  language: "portuguese"
+  description: ""
+
+- title: "On Memory"
+  raw_title: "On Memory"
+  speakers:
+    - John Crepezzi
+  event_name: "Tropical.rb 2015"
+  date: "2015-03-07"
+  video_provider:
+  video_id:
+  language: "english"
+  description: |-
+    The fact that Ruby doesn't require developers to manage memory provides us a much less frustrating day-to-day. Still, there are scenarios where losing sight of the memory implications of our patterns and logic, will get us into trouble! In this talk, I'll go over common (and less common) memory pitfalls, how they work, and how to fix them.
+
+- title: "Building a Single Page App. One Page at a Time."
+  raw_title: "Building a Single Page App. One Page at a Time."
+  speakers:
+    - Netto Farah
+  event_name: "Tropical.rb 2015"
+  date: "2015-03-07"
+  video_provider:
+  video_id:
+  language: "portuguese"
+  description: |-
+    It may sound simple to build a single page app these days with so many tools such as AngularJs, Knockout, Backbone, etc. But very little is said about transforming an existing app into to a single page one.
+
+- title: "Clean Architecture"
+  raw_title: "Clean Architecture"
+  speakers:
+    - Fabiano Beselga
+  event_name: "Tropical.rb 2015"
+  date: "2015-03-07"
+  video_provider:
+  video_id:
+  language: "portuguese"
+  description: |-
+    Rails is an awesome framework to build something fast from scratch, but when the app starts to grow it becomes harder to maintain if you keep following only the folders that Rails's initial configuration provides. There are a lot of approaches to get around it, Uncle Bob's Clean Architecture that separates the logic of the app from the delivery mechanism and from the database.
+
+- title: "Contributing to Open Source: From the Beginning to Lessons Learned"
+  raw_title: "Contributing to Open Source: From the Beginning to Lessons Learned"
+  speakers:
+    - Carlos Antonio
+  event_name: "Tropical.rb 2015"
+  date: "2015-03-07"
+  video_provider:
+  video_id:
+  language: "portuguese"
+  description: |-
+    Many people have difficulties to do a first contribution to open source, while others try to keep actively contributing. They do not feel confident enough, wondering if are doing it right, if they are following "patterns", if they will make mistakes in public, and this list of questions just keeps growing. This talk will attend the problems I've faced in the last years contributing and maintaining open source projects. It will give tips on how to start and remain active in today's open source world, and preserve your sanity to avoid the burnout.
+
+- title: "Property Testing on Rails"
+  raw_title: "Property Testing on Rails"
+  speakers:
+    - Andrew Rosa
+  event_name: "Tropical.rb 2015"
+  date: "2015-03-07"
+  video_provider:
+  video_id:
+  language: "portuguese"
+  description: |-
+    The Ruby community is known by its strong culture of testing, but this is not an excuse to refuse alternative approaches. One of these are Property Testing. In those tools we do not express examples, but the possible input formats; instead of specific outputs, characteristics that must remain true. In this way our tools are capable of exhaustively generate test cases and look for failures. In this talk we'll see how to create lean suites with wide coverage using Clojure's power to test a Rails application.
+
+- title: "MRuby: Change the Embedded Development Way"
+  raw_title: "MRuby: Change the Embedded Development Way"
+  speakers:
+    - Thiago Scalone
+  event_name: "Tropical.rb 2015"
+  date: "2015-03-07"
+  video_provider:
+  video_id:
+  language: "portuguese"
+  description: |-
+    MRuby (Minimalistc Ruby) is a new Ruby implementation made with resources saving in mind. MRuby is a perfect fit for embedded systems world and for limited responsibility applications. Let's understand the state of embedded system development today from the payment devices perspective. In the talk we'll learn how beautiful and useful MRuby is on a device-browser integration or in command line tool.
+
+- title: "Micro Problems!"
+  raw_title: "Micro Problems!"
+  speakers:
+    - Marcos Matos
+  event_name: "Tropical.rb 2015"
+  date: "2015-03-07"
+  video_provider:
+  video_id:
+  language: "portuguese"
+  description: |-
+    Micro services are trend. It's a magic cure for complex projects. The problem is in the details! Like every trend topic, the problems and complications around this style are not discussed, topics like performance, scalability, integration tests and infrastructure. At this anti-talk we are going to show the traps lurking around micro services' architecture and how to avoid them.
+
+- title: "Urban Legends: What You Code Makes You Who You Are"
+  raw_title: "Urban Legends: What You Code Makes You Who You Are"
+  speakers:
+    - PJ Hagerty
+  event_name: "Tropical.rb 2015"
+  date: "2015-03-07"
+  video_provider:
+  video_id:
+  language: "english"
+  description: |-
+    If you were a carpenter, would your skills at building be more important than the tools you use to build? Skills, right? Tools are just a means to an end. So why do developers think the language they use defines the problems they solve?
+
+- title: "Keynote: The Soul of Software"
+  raw_title: "Keynote: The Soul of Software"
+  speakers:
+    - Avdi Grimm
+  event_name: "Tropical.rb 2015"
+  date: "2015-03-07"
+  video_provider:
+  video_id:
+  language: "english"
+  description: ""

--- a/data/tropicalrb/tropicalrb-2015/videos.yml
+++ b/data/tropicalrb/tropicalrb-2015/videos.yml
@@ -7,8 +7,8 @@
     - Nick Sutterer
   event_name: "Tropical.rb 2015"
   date: "2015-03-06"
-  video_provider:
-  video_id:
+  video_provider: "not_recorded"
+  video_id: "nick-sutterer-tropical-rb-2015"
   language: "english"
   description: ""
 
@@ -18,8 +18,8 @@
     - Simone Carletti
   event_name: "Tropical.rb 2015"
   date: "2015-03-06"
-  video_provider:
-  video_id:
+  video_provider: "not_recorded"
+  video_id: "simone-carletti-tropical-rb-2015"
   language: "english"
   slides_url: "https://speakerdeck.com/weppos/maintaining-a-5yo-ruby-project-shark-edition"
   description: |-
@@ -31,8 +31,8 @@
     - Christopher Rigor
   event_name: "Tropical.rb 2015"
   date: "2015-03-06"
-  video_provider:
-  video_id:
+  video_provider: "not_recorded"
+  video_id: "christopher-rigor-tropical-rb-2015"
   language: "english"
   description: |-
     You know HTTPS keeps your website secure but do you know how? Ruby just released a new version to address a vulnerability with SSL but do you know your app might still be vulnerable? Cryptography is a hard and huge topic and this talk will give you a great introduction. You don't need a background on cryptography, just an open mind! You will learn about the public key cryptography, SSL/TLS and Ruby tips that will make your app secure.
@@ -43,8 +43,8 @@
     - Alex Coles
   event_name: "Tropical.rb 2015"
   date: "2015-03-06"
-  video_provider:
-  video_id:
+  video_provider: "not_recorded"
+  video_id: "alex-coles-tropical-rb-2015"
   language: "english"
   description: |-
     Rails was born in 2004, the time of the "Ajax revolution". With the help of a little bit of prototype, Scriptaculous and RJS, Rails made its mark in part because it facilitated creating beautiful and highly interactive web user interfaces in no time at all. Fast forward to 2013. Frameworks like Meteor and Hoodie are capturing increasing mindshare. Are we now in the decade of JavaScript? Is the "Rails Way" still relevant to the frontend?
@@ -55,8 +55,8 @@
     - Ricardo Nacif
   event_name: "Tropical.rb 2015"
   date: "2015-03-06"
-  video_provider:
-  video_id:
+  video_provider: "not_recorded"
+  video_id: "ricardo-nacif-tropical-rb-2015"
   language: "portuguese"
   description: |-
     In this talk we'll go through some concepts on the Ruby language that will help us creating our own custom Domain Specific Language. It's a very hands-on talk. We'll play with dynamic classes, dynamic methods, blocks, procs and method chaining, but our main goal is to write (and learn how) our own Pizza Menu DSL.
@@ -67,8 +67,8 @@
     - Marcelo De Polli
   event_name: "Tropical.rb 2015"
   date: "2015-03-06"
-  video_provider:
-  video_id:
+  video_provider: "not_recorded"
+  video_id: "marcelo-de-polli-tropical-rb-2015"
   language: "portuguese"
   description: |-
     Being tasked with rescuing an ancient codebase and turning it into something workable and manageable is a predicament most of us have already found ourselves in. In the 10 years since we began using Ruby to write Web applications, a lot has changed concerning architectures and design patterns. How do you take your code in a time travel from the olden days to more current practices such as POROs, lean models, presenters and decorators? This talk will walk you through some easy practices that can make that trip less bumpy and allow you to survive to tell the story.
@@ -79,8 +79,8 @@
     - Lucas Allan
   event_name: "Tropical.rb 2015"
   date: "2015-03-06"
-  video_provider:
-  video_id:
+  video_provider: "not_recorded"
+  video_id: "lucas-allan-tropical-rb-2015"
   language: "portuguese"
   description: |-
     Rumor has it that you can't write concurrent programs in Ruby. People once believed that the world was flat and we all know how that turned out. Between the native threads introduced in MRI 1.9 and the JVM threading available to JRuby, Ruby is now a valid platform for concurrent applications. What we've been missing — until now — are the advanced concurrency tools available to other languages like Clojure, Scala, Erlang, and Go.
@@ -91,8 +91,8 @@
     - Rafael França
   event_name: "Tropical.rb 2015"
   date: "2015-03-06"
-  video_provider:
-  video_id:
+  video_provider: "not_recorded"
+  video_id: "rafael-franca-tropical-rb-2015"
   language: "portuguese"
   description: |-
     The Ruby community has been bombarded by a plethora of discussions about software design best practices. Acronyms such as SOLID, DCI and SOA are up in the community and all them promise to materialize the ghost of maintainability. What few of these discussions present is that applying these principles and techniques fervently also impacts the software maintenance.
@@ -105,8 +105,8 @@
     - Yasodara Córdova
   event_name: "Tropical.rb 2015"
   date: "2015-03-06"
-  video_provider:
-  video_id:
+  video_provider: "not_recorded"
+  video_id: "yasodara-cordova-tropical-rb-2015"
   language: "portuguese"
   description: |-
     The promise is: you'll understand in 10 minutes why use Semantic Web. The following 15 minutes of the talk will be used to show 15 applications using the concepts of Semantic Web, one per minute :-)
@@ -120,8 +120,8 @@
     - Nick Sutterer
   event_name: "Tropical.rb 2015"
   date: "2015-03-06"
-  video_provider:
-  video_id:
+  video_provider: "not_recorded"
+  video_id: "rafael-franca-carlos-antonio-celso-nanderson-nick-sutterer-tropical-rb-2015"
   language: "english"
   description: |-
     Organizing and structuring Rails applications has been an ongoing discussion for years in the community. While some find in necessary to introduce new abstraction layers, indirection and encapsulation for a sustainable architecture, others defend we shouldn't abandon the Rails Way for the sake of conventions and compatibility.
@@ -134,8 +134,8 @@
     - Rodrigo Franco
   event_name: "Tropical.rb 2015"
   date: "2015-03-07"
-  video_provider:
-  video_id:
+  video_provider: "not_recorded"
+  video_id: "rodrigo-franco-tropical-rb-2015"
   language: "portuguese"
   description: ""
 
@@ -145,8 +145,8 @@
     - John Crepezzi
   event_name: "Tropical.rb 2015"
   date: "2015-03-07"
-  video_provider:
-  video_id:
+  video_provider: "not_recorded"
+  video_id: "john-crepezzi-tropical-rb-2015"
   language: "english"
   description: |-
     The fact that Ruby doesn't require developers to manage memory provides us a much less frustrating day-to-day. Still, there are scenarios where losing sight of the memory implications of our patterns and logic, will get us into trouble! In this talk, I'll go over common (and less common) memory pitfalls, how they work, and how to fix them.
@@ -157,8 +157,8 @@
     - Netto Farah
   event_name: "Tropical.rb 2015"
   date: "2015-03-07"
-  video_provider:
-  video_id:
+  video_provider: "not_recorded"
+  video_id: "netto-farah-tropical-rb-2015"
   language: "portuguese"
   description: |-
     It may sound simple to build a single page app these days with so many tools such as AngularJs, Knockout, Backbone, etc. But very little is said about transforming an existing app into to a single page one.
@@ -169,8 +169,8 @@
     - Fabiano Beselga
   event_name: "Tropical.rb 2015"
   date: "2015-03-07"
-  video_provider:
-  video_id:
+  video_provider: "not_recorded"
+  video_id: "fabiano-beselga-tropical-rb-2015"
   language: "portuguese"
   description: |-
     Rails is an awesome framework to build something fast from scratch, but when the app starts to grow it becomes harder to maintain if you keep following only the folders that Rails's initial configuration provides. There are a lot of approaches to get around it, Uncle Bob's Clean Architecture that separates the logic of the app from the delivery mechanism and from the database.
@@ -181,8 +181,8 @@
     - Carlos Antonio
   event_name: "Tropical.rb 2015"
   date: "2015-03-07"
-  video_provider:
-  video_id:
+  video_provider: "not_recorded"
+  video_id: "carlos-antonio-tropical-rb-2015"
   language: "portuguese"
   description: |-
     Many people have difficulties to do a first contribution to open source, while others try to keep actively contributing. They do not feel confident enough, wondering if are doing it right, if they are following "patterns", if they will make mistakes in public, and this list of questions just keeps growing. This talk will attend the problems I've faced in the last years contributing and maintaining open source projects. It will give tips on how to start and remain active in today's open source world, and preserve your sanity to avoid the burnout.
@@ -193,8 +193,8 @@
     - Andrew Rosa
   event_name: "Tropical.rb 2015"
   date: "2015-03-07"
-  video_provider:
-  video_id:
+  video_provider: "not_recorded"
+  video_id: "andrew-rosa-tropical-rb-2015"
   language: "portuguese"
   description: |-
     The Ruby community is known by its strong culture of testing, but this is not an excuse to refuse alternative approaches. One of these are Property Testing. In those tools we do not express examples, but the possible input formats; instead of specific outputs, characteristics that must remain true. In this way our tools are capable of exhaustively generate test cases and look for failures. In this talk we'll see how to create lean suites with wide coverage using Clojure's power to test a Rails application.
@@ -205,8 +205,8 @@
     - Thiago Scalone
   event_name: "Tropical.rb 2015"
   date: "2015-03-07"
-  video_provider:
-  video_id:
+  video_provider: "not_recorded"
+  video_id: "thiago-scalone-tropical-rb-2015"
   language: "portuguese"
   description: |-
     MRuby (Minimalistc Ruby) is a new Ruby implementation made with resources saving in mind. MRuby is a perfect fit for embedded systems world and for limited responsibility applications. Let's understand the state of embedded system development today from the payment devices perspective. In the talk we'll learn how beautiful and useful MRuby is on a device-browser integration or in command line tool.
@@ -217,8 +217,8 @@
     - Marcos Matos
   event_name: "Tropical.rb 2015"
   date: "2015-03-07"
-  video_provider:
-  video_id:
+  video_provider: "not_recorded"
+  video_id: "marcos-matos-tropical-rb-2015"
   language: "portuguese"
   description: |-
     Micro services are trend. It's a magic cure for complex projects. The problem is in the details! Like every trend topic, the problems and complications around this style are not discussed, topics like performance, scalability, integration tests and infrastructure. At this anti-talk we are going to show the traps lurking around micro services' architecture and how to avoid them.
@@ -229,8 +229,8 @@
     - PJ Hagerty
   event_name: "Tropical.rb 2015"
   date: "2015-03-07"
-  video_provider:
-  video_id:
+  video_provider: "not_recorded"
+  video_id: "pj-hagerty-tropical-rb-2015"
   language: "english"
   description: |-
     If you were a carpenter, would your skills at building be more important than the tools you use to build? Skills, right? Tools are just a means to an end. So why do developers think the language they use defines the problems they solve?
@@ -241,7 +241,7 @@
     - Avdi Grimm
   event_name: "Tropical.rb 2015"
   date: "2015-03-07"
-  video_provider:
-  video_id:
+  video_provider: "not_recorded"
+  video_id: "avdi-grimm-tropical-rb-2015"
   language: "english"
   description: ""


### PR DESCRIPTION
This PR adds all the talks and schedule for the event at https://www.rubyevents.org/events/tropicalrb-2015

The site is no longer available. However, since I was a speaker, I took some screenshots that I am adding below. Furthermore, the site is still available at https://web.archive.org/web/20150428132714/http://tropicalrb.com/en/schedule/march-5

Sadly, videos were removed from YouTube a couple of years ago.

<img width="1308" height="4286" alt="TropicalRuby 2015 — Schedule March 6" src="https://github.com/user-attachments/assets/af044dfd-dcd9-4edc-bef6-11e2ec766f90" />

<img width="1308" height="4012" alt="TropicalRuby 2015 — Schedule March 7" src="https://github.com/user-attachments/assets/c7d8cd4c-dfad-4eac-984a-b64aed225542" />
