### PR TITLE
Change Rubycon website URL

### DIFF
--- a/data/organisations.yml
+++ b/data/organisations.yml
@@ -1984,7 +1984,7 @@
   youtube_channel_id: UCPkGcnK-vKiYVmefSp22enA
 
 - name: Rubycon
-  website: https://rubycon.netlify.app/
+  website: https://www.rubycon.it/
   twitter: "https://x.com/rubycon2026"
   bsky: "https://bsky.app/profile/rubyconitaly.bsky.social"
   mastodon: "https://mastodon.social/@rubycon"


### PR DESCRIPTION
Just a simple change to the Rubycon conference website