### PR TITLE
Add MountainWest RubyConf dates and location

### DIFF
--- a/data/mountainwest-rubyconf/playlists.yml
+++ b/data/mountainwest-rubyconf/playlists.yml
@@ -1,100 +1,140 @@
 ---
 - id: PLE7tQUdRKcyadeTFH6784Vclvaco-HCIB
   title: MountainWest RubyConf 2007
+  location: "Salt Lake City, UT"
   description: ""
   published_at: "2007-xx-xx"
+  start_date: "2007-03-16"
+  end_date: "2007-03-17"
   channel_id: UCWnPjmqvljcafA0z2U1fwKQ
   year: "2007"
   videos_count: 12
   metadata_parser: YouTube::VideoMetadata
   slug: mountainwest-rubyconf-2007
+  website: https://web.archive.org/web/20160331211609/http://mtnwestrubyconf.org/2007/
 
 - id: PLE7tQUdRKcyY6qiiM02iD1Rl5xm8Yfa3A
   title: MountainWest RubyConf 2008
+  location: "Salt Lake City, UT"
   description: ""
   published_at: "2008-xx-xx"
+  start_date: "2008-03-28"
+  end_date: "2008-03-29"
   channel_id: UCWnPjmqvljcafA0z2U1fwKQ
   year: "2008"
   videos_count: 12
   metadata_parser: YouTube::VideoMetadata
   slug: mountainwest-rubyconf-2008
+  website: https://web.archive.org/web/20160331211609/http://mtnwestrubyconf.org/2008/
 
 - id: PLB3ABD9A8B27F76D8
   title: MountainWest RubyConf 2009
+  location: "Salt Lake City, UT"
   description: ""
   published_at: "2009-xx-xx"
+  start_date: "2009-03-13"
+  end_date: "2009-03-14"
   channel_id: UCWnPjmqvljcafA0z2U1fwKQ
   year: "2009"
   videos_count: 7
   metadata_parser: YouTube::VideoMetadata
   slug: mountainwest-rubyconf-2009
+  website: https://web.archive.org/web/20160331205937/http://mtnwestrubyconf.org/2009/
 
 - id: PLE7tQUdRKcyYk99N95TtGtLoeZJQwbWEc
   title: MountainWest RubyConf 2010
+  location: "Salt Lake City, UT"
   description: ""
   published_at: "2010-xx-xx"
+  start_date: "2010-03-11"
+  end_date: "2010-03-12"
   channel_id: UCWnPjmqvljcafA0z2U1fwKQ
   year: "2010"
   videos_count: 20
   metadata_parser: YouTube::VideoMetadata
   slug: mountainwest-rubyconf-2010
+  website: https://web.archive.org/web/20160331205937/http://mtnwestrubyconf.org/2010/
 
 - id: PLE7tQUdRKcya5OgHPof3Jrq0VNmvxMEWX
   title: MountainWest RubyConf 2011
+  location: "Salt Lake City, UT"
   description: ""
   published_at: "2011-xx-xx"
+  start_date: "2011-03-17"
+  end_date: "2011-03-18"
   channel_id: UCWnPjmqvljcafA0z2U1fwKQ
   year: "2011"
   videos_count: 20
   metadata_parser: YouTube::VideoMetadata
   slug: mountainwest-rubyconf-2011
+  website: https://web.archive.org/web/20171022163315/http://mtnwestrubyconf.org/2011/
 
 - id: PLE7tQUdRKcyZ0cXIcLlmsFfhjAzg5uP0b
   title: MountainWest RubyConf 2012
+  location: "Salt Lake City, UT"
   description: ""
   published_at: "2012-08-16"
+  start_date: "2012-03-15"
+  end_date: "2012-03-17"
   channel_id: UCWnPjmqvljcafA0z2U1fwKQ
   year: "2012"
   videos_count: 13
   metadata_parser: YouTube::VideoMetadata
   slug: mountainwest-rubyconf-2012
+  website: https://web.archive.org/web/20140117085320/http://mtnwestrubyconf.org/2012/
 
 - id: PLE7tQUdRKcyazvc4Ib-TRyGirwi1z1ywc
   title: MountainWest RubyConf 2013
+  location: "Salt Lake City, UT"
   description: ""
   published_at: "2013-xx-xx"
+  start_date: "2013-04-03"
+  end_date: "2013-04-05"
   channel_id: UCWnPjmqvljcafA0z2U1fwKQ
   year: "2013"
   videos_count: 30
   metadata_parser: YouTube::VideoMetadata
   slug: mountainwest-rubyconf-2013
+  website: https://web.archive.org/web/20171022010216/http://mtnwestrubyconf.org/2013/
 
 - id: PLE7tQUdRKcybwu-NByNoeOrDuBBxHDZ-q
   title: MountainWest RubyConf 2014
+  location: "Salt Lake City, UT"
   description: ""
   published_at: "2014-xx-xx"
+  start_date: "2014-03-20"
+  end_date: "2014-03-21"
   channel_id: UCWnPjmqvljcafA0z2U1fwKQ
   year: "2014"
   videos_count: 20
   metadata_parser: YouTube::VideoMetadata
   slug: mountainwest-rubyconf-2014
+  website: https://web.archive.org/web/20171022010216/http://mtnwestrubyconf.org/2014/
 
 - id: PLE7tQUdRKcybKenrGRnvqtCIsniljlpIp
   title: MountainWest RubyConf 2015
+  location: "Salt Lake City, UT"
   description: ""
   published_at: "2015-03-29"
+  start_date: "2015-03-09"
+  end_date: "2015-03-10"
   channel_id: UCWnPjmqvljcafA0z2U1fwKQ
   year: "2015"
   videos_count: 20
   metadata_parser: YouTube::VideoMetadata
   slug: mountainwest-rubyconf-2015
+  website: https://web.archive.org/web/20170804074306/http://mtnwestrubyconf.org/2015/
 
 - id: PLE7tQUdRKcybjaXiRW_mjOuw1JGrWsCdt
   title: MountainWest RubyConf 2016
+  location: "Salt Lake City, UT"
   description: ""
   published_at: "2016-xx-xx"
+  start_date: "2016-03-21"
+  end_date: "2016-03-22"
   channel_id: UCWnPjmqvljcafA0z2U1fwKQ
   year: "2016"
   videos_count: 12
   metadata_parser: YouTube::VideoMetadata
   slug: mountainwest-rubyconf-2016
+  website: https://web.archive.org/web/20170804074306/http://mtnwestrubyconf.org/2016/

--- a/data/organisations.yml
+++ b/data/organisations.yml
@@ -400,7 +400,7 @@
   youtube_channel_id: UCWnPjmqvljcafA0z2U1fwKQ
 
 - name: MountainWest RubyConf
-  website: http://mtnwestrubyconf.org
+  website: https://web.archive.org/web/20160331205937/http://mtnwestrubyconf.org/
   twitter: mwrc
   kind: conference
   frequency: yearly


### PR DESCRIPTION
As per https://www.rubyevents.org/contributions, this commit adds the location and dates to all MountainWest RubyConf events.
