### PR TITLE
Add XO Ruby Portland

### DIFF
--- a/data/xoruby/playlists.yml
+++ b/data/xoruby/playlists.yml
@@ -55,3 +55,25 @@
   cfp_open_date: "2025-07-29"
   cfp_close_date: "2025-08-27"
   cfp_link: https://www.xoruby.com/speak/
+
+- id: xoruby-portland-2025
+  title: XO Ruby Portland 2025
+  location: "Portland, OR"
+  description: |-
+    XO Ruby Portland is a single-day, single-track conference designed to draw folks in from the city and the region.
+
+    In Portland, rain-soaked streets weave through murals and food carts, where centuries-old forests edge up against a city humming with bikes, indie bookstores, and weekend farmers’ markets. Here, innovators, adventurers, and makers from St. Johns to Sellwood, and from Vancouver to Hood River, gather to exchange bold ideas beneath the ever-present gaze of Mt. Hood. This is an invitation to immerse yourself in Portland’s spirit of sustainability, DIY ingenuity, and offbeat charm—forming connections that are as authentic and unexpected as the city itself.
+  start_date: "2025-10-11"
+  end_date: "2025-10-11"
+  channel_id: ""
+  year: "2025"
+  videos_count: 0
+  metadata_parser: YouTube::VideoMetadata
+  slug: xoruby-portland-2025
+  website: https://xoruby.com/event/portland/
+  banner_background: "#230902"
+  featured_background: "#230902"
+  featured_color: "#FE470B"
+  cfp_open_date: "2025-09-09"
+  cfp_close_date: "2025-10-11"
+  cfp_link: https://www.xoruby.com/speak/

--- a/data/xoruby/xoruby-portland-2025/schedule.yml
+++ b/data/xoruby/xoruby-portland-2025/schedule.yml
@@ -1,0 +1,75 @@
+# Schedule: https://www.xoruby.com/event/portland/
+
+days:
+  - name: "XO Ruby Portland 2025"
+    date: "2025-10-11"
+    grid:
+      - start_time: "08:00"
+        end_time: "09:00"
+        slots: 1
+        items:
+          - Registration / Set up
+
+      - start_time: "09:00"
+        end_time: "09:15"
+        slots: 1
+        items:
+          - Welcome
+
+      - start_time: "09:15"
+        end_time: "09:45"
+        slots: 1
+        items:
+          - Fish Bowl Game
+
+      - start_time: "09:45"
+        end_time: "10:15"
+        slots: 1
+        items:
+          - TBA
+
+      - start_time: "10:15"
+        end_time: "10:45"
+        slots: 1
+        items:
+          - Break
+
+      - start_time: "10:45"
+        end_time: "11:15"
+        slots: 1
+        items:
+          - TBA
+
+      - start_time: "11:15"
+        end_time: "11:45"
+        slots: 1
+
+      - start_time: "11:45"
+        end_time: "13:00"
+        slots: 1
+        items:
+          - Lunch
+
+      - start_time: "14:15"
+        end_time: "14:45"
+        slots: 1
+        items:
+          - Break
+
+      - start_time: "15:45"
+        end_time: "16:15"
+        slots: 1
+        items:
+          - Break
+
+      - start_time: "16:15"
+        end_time: "16:45"
+        slots: 1
+        items:
+          - TBA
+
+      - start_time: "16:45"
+        end_time: "17:00"
+        slots: 1
+        items:
+          - Closing

--- a/data/xoruby/xoruby-portland-2025/sponsors.yml
+++ b/data/xoruby/xoruby-portland-2025/sponsors.yml
@@ -1,0 +1,25 @@
+---
+- tiers:
+    - name: Sponsors
+      description: ""
+      level: 1
+      sponsors:
+        - name: Planet Argon
+          website: https://www.planetargon.com/
+          slug: planet-argon
+          logo_url: https://www.xoruby.com/content/images/size/w1200/2025/08/pa-logo-765-1-.png
+
+        - name: DNSimple
+          website: https://dnsimple.com/
+          slug: dnsimple
+          logo_url: https://www.xoruby.com/content/images/size/w1200/2025/08/logomark-classic.png
+
+        - name: Flagrant
+          website: https://www.flagrant.com/
+          slug: flagrant
+          logo_url: https://www.xoruby.com/content/images/size/w1200/2025/07/Flagrant_logo_stacked_1c_Orange_pms485U.jpg
+
+        - name: Cisco
+          website: https://www.cisco.com/
+          slug: cisco
+          logo_url: https://www.xoruby.com/content/images/size/w1200/2025/07/cisco.png

--- a/data/xoruby/xoruby-portland-2025/videos.yml
+++ b/data/xoruby/xoruby-portland-2025/videos.yml
@@ -1,0 +1,5 @@
+---
+# Videos for XO Ruby Portland 2025
+# Event date: 2025-10-11
+# Website: https://www.xoruby.com/event/portland/
+[]


### PR DESCRIPTION
This PR adds the [XO Ruby Portland conference](https://www.xoruby.com/event/portland/), coming in October 2025.

Talks have not been announced yet, therefore the `video.yml` file is intentionally left empty.
