### PR TITLE
improve youtube api client to fetch video duration

### DIFF
--- a/app/clients/youtube/video.rb
+++ b/app/clients/youtube/video.rb
@@ -28,7 +28,12 @@ module YouTube
 
       response = all_items(path, query: query)
 
-      response&.first&.dig("contentDetails", "duration")
+      duration_str = response&.first&.dig("contentDetails", "duration")
+
+      return nil unless duration_str
+
+      # Convert ISO 8601 duration (PT1H1M17S) to seconds
+      ActiveSupport::Duration.parse(duration_str).to_i
     end
   end
 end

--- a/test/clients/youtube/video_test.rb
+++ b/test/clients/youtube/video_test.rb
@@ -25,5 +25,16 @@ module YouTube
         assert_nil stats
       end
     end
+
+    test "should return duration for a valid video" do
+      video_id = "9LfmrkyP81M"
+
+      VCR.use_cassette("youtube_duration", match_requests_on: [:method]) do
+        stats = @client.duration(video_id)
+        assert_not_nil stats
+        assert stats.is_a?(Integer)
+        assert stats > 0
+      end
+    end
   end
 end

--- a/test/vcr_cassettes/youtube_duration.yml
+++ b/test/vcr_cassettes/youtube_duration.yml
@@ -1,0 +1,69 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://youtube.googleapis.com/youtube/v3/videos?id=9LfmrkyP81M&key=AIzaSyCe3yTMydyYrEKSS0N0oh9w5y9Rct3g3QU&maxResults=50&part=contentDetails
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Origin
+      - Referer
+      - X-Origin
+      Date:
+      - Thu, 28 Aug 2025 21:03:02 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Content-Type-Options:
+      - nosniff
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "kind": "youtube#videoListResponse",
+          "etag": "k4Tckuzp6iqi-TbYt9gLMfjwars",
+          "items": [
+            {
+              "kind": "youtube#video",
+              "etag": "sb9PwS-6NnHvqRCQzbV2Yy8NjAA",
+              "id": "9LfmrkyP81M",
+              "contentDetails": {
+                "duration": "PT1H1M17S",
+                "dimension": "2d",
+                "definition": "hd",
+                "caption": "true",
+                "licensedContent": true,
+                "contentRating": {},
+                "projection": "rectangular"
+              }
+            }
+          ],
+          "pageInfo": {
+            "totalResults": 1,
+            "resultsPerPage": 1
+          }
+        }
+  recorded_at: Thu, 28 Aug 2025 21:03:02 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
while testing #923 I thought it would be nice to be able to display the progress. We had a basic API endpoint to retrieve the video duration for Youtube this PR improves that endpoint. 

This is just a building block for future use. I think it would be nice to add a new duration_seconds attribute to the Talk model and fill this value with this API endpoint

This way it would become easy to show the progress 