### PR TITLE
display progress in talk index

### DIFF
--- a/app/views/talks/_card.html.erb
+++ b/app/views/talks/_card.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (talk:, user_favorite_talks_ids: [], favoritable: false, back_to: nil, back_to_title: nil, user_watched_talks: [], watched_talks: []) -%>
 
 <% language = Language.by_code(talk.language) %>
-<% watched_talk = watched_talks.find { |wt| wt.talk_id == talk.id } %>
+<% watched_talk = watched_talks.find { |wt| wt.talk_id == talk.id } || user_watched_talks.find { |wt| wt.talk_id == talk.id } %>
 
 <div
   class="relative w-full bg-white border card card-compact"


### PR DESCRIPTION
#959 removed the display of the progress in the /talks or events/:event/talks view 