### PR TITLE
optimize home page queries

### DIFF
--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -24,7 +24,7 @@ class PageController < ApplicationController
     @latest_talks = Talk.includes(event: :organisation).where(id: home_page_cached_data[:latest_talk_ids])
     @upcoming_talks = Talk.includes(event: :organisation).where(id: home_page_cached_data[:upcoming_talk_ids])
     @latest_events = Event.includes(:organisation).where(id: home_page_cached_data[:latest_event_ids])
-    @featured_speakers = Speaker.where(id: home_page_cached_data[:featured_speaker_ids]).sample(10)
+    @featured_speakers = User.where(id: home_page_cached_data[:featured_speaker_ids]).sample(10)
     @featured_sponsors = Sponsor.joins(:event_sponsors).includes(:events).group("sponsors.id").order("COUNT(event_sponsors.id) DESC").limit(10)
 
     # Add featured events logic

--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -10,9 +10,11 @@ class PageController < ApplicationController
         latest_talk_ids: latest_talks.pluck(:id),
         upcoming_talk_ids: Talk.with_speakers.where(date: Date.today..).order(date: :asc).limit(15).pluck(:id),
         latest_event_ids: Event.order(date: :desc).limit(10).pluck(:id).sample(4),
-        featured_speaker_ids: Speaker.with_github
+        featured_speaker_ids: User.with_github
           .joins(:talks)
           .where(talks: {date: 12.months.ago..})
+          .order(Arel.sql("RANDOM()"))
+          .limit(40)
           .pluck(:id)
       }
     end
@@ -23,7 +25,7 @@ class PageController < ApplicationController
     @upcoming_talks = Talk.includes(event: :organisation).where(id: home_page_cached_data[:upcoming_talk_ids])
     @latest_events = Event.includes(:organisation).where(id: home_page_cached_data[:latest_event_ids])
     @featured_speakers = Speaker.where(id: home_page_cached_data[:featured_speaker_ids]).sample(10)
-    @featured_sponsors = Sponsor.joins(:event_sponsors).group("sponsors.id").order("COUNT(event_sponsors.id) DESC").limit(25)
+    @featured_sponsors = Sponsor.joins(:event_sponsors).includes(:events).group("sponsors.id").order("COUNT(event_sponsors.id) DESC").limit(10)
 
     # Add featured events logic
     playlist_slugs = Static::Playlist.where.not(featured_background: nil)


### PR DESCRIPTION
relates to #950


as part of the talks we had in #950 and has a follow up of #957 this PR improves the queries for the home page. 

Rather than retreiving all speakers who gave a talk in the last 12 months. we randomly pick 40 and store this ids in cache. Then for every visit 10 are selected randomly. Every hour the cache is invalidated so another set of 40 are selected


This remove also the n+1 on sponsors and reduce from 25 to 15 featured sponsors which I think is largely enough for the home page