### PR TITLE
remove top banner for rubyvideo ruby conference merge

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,7 +37,6 @@
 
   <body data-controller="preserve-scroll">
     <div class="hotwire-native:hidden">
-      <%= render "shared/top_banner" %>
       <%= render "shared/navbar" %>
     </div>
 

--- a/app/views/shared/_top_banner.html.erb
+++ b/app/views/shared/_top_banner.html.erb
@@ -7,7 +7,7 @@
       <div class="aspect-[577/310] w-[36.0625rem] bg-gradient-to-r from-[#DC143C] to-[#FBEEEE] opacity-30" style="clip-path: polygon(74.8% 41.9%, 97.2% 73.2%, 100% 34.9%, 92.5% 0.4%, 87.5% 0%, 75% 28.6%, 58.5% 54.6%, 50.1% 56.8%, 46.9% 44%, 48.3% 17.4%, 24.7% 53.9%, 0% 27.9%, 11.9% 74.2%, 24.9% 54.1%, 68.6% 100%, 74.8% 41.9%)"></div>
     </div>
     <p class="text-sm leading-6">
-      RubyVideo becomes RubyEvents! Learn more about it <%= link_to "here", about_path, class: "link link-brand" %>.
+      HERE IS THE TOP BANNER TEXT
     </p>
     <div class="flex flex-1 justify-end">
       <button type="button" class="-m-3 p-3 focus-visible:outline-offset-[-4px] tertiary" data-action="click->top-banner#dismiss">


### PR DESCRIPTION
I think it is time tome remove it

I kep the code for the banner in case we need it again for some other announcement 