### PR TITLE
Add Ruby on Ales dates and location

### DIFF
--- a/data/ruby-on-ales/playlists.yml
+++ b/data/ruby-on-ales/playlists.yml
@@ -54,7 +54,7 @@
 - id: PLE7tQUdRKcyaUIjpEKMLTKc32kr4vseg9
   title: Ruby on Ales 2015
   location: "Bend, OR"
-  description: ""
+  description: "At the Tower Theatre in Bend, Oregon"
   published_at: "2015-03-05"
   start_date: "2015-03-05"
   end_date: "2015-03-06"


### PR DESCRIPTION
As per https://www.rubyevents.org/contributions, this commit adds the location and dates to all Ruby on Ales events.
