### PR TITLE
Update passport tooltip to be gender inclusive

### DIFF
--- a/app/views/profiles/_header_content.html.erb
+++ b/app/views/profiles/_header_content.html.erb
@@ -15,7 +15,7 @@
           <% end %>
         <% end %>
         <% if user.passports.any? %>
-          <%= ui_tooltip "#{user.name} claimed his Ruby Passport" do %>
+          <%= ui_tooltip "#{user.name} claimed their Ruby Passport" do %>
             <%= fa("passport", class: "fill-orange-800", size: :md) %>
           <% end %>
         <% end %>


### PR DESCRIPTION
Just a simple improvement to use “their” instead of “his” on the passport tooltip. As far as I can tell, the GitHub API doesn’t return user pronouns even if set.  
