### PR TITLE
Event Attendees

### DIFF
--- a/app/avo/resources/event_participation.rb
+++ b/app/avo/resources/event_participation.rb
@@ -1,0 +1,16 @@
+class Avo::Resources::EventParticipation < Avo::BaseResource
+  # self.includes = []
+  # self.attachments = []
+  # self.search = {
+  #   query: -> { query.ransack(id_eq: q, m: "or").result(distinct: false) }
+  # }
+  
+  def fields
+    field :id, as: :id
+    field :user_id, as: :number
+    field :event_id, as: :number
+    field :attended_as, as: :select, enum: ::EventParticipation.attended_as
+    field :user, as: :belongs_to
+    field :event, as: :belongs_to
+  end
+end

--- a/app/avo/resources/event_participation.rb
+++ b/app/avo/resources/event_participation.rb
@@ -4,7 +4,7 @@ class Avo::Resources::EventParticipation < Avo::BaseResource
   # self.search = {
   #   query: -> { query.ransack(id_eq: q, m: "or").result(distinct: false) }
   # }
-  
+
   def fields
     field :id, as: :id
     field :user_id, as: :number

--- a/app/avo/resources/user.rb
+++ b/app/avo/resources/user.rb
@@ -37,6 +37,7 @@ class Avo::Resources::User < Avo::BaseResource
     field :user_talks, as: :has_many, hide_on: :index
     field :connected_accounts, as: :has_many
     field :sessions, as: :has_many
+    field :participated_events, as: :has_many, hide_on: :index, use_resource: Avo::Resources::Event
   end
 
   def filters

--- a/app/avo/resources/user.rb
+++ b/app/avo/resources/user.rb
@@ -11,6 +11,9 @@ class Avo::Resources::User < Avo::BaseResource
   self.search = {
     query: -> { query.where("lower(name) LIKE ? OR email LIKE ?", "%#{params[:q]&.downcase}%", "%#{params[:q]}%") }
   }
+  self.external_link = -> {
+    main_app.profile_path(record)
+  }
 
   def fields
     field :id, as: :id, link_to_record: true

--- a/app/controllers/avo/event_participations_controller.rb
+++ b/app/controllers/avo/event_participations_controller.rb
@@ -1,0 +1,4 @@
+# This controller has been generated to enable Rails' resource routes.
+# More information on https://docs.avohq.io/3.0/controllers.html
+class Avo::EventParticipationsController < Avo::ResourcesController
+end

--- a/app/controllers/event_participations_controller.rb
+++ b/app/controllers/event_participations_controller.rb
@@ -1,0 +1,47 @@
+class EventParticipationsController < ApplicationController
+  before_action :set_event
+  before_action :set_participation, only: [:destroy]
+
+  # POST /events/:event_slug/event_participations
+  def create
+    @participation = @event.event_participations.build(participation_params)
+    @participation.user = Current.user
+
+    if @participation.save
+      respond_to do |format|
+        format.turbo_stream { render turbo_stream: turbo_stream.replace("participation_button", partial: "events/participation_button", locals: {event: @event, participation: @participation}) }
+        format.html { redirect_to event_path(@event), notice: "Participation recorded!" }
+      end
+    else
+      respond_to do |format|
+        format.turbo_stream { render turbo_stream: turbo_stream.replace("participation_button", partial: "events/participation_button", locals: {event: @event, participation: nil, errors: @participation.errors}) }
+        format.html { redirect_to event_path(@event), alert: "Failed to record participation." }
+      end
+    end
+  end
+
+  # DELETE /events/:event_slug/event_participations/:id
+  def destroy
+    @participation.destroy
+    respond_to do |format|
+      format.turbo_stream { render turbo_stream: turbo_stream.replace("participation_button", partial: "events/participation_button", locals: {event: @event, participation: nil}) }
+      format.html { redirect_to event_path(@event), notice: "Participation removed." }
+    end
+  end
+
+  private
+
+  def set_event
+    @event = Event.find_by(slug: params[:event_slug])
+    redirect_to root_path, status: :moved_permanently unless @event
+  end
+
+  def set_participation
+    @participation = @event.event_participations.find_by(id: params[:id], user: Current.user)
+    redirect_to event_path(@event), alert: "Participation not found." unless @participation
+  end
+
+  def participation_params
+    params.permit(:attended_as)
+  end
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -32,6 +32,8 @@ class EventsController < ApplicationController
     end
 
     @sponsors = @event.event_sponsors.includes(:sponsor).joins(:sponsor).shuffle
+
+    @participation = Current.user&.main_participation_to(@event)
   end
 
   # GET /events/1/edit

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -55,6 +55,16 @@ class Event < ApplicationRecord
   belongs_to :canonical, class_name: "Event", optional: true
   has_many :aliases, class_name: "Event", foreign_key: "canonical_id"
 
+  # Event participation associations
+  has_many :event_participations, dependent: :destroy
+  has_many :participants, through: :event_participations, source: :user
+  has_many :speaker_participants, -> { where(event_participations: {attended_as: :speaker}) },
+    through: :event_participations, source: :user
+  has_many :keynote_speaker_participants, -> { where(event_participations: {attended_as: :keynote_speaker}) },
+    through: :event_participations, source: :user
+  has_many :visitor_participants, -> { where(event_participations: {attended_as: :visitor}) },
+    through: :event_participations, source: :user
+
   has_object :schedule
   has_object :static_metadata
   has_object :sponsors_file

--- a/app/models/event_participation.rb
+++ b/app/models/event_participation.rb
@@ -1,0 +1,35 @@
+# == Schema Information
+#
+# Table name: event_participations
+#
+#  id          :integer          not null, primary key
+#  attended_as :string           not null, uniquely indexed => [user_id, event_id], indexed
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  event_id    :integer          not null, uniquely indexed => [user_id, attended_as], indexed
+#  user_id     :integer          not null, uniquely indexed => [event_id, attended_as], indexed
+#
+# Indexes
+#
+#  idx_on_user_id_event_id_attended_as_ca0a2916e2  (user_id,event_id,attended_as) UNIQUE
+#  index_event_participations_on_attended_as       (attended_as)
+#  index_event_participations_on_event_id          (event_id)
+#  index_event_participations_on_user_id           (user_id)
+#
+# Foreign Keys
+#
+#  event_id  (event_id => events.id)
+#  user_id   (user_id => users.id)
+#
+class EventParticipation < ApplicationRecord
+  # associations
+  belongs_to :user
+  belongs_to :event
+
+  # validations
+  validates :user_id, uniqueness: {scope: [:event_id, :attended_as]}
+  validates :attended_as, presence: true, inclusion: {in: %w[speaker keynote_speaker visitor]}
+
+  # enums
+  enum :attended_as, %w[keynote_speaker speaker visitor].index_by(&:itself), prefix: true
+end

--- a/app/views/events/_header.html.erb
+++ b/app/views/events/_header.html.erb
@@ -1,3 +1,4 @@
+<%# locals: (event:, participation: nil) -%>
 <div
   class="w-full md:h-[198px] lg:h-[267px] xl:h-[336px] 2xl:h-[405px] justify-center align-center flex mt-3 border-t border-b hotwire-native:hidden"
   style="
@@ -37,8 +38,9 @@
       </div>
     </div>
 
-    <div class="flex flex-col gap-3 place-items-center">
+    <div class="flex flex-col gap-2">
       <%= ui_button "View all #{event.organisation.name} events", url: organisation_path(event.organisation), kind: :secondary, size: :sm, class: "w-full" %>
+      <%= render "events/participation_button", event: @event, participation: participation %>
     </div>
   </div>
 

--- a/app/views/events/_participation_button.html.erb
+++ b/app/views/events/_participation_button.html.erb
@@ -1,0 +1,49 @@
+<div id="participation_button" class="mt-4">
+  <% if Current.user %>
+    <% if participation&.attended_as_visitor? %>
+      <%= ui_tooltip "Remove your participation to this event" do %>
+        <%= ui_button url: event_event_participation_path(event, participation), params: {attended_as: "visitor"}, method: :delete, kind: :pill, class: "w-full", data: {turbo_frame: "modal"} do %>
+          <%= fa("circle-check", size: :xs, style: :solid, class: "fill-green-700") %>
+          <span class="text-nowrap">
+            Participated as Visitor
+          </span>
+        <% end %>
+      <% end %>
+    <% elsif participation %>
+      <%= ui_button kind: :pill, class: "w-full", disabled: true do %>
+        <%= fa("circle-check", size: :xs, style: :solid, class: "fill-green-700") %>
+        <span class="text-nowrap">
+          <% case participation.attended_as %>
+          <% when "keynote_speaker" %>
+            Participated as Keynote Speaker
+          <% when "speaker" %>
+            Participated as Speaker
+          <% end %>
+        </span>
+      <% end %>
+
+    <% else %>
+      <%= ui_tooltip "Add this event to your list of participations" do %>
+        <%= ui_button url: event_event_participations_path(event), params: {attended_as: "visitor"}, method: :post, kind: :pill, class: "w-full", data: {turbo_frame: "modal"} do %>
+          <%= fa("plus", style: :solid) %>
+          <span class="text-nowrap">Add to My Events</span>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <% if defined?(errors) && errors&.any? %>
+      <div class="mt-2 text-sm text-red-600">
+        <% errors.full_messages.each do |message| %>
+          <div><%= message %></div>
+        <% end %>
+      </div>
+    <% end %>
+  <% else %>
+    <%= ui_tooltip "Add this event to your list of participations" do %>
+      <%= ui_button url: new_session_path(redirect_to: request.fullpath), kind: :pill, class: "w-full", data: {turbo_frame: "modal"} do %>
+        <%= fa("plus", style: :solid) %>
+        <span class="text-nowrap">Add to My Events</span>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: "events/header", locals: {event: @event} %>
+<%= render partial: "events/header", locals: {event: @event, participation: @participation} %>
 
 <%= turbo_frame_tag dom_id(@event), data: {turbo_action: "advance", turbo_frame: "_top"} do %>
   <div class="container py-8">

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -14,85 +14,123 @@
 
   <div role="tablist" class="tabs tabs-bordered mt-6">
     <% if @talks.length.positive? %>
-      <input type="radio" name="talk_tabs" role="tab" class="tab" aria-label="All (<%= @talks.count %>)" checked>
-
+      <%# Talks %>
+      <input type="radio" name="talk_tabs" role="tab" class="tab" aria-label="Talks (<%= @talks.size %>)" <%= "checked" if @talks.size.positive? %>>
       <div role="tabpanel" class="tab-content mt-6">
-        <div class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 md:[&>:nth-child(4)]:hidden lg:grid-cols-4 lg:[&>:nth-child(4)]:block">
-          <%= render partial: "talks/card",
-                collection: @talks,
-                as: :talk,
-                locals: {
-                  favoritable: true,
-                  user_favorite_talks_ids: @user_favorite_talks_ids,
-                  user_watched_talks: user_watched_talks,
-                  back_to: back_to_from_request,
-                  back_to_title: @user.name
-                } %>
+        <div role="tablist" class="tabs tabs-boxed bg-base-100 mt-2">
+          <input type="radio" name="talk_kinds" role="tab" class="tab px-6 !rounded-lg" aria-label="All" <%= "checked" if @talks.size.positive? %>>
+          <div role="tabpanel" class="tab-content mt-6">
+            <div class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 md:[&>:nth-child(4)]:hidden lg:grid-cols-4 lg:[&>:nth-child(4)]:block">
+              <%= render partial: "talks/card",
+                    collection: @talks,
+                    as: :talk,
+                    locals: {
+                      favoritable: true,
+                      user_favorite_talks_ids: @user_favorite_talks_ids,
+                      user_watched_talks: user_watched_talks,
+                      back_to: back_to_from_request,
+                      back_to_title: @user.name
+                    } %>
+            </div>
+          </div>
+          <% @talks_by_kind.each do |kind, talks| %>
+            <input type="radio" name="talk_kinds" role="tab" class="tab px-6 !rounded-lg" aria-label="<%= talks.first.formatted_kind.pluralize %> (<%= talks.size %>)">
+
+            <div role="tabpanel" class="tab-content mt-6">
+              <div class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 md:[&>:nth-child(4)]:hidden lg:grid-cols-4 lg:[&>:nth-child(4)]:block">
+                <%= render partial: "talks/card",
+                      collection: talks,
+                      as: :talk,
+                      locals: {
+                        favoritable: true,
+                        user_favorite_talks_ids: @user_favorite_talks_ids,
+                        user_watched_talks: user_watched_talks,
+                        back_to: back_to_from_request,
+                        back_to_title: @user.name
+                      } %>
+              </div>
+            </div>
+          <% end %>
+
         </div>
       </div>
+    <% end %>
 
-      <% @talks_by_kind.each do |kind, talks| %>
-        <input type="radio" name="talk_tabs" role="tab" class="tab px-6" aria-label="<%= talks.first.formatted_kind.pluralize %> (<%= talks.count %>)">
+    <%# Event Participations %>
+    <input type="radio" name="talk_tabs" role="tab" class="tab px-6" aria-label="Event participations (<%= @events.size %>)" <%= "checked" if @talks.size.zero? %>>
 
-        <div role="tabpanel" class="tab-content mt-6">
-          <div class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 md:[&>:nth-child(4)]:hidden lg:grid-cols-4 lg:[&>:nth-child(4)]:block">
-            <%= render partial: "talks/card",
-                  collection: talks,
-                  as: :talk,
-                  locals: {
-                    favoritable: true,
-                    user_favorite_talks_ids: @user_favorite_talks_ids,
-                    user_watched_talks: user_watched_talks,
-                    back_to: back_to_from_request,
-                    back_to_title: @user.name
-                  } %>
-          </div>
-        </div>
-      <% end %>
-
-      <% if @events.any? %>
-        <input type="radio" name="talk_tabs" role="tab" class="tab px-6" aria-label="Spoken at (<%= @events.count %>)">
-
-        <div role="tabpanel" class="tab-content mt-6">
-          <% @events_by_year.each do |year, events| %>
-            <div class="mb-12">
-              <h2 class="text-2xl font-bold text-gray-900 mb-6">
-                <%= year %>
-              </h2>
+    <div role="tabpanel" class="tab-content mt-6">
+      <div class="space-y-8">
+        <% @participated_events_by_type.each do |participation_type, events| %>
+          <div>
+            <h3 class="text-lg font-semibold mb-4">
+              <%= participation_type.humanize %> Events
+            </h3>
+            <div class="mb-6">
               <div class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
                 <%= render partial: "events/card", collection: events, as: :event %>
               </div>
             </div>
+          </div>
+        <% end %>
+
+        <div class="text-center py-12 hidden only:block">
+          <div class="mb-6">
+            <h3 class="text-lg font-semibold text-gray-900 mb-2">No participated events yet</h3>
+            <p class="text-gray-600 mb-6 max-w-xl mx-auto">
+              <% if Current.user == @user %>
+                You haven't marked your participation in any events yet. Visit <%= link_to "event pages", events_path, class: "link link-primary link-ghost" %> or search events with <kbd class="kbd kbd-sm text-base-content">⌘ k</kbd> and click "Add to My Events" to start building your event history.
+              <% elsif Current.user %>
+                This user hasn't marked their participation in any events yet.
+              <% else %>
+                Sign in to manage your profile and mark your participation in events you've attended.
+              <% end %>
+            </p>
+          </div>
+
+          <% if Current.user && Current.user == @user %>
+            <div class="space-y-3">
+              <%= link_to events_path, class: "btn btn-primary" do %>
+                <%= fa("magnifying-glass", style: :regular) %>
+                Browse Events
+              <% end %>
+            </div>
+          <% elsif !Current.user %>
+            <div class="space-y-3">
+              <%= link_to "Sign in", new_session_path(redirect_to: request.fullpath), data: {turbo_frame: "modal"}, class: "btn btn-primary" %>
+            </div>
           <% end %>
         </div>
-      <% end %>
+      </div>
+    </div>
 
-      <% if @countries_with_events.any? %>
-        <input type="radio" name="talk_tabs" role="tab" class="tab px-6" aria-label="Map (<%= @countries_with_events.count %>)">
+    <%# Stickers %>
+    <% if @events_with_stickers.any? %>
+      <input type="radio" name="talk_tabs" role="tab" class="tab px-6" aria-label="Stickers (<%= @events_with_stickers.size %>)">
 
-        <div role="tabpanel" class="tab-content mt-6">
-          <div class="space-y-8">
-            <% @countries_with_events.group_by { |country, _| country.continent }.sort_by(&:first).each do |continent, countries_group| %>
-              <div>
-                <h3 class="text-lg font-semibold mb-4"><%= continent %></h3>
-                <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
-                  <% countries_group.each do |country, events| %>
-                    <%= render "shared/country_card", country: country, events: events %>
-                  <% end %>
-                </div>
+      <div role="tabpanel" class="tab-content mt-6">
+        <%= render partial: "shared/stickers_display", locals: {events: @events_with_stickers} %>
+      </div>
+    <% end %>
+
+    <%# Map %>
+    <% if @countries_with_events.any? %>
+      <input type="radio" name="talk_tabs" role="tab" class="tab px-6" aria-label="Map (<%= @countries_with_events.size %>)">
+
+      <div role="tabpanel" class="tab-content mt-6">
+        <div class="space-y-8">
+          <% @countries_with_events.group_by { |country, _| country.continent }.sort_by(&:first).each do |continent, countries_group| %>
+            <div>
+              <h3 class="text-lg font-semibold mb-4"><%= continent %></h3>
+              <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                <% countries_group.each do |country, events| %>
+                  <%= render "shared/country_card", country: country, events: events %>
+                <% end %>
               </div>
-            <% end %>
-          </div>
+            </div>
+          <% end %>
         </div>
-      <% end %>
-
-      <% if @events_with_stickers.any? %>
-        <input type="radio" name="talk_tabs" role="tab" class="tab px-6" aria-label="Stickers (<%= @events_with_stickers.count %>)">
-
-        <div role="tabpanel" class="tab-content mt-6">
-          <%= render partial: "shared/stickers_display", locals: {events: @events_with_stickers} %>
-        </div>
-      <% end %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,8 @@ Rails.application.routes.draw do
   resources :speakers, param: :slug, only: [:index, :show]
   resources :profiles, param: :slug, only: [:show, :update, :edit]
   resources :events, param: :slug, only: [:index, :show, :update, :edit] do
+    resources :event_participations, only: [:create, :destroy]
+
     scope module: :events do
       collection do
         get "/past" => "past#index", :as => :past

--- a/db/migrate/20250903125458_create_event_participations.rb
+++ b/db/migrate/20250903125458_create_event_participations.rb
@@ -1,0 +1,14 @@
+class CreateEventParticipations < ActiveRecord::Migration[8.1]
+  def change
+    create_table :event_participations do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :event, null: false, foreign_key: true
+      t.string :attended_as, null: false
+
+      t.timestamps
+    end
+
+    add_index :event_participations, [:user_id, :event_id, :attended_as], unique: true
+    add_index :event_participations, :attended_as
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_09_01_185702) do
+ActiveRecord::Schema[8.1].define(version: 2025_09_03_125458) do
   create_table "_litestream_lock", id: false, force: :cascade do |t|
     t.integer "id"
   end
@@ -77,6 +77,18 @@ ActiveRecord::Schema[8.1].define(version: 2025_09_01_185702) do
   create_table "email_verification_tokens", force: :cascade do |t|
     t.integer "user_id", null: false
     t.index ["user_id"], name: "index_email_verification_tokens_on_user_id"
+  end
+
+  create_table "event_participations", force: :cascade do |t|
+    t.string "attended_as", null: false
+    t.datetime "created_at", null: false
+    t.integer "event_id", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["attended_as"], name: "index_event_participations_on_attended_as"
+    t.index ["event_id"], name: "index_event_participations_on_event_id"
+    t.index ["user_id", "event_id", "attended_as"], name: "idx_on_user_id_event_id_attended_as_ca0a2916e2", unique: true
+    t.index ["user_id"], name: "index_event_participations_on_user_id"
   end
 
   create_table "event_sponsors", force: :cascade do |t|
@@ -391,6 +403,8 @@ ActiveRecord::Schema[8.1].define(version: 2025_09_01_185702) do
 
   add_foreign_key "connected_accounts", "users"
   add_foreign_key "email_verification_tokens", "users"
+  add_foreign_key "event_participations", "events"
+  add_foreign_key "event_participations", "users"
   add_foreign_key "event_sponsors", "events"
   add_foreign_key "event_sponsors", "sponsors"
   add_foreign_key "events", "events", column: "canonical_id"

--- a/lib/tasks/backfill_speaker_participation.rake
+++ b/lib/tasks/backfill_speaker_participation.rake
@@ -1,0 +1,61 @@
+namespace :backfill do
+  desc "Backfill EventParticipation records for existing speakers"
+  task speaker_participation: :environment do
+    puts "Starting backfill of speaker participation records..."
+
+    # Query all UserTalk records with discarded_at: nil
+    user_talks = UserTalk.includes(:user, talk: :event).where(discarded_at: nil)
+    total_count = user_talks.count
+    processed_count = 0
+    created_count = 0
+    error_count = 0
+
+    puts "Found #{total_count} user-talk relationships to process"
+
+    # Process in batches
+    user_talks.find_in_batches(batch_size: 1000) do |batch|
+      batch.each do |user_talk|
+        begin
+          user = user_talk.user
+          talk = user_talk.talk
+          event = talk.event
+
+          next unless user && talk && event
+
+          # Determine participation type based on talk kind
+          participation_type = case talk.kind
+          when "keynote"
+            "keynote_speaker"
+          else
+            "speaker"
+          end
+
+          # Create EventParticipation record if it doesn't exist
+          participation = EventParticipation.find_or_create_by(user: user, event: event, attended_as: participation_type)
+
+          if participation.persisted?
+            created_count += 1 if participation.previously_new_record?
+          else
+            puts "Failed to create participation for user #{user.id} at event #{event.id}: #{participation.errors.full_messages.join(", ")}"
+            error_count += 1
+          end
+        rescue => e
+          puts "Error processing user_talk #{user_talk.id}: #{e.message}"
+          error_count += 1
+        end
+
+        processed_count += 1
+
+        # Progress reporting every 100 records
+        if processed_count % 100 == 0
+          puts "Processed #{processed_count}/#{total_count} records (#{(processed_count.to_f / total_count * 100).round(1)}%)"
+        end
+      end
+    end
+
+    puts "\nBackfill completed!"
+    puts "Total processed: #{processed_count}"
+    puts "New participations created: #{created_count}"
+    puts "Errors: #{error_count}"
+  end
+end

--- a/test/models/event_participation_test.rb
+++ b/test/models/event_participation_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class EventParticipationTest < ActiveSupport::TestCase
+  test "validates the main participation" do
+    user = users(:one)
+    user2 = users(:two)
+    event = events(:rails_world_2023)
+    EventParticipation.create(user: user2, event: event, attended_as: "keynote_speaker")
+    EventParticipation.create(user: user, event: event, attended_as: "speaker")
+    EventParticipation.create(user: user, event: event, attended_as: "keynote_speaker")
+    EventParticipation.create(user: user, event: event, attended_as: "visitor")
+    EventParticipation.create(user: user2, event: event, attended_as: "speaker")
+    EventParticipation.create(user: user2, event: event, attended_as: "visitor")
+    assert_equal 3, user.event_participations.count
+    assert_equal "keynote_speaker", user.main_participation_to(event).attended_as
+  end
+end


### PR DESCRIPTION
This PR adds the ability for user to add events to their list of attended events

It changes the way we link a user to an event for the speakers as we now have this new talk EventAttendance with different kind of attendance (keynote_speaker, speaker, visitor)

@marcoroth locally you will need to run this script

```
rake backfill:speaker_participation 
```

In a subsequent PR I will update the seed scrip 


## preview of the Event page

<img width="2654" height="1612" alt="CleanShot 2025-09-04 at 07 25 22@2x" src="https://github.com/user-attachments/assets/fd9ff044-1624-4dff-a37a-8255f7fb294f" />
