### PR TITLE
Fix XSS vulnerabilities

### DIFF
--- a/app/views/talks/show.html.erb
+++ b/app/views/talks/show.html.erb
@@ -7,7 +7,7 @@
   <div class="w-full flex">
     <div class="flex-grow">
       <div class="flex items-center justify-between w-full hotwire-native:hidden">
-        <%= link_to back_path do %>
+        <%= link_to sanitize(back_path) do %>
           <div class="flex items-center gap-2 title text-base text-primary mb-4">
             <%= fa("arrow-left-long", class: "transition-arrow fill-primary", size: :xs) %>
             <div style="view-transition-name: title"><%= back_to_title %></div>

--- a/app/views/talks/slides/show.html.erb
+++ b/app/views/talks/slides/show.html.erb
@@ -16,6 +16,6 @@
       <% end %>
     <% end %>
 
-    <a class="btn btn-primary mt-6" href="<%= @talk.slides_url %>" target="_blank">See Slides on <%= uri.host %></a>
+    <a class="btn btn-primary mt-6" href="<%= sanitize(@talk.slides_url) %>" target="_blank">See Slides on <%= uri.host %></a>
   <% end %>
 <% end %>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -1,7 +1,7 @@
 <div class="container flex flex-col w-full gap-4 my-8">
   <% back_path = params[:back_to].presence || topics_path %>
   <% back_to_title = params[:back_to_title].presence || "Topics" %>
-  <%= link_to back_path, class: "hotwire-native:hidden" do %>
+  <%= link_to sanitize(back_path), class: "hotwire-native:hidden" do %>
     <div class="flex items-center gap-2 title text-primary">
       <%= fa("arrow-left-long", class: "transition-arrow fill-primary", size: :xs) %>
       <div style="view-transition-name: title"><%= back_to_title %></div>


### PR DESCRIPTION
The URL parameter of the `link_to` helper can any valid URL protocols, and javascript is one of those. If a user controlled string is passed to this parameter, it can be used for an XSS. For instance on the following link: https://www.rubyevents.org/talks/the-state-of-security-in-rails-8?back_to=javascript:alert(%27Hi%27)&back_to_title=Greg+Molnar, if you click the back button, it will open an alert window.
The [`sanitize`](https://api.rubyonrails.org/classes/ActionView/Helpers/SanitizeHelper.html#method-i-sanitize) helper strips unsafe protocols to prevent this.

/cc @marcoroth 