### PR TITLE
Add basic export to ics (calendar format)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -282,3 +282,5 @@ group :test do
   gem "vcr", "~> 6.1"
   gem "webmock"
 end
+
+gem "icalendar", "~> 2.12"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -382,6 +382,12 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
+    icalendar (2.12.2)
+      base64
+      ice_cube (~> 0.16)
+      logger
+      ostruct
+    ice_cube (0.17.0)
     image_processing (1.14.0)
       mini_magick (>= 4.9.5, < 6)
       ruby-vips (>= 2.0.17, < 3)
@@ -832,6 +838,7 @@ DEPENDENCIES
   herb (~> 0.9)
   hotwire_combobox (~> 0.4.0)
   httparty
+  icalendar (~> 2.12)
   image_processing (~> 1.2)
   iso-639
   jbuilder

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -12,6 +12,19 @@ class EventsController < ApplicationController
     @events = Event.includes(:series, :keynote_speakers)
       .where(end_date: Date.today..)
       .order(start_date: :asc)
+
+    respond_to do |format|
+      format.html
+      format.ics do
+        calendar = Icalendar::Calendar.new
+
+        @events.where(date_precision: :day).each do |event|
+          calendar.add_event(event.to_ical)
+        end
+
+        render plain: calendar.to_ical
+      end
+    end
   end
 
   # GET /events/1

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -357,6 +357,18 @@ class Event < ApplicationRecord
     }
   end
 
+  def to_ical
+    Icalendar::Event.new.tap do |event|
+      event.uid = "RUBYEVENTS-#{id}"
+      event.dtstart = start_date
+      event.dtend = end_date + 1.day # dtend is exclusive, add 1 day to make it inclusive
+      event.summary = name
+      event.description = description
+      event.location = static_metadata.location
+      event.url = website
+    end
+  end
+
   private
 
   def todos_data_path

--- a/app/views/events/years/_header.html.erb
+++ b/app/views/events/years/_header.html.erb
@@ -22,6 +22,37 @@
             across <%= events_by_month.keys.count %> months
           <% end %>
         </span>
+
+        <%= ui_button "Subscribe to calendar", size: :sm, kind: :link, data: {toggle: "modal", target: "modal-middle"} %>
+        <%= ui_modal position: :middle, id: "modal-middle" do %>
+          <h1>Subscribe to calendar</h1>
+          <div class="flex flex-col gap-3">
+            <p>Copy the URL below and add it to your calendar application as an external calendar.</p>
+            <div
+              class="flex justify-between items-center"
+              data-controller="copy-to-clipboard"
+              data-copy-to-clipboard-success-class="scale-95">
+              <pre
+                class="text-sm font-mono text-gray-800 whitespace-pre-wrap break-words"
+                data-copy-to-clipboard-target="source">
+                <%= events_url(format: :ics) %>
+              </pre>
+              <button
+                class="btn btn-sm btn-outline transition-transform duration-150 ease-in-out"
+                data-action="click->copy-to-clipboard#copy"
+                data-copy-to-clipboard-target="button">
+                Copy
+              </button>
+            </div>
+            <p>Instructions for your device can be found here:</p>
+            <ul>
+              <li><%= external_link_to "Google Calendar / Android", "https://support.google.com/calendar/answer/37100?co=GENIE.Platform%3DDesktop&amp;hl=en&amp;oco=1" %></li>
+              <li><%= external_link_to "Microsoft Outlook", "https://support.microsoft.com/en-us/office/import-calendars-into-outlook-8e8364e1-400e-4c0f-a573-fe76b5a2d379" %></li>
+              <li><%= external_link_to "Mac", "https://support.apple.com/kb/ph11523?locale=en_US" %></li>
+              <li><%= external_link_to "iPhone (iCloud)", "https://support.apple.com/en-us/HT202361" %></li>
+            </ul>
+          </div>
+        <% end %>
       </p>
     </div>
 

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Mime::Type.register "text/calendar", :ics

--- a/test/controllers/events/archive_controller_test.rb
+++ b/test/controllers/events/archive_controller_test.rb
@@ -9,6 +9,7 @@ class Events::ArchiveControllerTest < ActionDispatch::IntegrationTest
   test "should get index with all filter" do
     get archive_events_path(kind: "all")
     assert_response :success
+    assert_select "h1", /Events Archive/i
     assert_includes @response.body, @conference.name
     assert_includes @response.body, @meetup.name
   end
@@ -18,5 +19,31 @@ class Events::ArchiveControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_includes @response.body, @meetup.name
     assert_not_includes @response.body, @conference.name
+  end
+
+  test "should get index with search results" do
+    get archive_events_path(s: "brighton")
+    assert_response :success
+    assert_select "h1", /Events Archive/i
+    assert_select "div", /search results for "brighton"/i
+    assert_select "##{dom_id(@conference)}", 1
+  end
+
+  test "should get index and return events in the correct order" do
+    event_names = %i[brightonruby_2024 no_sponsors_event new_rb_meetup railsconf_2017 rails_world_2023 tropical_rb_2024 future_conference rubyconfth_2022 wnb_rb_meetup].map { |event| events(event) }.map(&:name)
+
+    get archive_events_path
+
+    assert_response :success
+
+    assert_select ".event .event-name", count: event_names.size do |nodes|
+      assert_equal event_names, nodes.map(&:text)
+    end
+  end
+
+  test "should get index search result" do
+    get archive_events_path(letter: "T")
+    assert_response :success
+    assert_select "span", text: "Tropical Ruby 2024"
   end
 end

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -2,41 +2,15 @@ require "test_helper"
 
 class EventsControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @event = events(:railsconf_2017)
+    @event = events(:future_conference)
     @user = users(:lazaro_nixon)
   end
 
   test "should get index" do
-    get archive_events_url
+    get events_url
     assert_response :success
-    assert_select "h1", /Events Archive/i
-    assert_select "##{dom_id(@event)}", 1
-  end
-
-  test "should get index with search results" do
-    get archive_events_url(s: "rails")
-    assert_response :success
-    assert_select "h1", /Events Archive/i
-    assert_select "div", /search results for "rails"/i
-    assert_select "##{dom_id(@event)}", 1
-  end
-
-  test "should get index and return events in the correct order" do
-    event_names = %i[brightonruby_2024 no_sponsors_event new_rb_meetup railsconf_2017 future_conference rails_world_2023 tropical_rb_2024 rubyconfth_2022 wnb_rb_meetup].map { |event| events(event) }.map(&:name)
-
-    get archive_events_url
-
-    assert_response :success
-
-    assert_select ".event .event-name", count: event_names.size do |nodes|
-      assert_equal event_names, nodes.map(&:text)
-    end
-  end
-
-  test "should get index search result" do
-    get archive_events_url(letter: "T")
-    assert_response :success
-    assert_select "span", text: "Tropical Ruby 2024"
+    assert_select "h1", /Upcoming Events/i
+    assert_select "[data-event-id=#{@event.slug}]", 2
   end
 
   test "should show event" do

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -13,6 +13,14 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     assert_select "[data-event-id=#{@event.slug}]", 2
   end
 
+  test "should get index as ics" do
+    get events_url(format: :ics)
+    assert_response :success
+    assert_equal "text/calendar; charset=utf-8", response.content_type
+    assert_includes response.body, "BEGIN:VCALENDAR"
+    assert_includes response.body, "UID:RUBYEVENTS-#{@event.id}"
+  end
+
   test "should show event" do
     get event_url(@event)
     assert_response :success

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -102,6 +102,8 @@ brightonruby_2024:
 
 future_conference:
   date: <%= 3.weeks.from_now %>
+  start_date: <%= 3.weeks.from_now %>
+  end_date: <%= 3.weeks.from_now %>
   series: rails_world
   name: Future Conference
   kind: conference

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -269,4 +269,9 @@ class EventTest < ActiveSupport::TestCase
 
     assert event.today?
   end
+
+  test "to_ical returns a Icalendar::Event" do
+    event = events(:rails_world_2023)
+    assert_kind_of Icalendar::Event, event.to_ical
+  end
 end


### PR DESCRIPTION
This adds a simple icalendar export of the upcoming conferences. This way you can have an up-to-date list of upcoming conferences in your calendar. 

http://localhost:3000/events.ics

This file can be read by all major calendar apps, [Google][1], [Apple][2] etc. My experience is that Google updates it once every ~12 hours, so server load should be ok.

I haven't added a link to it in the UI yet, what do you think would be a good place for that?

[1]: https://support.google.com/calendar/answer/37100?co=GENIE.Platform%3DDesktop&hl=en&oco=1
[2]: https://support.apple.com/guide/calendar/subscribe-to-calendars-icl1022/mac