### PR TITLE
Add location for LoneStarRuby

### DIFF
--- a/data/lone-star-ruby-conf/playlists.yml
+++ b/data/lone-star-ruby-conf/playlists.yml
@@ -1,8 +1,11 @@
 ---
 - id: PLE7tQUdRKcybMA_ncEV_0UYwollGNzopO
   title: LoneStarRuby Conf 2008
+  location: Austin, TX
   description: "September 4-6, 2008 - Austin, Texas"
   published_at: "2008-09-04"
+  start_date: "2008-09-04"
+  end_date: "2008-09-06"
   channel_id: UCWnPjmqvljcafA0z2U1fwKQ
   year: "2008"
   videos_count: 26
@@ -11,8 +14,11 @@
 
 - id: PLE7tQUdRKcyaLkdalB5pBAaDEFTFKQfXk
   title: LoneStarRuby Conf 2009
+  location: Austin, TX
   description: "August 27-29, 2009 - Norris Conference Center Austin, TX"
   published_at: "2009-08-27"
+  start_date: "2009-08-27"
+  end_date: "2009-08-29"
   channel_id: UCWnPjmqvljcafA0z2U1fwKQ
   year: "2009"
   videos_count: 18
@@ -21,8 +27,11 @@
 
 - id: PL1BC12596233ACAFB
   title: LoneStarRuby Conf 2010
+  location: Austin, TX
   description: "August 26-28, 2010 - Norris Conference Center, Austin, TX"
   published_at: "2010-08-26"
+  start_date: "2010-08-26"
+  end_date: "2010-08-28"
   channel_id: UCWnPjmqvljcafA0z2U1fwKQ
   year: "2010"
   videos_count: 29
@@ -31,8 +40,11 @@
 
 - id: PLE7tQUdRKcyaUov1d_26VGMXVkjT2Fz00
   title: LoneStarRuby Conf 2011
+  location: Austin, TX
   description: "August 11-13, 2011 - Norris Conference Center, Austin, TX"
   published_at: "2011-08-11"
+  start_date: "2011-08-11"
+  end_date: "2011-08-13"
   channel_id: UCWnPjmqvljcafA0z2U1fwKQ
   year: "2011"
   videos_count: 28
@@ -41,8 +53,11 @@
 
 - id: ""
   title: LoneStarRuby Conf 2012
+  location: Austin, TX
   description: "August 9-11, 2012 - Norris Conference Center, Austin, TX"
   published_at: "2012-08-09"
+  start_date: "2012-08-09"
+  end_date: "2012-08-11"
   channel_id: UCWnPjmqvljcafA0z2U1fwKQ
   year: "2012"
   videos_count: 0
@@ -51,8 +66,11 @@
 
 - id: PLE7tQUdRKcybnOxObNbTbx6PyyWrTGJP9
   title: LoneStarRuby Conf 2013
-  description: "Aug 11-13 in Austin, TX"
+  location: Austin, TX
+  description: "August 11-13, 2013 - Austin, TX"
   published_at: "2013-08-11"
+  start_date: "2013-08-11"
+  end_date: "2013-08-13"
   channel_id: UCWnPjmqvljcafA0z2U1fwKQ
   year: "2013"
   videos_count: 27


### PR DESCRIPTION
As per https://www.rubyevents.org/contributions, this commit adds the location and dates to all LoneStarRuby Conf events.
