### PR TITLE
fix: bookmark icon alignment to match slides icon

### DIFF
--- a/app/views/talks/_card.html.erb
+++ b/app/views/talks/_card.html.erb
@@ -200,7 +200,7 @@
           <div class="self-end hotwire-native:hidden">
             <% if default_watch_list %>
               <% if user_favorite_talks_ids.include?(talk.id) %>
-                <%= button_to watch_list_talk_path(default_watch_list, talk.id), method: :delete do %>
+                <%= button_to watch_list_talk_path(default_watch_list, talk.id), method: :delete, form: {class: 'h-5'} do %>
                   <%= fa(
                         "bookmark",
                         style: :solid,
@@ -209,7 +209,7 @@
                       ) %>
                 <% end %>
               <% else %>
-                <%= button_to watch_list_talks_path(default_watch_list, talk_id: talk.id), method: :post do %>
+                <%= button_to watch_list_talks_path(default_watch_list, talk_id: talk.id), method: :post, form: {class: 'h-5'} do %>
                   <%= fa(
                         "bookmark",
                         class: "shrink-0 cursor-pointer",


### PR DESCRIPTION
Fixes issue: #929 

| Before | After |
|:-----|:---:|
| <img width="320" height="679" alt="before alignment" src="https://github.com/user-attachments/assets/cfab006c-a9ab-40e1-ba90-02d67aefd56a" /> |  <img width="320" height="679" alt="after alignment" src="https://github.com/user-attachments/assets/804e32fc-ceff-4a4d-8bd1-0ac85f1ae995" /> |