### PR TITLE
Fix home N+1s for users/speakers

### DIFF
--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -34,7 +34,7 @@ class PageController < ApplicationController
       .map(&:slug)
 
     @featured_events = Event.distinct
-      .includes(:organisation)
+      .includes(:organisation, :keynote_speakers, :speakers)
       .where(slug: playlist_slugs)
       # .with_watchable_talks
       .in_order_of(:slug, playlist_slugs)


### PR DESCRIPTION
While investigating #950, I identified two low-hanging fruits that I could address. There were a bunch of N+1s related to `keynote speakers ` and `speakers`.

<details>
 <summary>Queries before</summary> 
 <pre>
20:40:10 web.1  |   User Load (0.8ms)  SELECT DISTINCT "users".* FROM "users" INNER JOIN "user_talks" ON "users"."id" = "user_talks"."user_id" INNER JOIN "talks" ON "user_talks"."talk_id" = "talks"."id" WHERE "talks"."event_id" = 550 AND (users.talks_count > 0) /*action='home',application='RubyEvents',controller='page'*/
20:40:10 web.1  |   ↳ app/views/events/_featured.html.erb:40
20:40:10 web.1  |   Rendered events/_featured.html.erb (Duration: 85.8ms | GC: 25.1ms)
20:40:10 web.1  |   User Count (0.8ms)  SELECT COUNT(DISTINCT "users"."id") FROM "users" INNER JOIN "user_talks" ON "users"."id" = "user_talks"."user_id" INNER JOIN "talks" ON "user_talks"."talk_id" = "talks"."id" INNER JOIN "user_talks" AS "user_talks_users_join" ON "user_talks_users_join"."user_id" = "users"."id" INNER JOIN "talks" AS "talks_users" ON "talks_users"."id" = "user_talks_users_join"."talk_id" WHERE "talks"."event_id" = 187 AND (users.talks_count > 0) AND "talks"."kind" = 'keynote' /*action='home',application='RubyEvents',controller='page'*/
20:40:10 web.1  |   ↳ app/models/event.rb:203:in 'Event#keynote_speakers_text'
20:40:10 web.1  |   User Load (0.6ms)  SELECT DISTINCT "users".* FROM "users" INNER JOIN "user_talks" ON "users"."id" = "user_talks"."user_id" INNER JOIN "talks" ON "user_talks"."talk_id" = "talks"."id" WHERE "talks"."event_id" = 187 AND (users.talks_count > 0) /*action='home',application='RubyEvents',controller='page'*/
20:40:10 web.1  |   ↳ app/views/events/_featured.html.erb:40
20:40:10 web.1  |   Rendered events/_featured.html.erb (Duration: 5.0ms | GC: 0.5ms)
20:40:10 web.1  |   User Count (0.8ms)  SELECT COUNT(DISTINCT "users"."id") FROM "users" INNER JOIN "user_talks" ON "users"."id" = "user_talks"."user_id" INNER JOIN "talks" ON "user_talks"."talk_id" = "talks"."id" INNER JOIN "user_talks" AS "user_talks_users_join" ON "user_talks_users_join"."user_id" = "users"."id" INNER JOIN "talks" AS "talks_users" ON "talks_users"."id" = "user_talks_users_join"."talk_id" WHERE "talks"."event_id" = 20 AND (users.talks_count > 0) AND "talks"."kind" = 'keynote' /*action='home',application='RubyEvents',controller='page'*/
20:40:10 web.1  |   ↳ app/models/event.rb:203:in 'Event#keynote_speakers_text'
20:40:10 web.1  |   User Load (0.6ms)  SELECT DISTINCT "users".* FROM "users" INNER JOIN "user_talks" ON "users"."id" = "user_talks"."user_id" INNER JOIN "talks" ON "user_talks"."talk_id" = "talks"."id" WHERE "talks"."event_id" = 20 AND (users.talks_count > 0) /*action='home',application='RubyEvents',controller='page'*/
20:40:10 web.1  |   ↳ app/views/events/_featured.html.erb:40
20:40:10 web.1  |   Rendered events/_featured.html.erb (Duration: 5.4ms | GC: 0.5ms)
20:40:10 web.1  |   User Count (0.7ms)  SELECT COUNT(DISTINCT "users"."id") FROM "users" INNER JOIN "user_talks" ON "users"."id" = "user_talks"."user_id" INNER JOIN "talks" ON "user_talks"."talk_id" = "talks"."id" INNER JOIN "user_talks" AS "user_talks_users_join" ON "user_talks_users_join"."user_id" = "users"."id" INNER JOIN "talks" AS "talks_users" ON "talks_users"."id" = "user_talks_users_join"."talk_id" WHERE "talks"."event_id" = 596 AND (users.talks_count > 0) AND "talks"."kind" = 'keynote' /*action='home',application='RubyEvents',controller='page'*/
20:40:10 web.1  |   ↳ app/models/event.rb:203:in 'Event#keynote_speakers_text'
20:40:10 web.1  |   User Load (0.6ms)  SELECT DISTINCT "users".* FROM "users" INNER JOIN "user_talks" ON "users"."id" = "user_talks"."user_id" INNER JOIN "talks" ON "user_talks"."talk_id" = "talks"."id" WHERE "talks"."event_id" = 596 AND (users.talks_count > 0) /*action='home',application='RubyEvents',controller='page'*/
20:40:10 web.1  |   ↳ app/views/events/_featured.html.erb:40
20:40:10 web.1  |   Rendered events/_featured.html.erb (Duration: 4.2ms | GC: 0.0ms)
20:40:10 web.1  |   User Count (0.7ms)  SELECT COUNT(DISTINCT "users"."id") FROM "users" INNER JOIN "user_talks" ON "users"."id" = "user_talks"."user_id" INNER JOIN "talks" ON "user_talks"."talk_id" = "talks"."id" INNER JOIN "user_talks" AS "user_talks_users_join" ON "user_talks_users_join"."user_id" = "users"."id" INNER JOIN "talks" AS "talks_users" ON "talks_users"."id" = "user_talks_users_join"."talk_id" WHERE "talks"."event_id" = 546 AND (users.talks_count > 0) AND "talks"."kind" = 'keynote' /*action='home',application='RubyEvents',controller='page'*/
20:40:10 web.1  |   ↳ app/models/event.rb:203:in 'Event#keynote_speakers_text'
20:40:10 web.1  |   User Load (0.6ms)  SELECT DISTINCT "users".* FROM "users" INNER JOIN "user_talks" ON "users"."id" = "user_talks"."user_id" INNER JOIN "talks" ON "user_talks"."talk_id" = "talks"."id" WHERE "talks"."event_id" = 546 AND (users.talks_count > 0) /*action='home',application='RubyEvents',controller='page'*/
20:40:10 web.1  |   ↳ app/views/events/_featured.html.erb:40
20:40:10 web.1  |   Rendered events/_featured.html.erb (Duration: 4.2ms | GC: 0.4ms)
...
</pre>
 </details> 


<details>
 <summary>Queries after</summary>
 <pre>
20:43:05 web.1  |   Talk Load (0.9ms)  SELECT "talks".* FROM "talks" INNER JOIN "user_talks" ON "user_talks"."talk_id" = "talks"."id" INNER JOIN "users" ON "users"."id" = "user_talks"."user_id" AND (users.talks_count > 0) INNER JOIN "user_talks" AS "user_talks_users_join" ON "user_talks_users_join"."user_id" = "users"."id" INNER JOIN "talks" AS "talks_users" ON "talks_users"."id" = "user_talks_users_join"."talk_id" WHERE (users.talks_count > 0) AND "talks"."kind" = 'keynote' AND "talks"."event_id" IN (550, 187, 20, 596, 546, 566, 59, 281, 64, 137, 109, 93, 106, 302, 79) /*action='home',application='RubyEvents',controller='page'*/
20:43:05 web.1  |   ↳ app/views/page/home.html.erb:13:in 'Enumerable#each_with_index'
20:43:05 web.1  |   Talk Eager Load (0.8ms)  SELECT "talks"."id" AS t0_r0, "talks"."title" AS t0_r1, "talks"."description" AS t0_r2, "talks"."slug" AS t0_r3, "talks"."video_id" AS t0_r4, "talks"."video_provider" AS t0_r5, "talks"."thumbnail_sm" AS t0_r6, "talks"."thumbnail_md" AS t0_r7, "talks"."thumbnail_lg" AS t0_r8, "talks"."created_at" AS t0_r9, "talks"."updated_at" AS t0_r10, "talks"."event_id" AS t0_r11, "talks"."thumbnail_xs" AS t0_r12, "talks"."thumbnail_xl" AS t0_r13, "talks"."date" AS t0_r14, "talks"."like_count" AS t0_r15, "talks"."view_count" AS t0_r16, "talks"."summary" AS t0_r17, "talks"."language" AS t0_r18, "talks"."slides_url" AS t0_r19, "talks"."summarized_using_ai" AS t0_r20, "talks"."external_player" AS t0_r21, "talks"."external_player_url" AS t0_r22, "talks"."kind" AS t0_r23, "talks"."parent_talk_id" AS t0_r24, "talks"."meta_talk" AS t0_r25, "talks"."start_seconds" AS t0_r26, "talks"."end_seconds" AS t0_r27, "talks"."duration_in_seconds" AS t0_r28, "talks"."announced_at" AS t0_r29, "talks"."published_at" AS t0_r30, "talks"."original_title" AS t0_r31, "users"."id" AS t1_r0, "users"."email" AS t1_r1, "users"."password_digest" AS t1_r2, "users"."verified" AS t1_r3, "users"."admin" AS t1_r4, "users"."created_at" AS t1_r5, "users"."updated_at" AS t1_r6, "users"."name" AS t1_r7, "users"."github_handle" AS t1_r8, "users"."bio" AS t1_r9, "users"."website" AS t1_r10, "users"."slug" AS t1_r11, "users"."twitter" AS t1_r12, "users"."bsky" AS t1_r13, "users"."mastodon" AS t1_r14, "users"."linkedin" AS t1_r15, "users"."speakerdeck" AS t1_r16, "users"."pronouns" AS t1_r17, "users"."pronouns_type" AS t1_r18, "users"."talks_count" AS t1_r19, "users"."canonical_id" AS t1_r20, "users"."bsky_metadata" AS t1_r21, "users"."github_metadata" AS t1_r22, "users"."watched_talks_count" AS t1_r23 FROM "talks" LEFT OUTER JOIN "user_talks" ON "user_talks"."talk_id" = "talks"."id" LEFT OUTER JOIN "users" ON "users"."id" = "user_talks"."user_id" AND (users.talks_count > 0) WHERE (users.talks_count > 0) AND "talks"."event_id" IN (550, 187, 20, 596, 546, 566, 59, 281, 64, 137, 109, 93, 106, 302, 79) /*action='home',application='RubyEvents',controller='page'*/

</pre>
 </details>

## Performance

Adding some includes for `keynote_speakers` and `speakers` results in a roughly 20% speedup in my local testing with `wrk`. 

**Before**
```
Running 30s test @ http://localhost:3000/
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     3.30s     4.89s   20.37s    86.49%
    Req/Sec     2.91      3.63    20.00     88.89%
  90 requests in 30.04s, 5.69MB read
Requests/sec:      3.00
Transfer/sec:    193.86KB
```

**After**
```
Running 30s test @ http://localhost:3000/
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     4.07s     5.70s   25.56s    81.88%
    Req/Sec     2.43      2.55    10.00     91.43%
  111 requests in 30.04s, 7.02MB read
Requests/sec:      3.69
Transfer/sec:    239.33KB
```
