### PR TITLE
Set up devcontainers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,44 @@
+ARG RUBY_VERSION=3.4.5
+FROM docker.io/library/ruby:$RUBY_VERSION-slim
+
+# Rails app lives here
+WORKDIR /rails
+
+# Install base packages
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y \
+    build-essential \
+    curl \
+    git \
+    libjemalloc2 \
+    libvips \
+    libyaml-dev \
+    node-gyp \
+    pkg-config \
+    python-is-python3 \
+    sqlite3 \
+    && rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+# Copy application code
+COPY . .
+
+# copy .env file if it doesn't exist
+# RUN "cp .env.sample .env"
+
+# Install JavaScript dependencies
+ARG NODE_VERSION=22.15.1
+ARG YARN_VERSION=1.22.22
+ENV PATH=/usr/local/node/bin:$PATH
+RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ && \
+    /tmp/node-build-master/bin/node-build "${NODE_VERSION}" /usr/local/node && \
+    npm install -g yarn@$YARN_VERSION && \
+    rm -rf /tmp/node-build-master
+
+# Install application gems
+RUN bundle install
+
+# Install node modules
+RUN yarn install
+
+# Default command
+CMD ["bin/dev"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "RubyEvents Dev",
+  "dockerComposeFile": "./docker-compose.yml",
+  "service": "rails-app",
+  "workspaceFolder": "/rails",
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/sshd:1": {}
+  },
+  "forwardPorts": [
+    3000
+  ],
+  "portsAttributes": {
+    "3000": {
+      "label": "Rails Server",
+      "onAutoForward": "notify"
+    }
+  },
+  "postCreateCommand": "bin/rails db:prepare",
+  "postStartCommand": "bin/dev",
+  "mounts": [
+    "source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached"
+  ]
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  rails-app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    command: sleep infinity
+    environment:
+      - RAILS_ENV=development
+      - NODE_ENV=development
+    ports:
+      - "3000:3000"
+    volumes:
+      - ..:/rails:cached
+    stdin_open: true
+    tty: true

--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ For more information on contributing conference data, please visit [this page](/
 
 We have tried to make the setup process as simple as possible so that in a few commands you can have the project with real data running locally.
 
+### Devcontainers
+
+In addition to the local development flow described below, we support [devcontainers](https://containers.dev).
+If you open this project in VS Code and you have the [dev containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) installed, it will prompt you and ask if you want to reopen in a dev contatiner.
+This will set up the dev environment for you in docker, and reopen your editor from within the context of the rails container, so you can run commands and work with the project as if it was local.
+All file changes will be present locally when you close the container.
+
+- Use `gh auth login` to auth with GitHub, so you can push commits from within the container.
+- Do not run `bin/setup`. It starts docker containers, and you're already in one.
+- The application is forwarded to [localhost:3000](localhost:3000) and starts automatically on boot.
+
 ### Requirements
 
 - Ruby 3.4.5


### PR DESCRIPTION
# Description
closes #1004

This pull request adds support for devcontainers to streamline development environment setup. It is purely additive, and does not impact the existing dev setup.

- git auth is handled using gh auth login, and it supports SSH
- docker-compose.yml is duplicated inside .devcontainers, so the existing dev setup will still work
- the db:prepare is run on creation
- the server automatically starts on start-up, and the port is forwarded to localhost:3000

## Devcontainer support and configuration

* Added `.devcontainer/Dockerfile` to define the development container, including installation of Ruby, Node.js, Yarn, and all required system dependencies.
* Added `.devcontainer/docker-compose.yml` to orchestrate the Rails app and Meilisearch services, including port mappings, volumes, and environment variables.
* Added `.devcontainer/devcontainer.json` to configure the devcontainer for VS Code, specifying services, port forwarding, post-creation commands, and feature integrations like SSH and GitHub CLI.

## Documentation updates

* Updated `README.md` to document devcontainer support, including setup instructions, workflow notes, and usage tips for working within the containerized environment.