### PR TITLE
Make empty state page consistent

### DIFF
--- a/app/views/watch_lists/_watch_list.html.erb
+++ b/app/views/watch_lists/_watch_list.html.erb
@@ -1,7 +1,7 @@
 <div class="flex flex-col gap-4">
-  <div id="talks" class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gallery">
-    <p class="only:block hidden">Whoops! you have no videos!</p>
-    <%= render partial: "talks/card",
+  <% if watch_list.talks.present? %>
+    <div id="talks" class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gallery">
+      <%= render partial: "talks/card",
           collection: watch_list.talks,
           as: :talk,
           locals: {
@@ -11,5 +11,12 @@
             back_to: watch_lists_path,
             back_to_title: watch_list.name
           } %>
-  </div>
+    </div>
+  <% else %>
+    <div class="py-8 text-center">
+      <h2 class="mb-4 text-xl">No favorite videos yet</h2>
+      <p class="mb-4 text-gray-600">Start favorite videos to see them appear here.</p>
+      <%= link_to "Browse Videos", talks_path, class: "btn btn-primary" %>
+    </div>
+  <% end %>
 </div>


### PR DESCRIPTION
Recently watched and favorites empty state should be same.

# Before
<img width="1580" height="341" alt="Screenshot 2025-09-17 at 19 30 01" src="https://github.com/user-attachments/assets/fb8d8b9d-1de0-45c6-a03e-2b9417798090" />
<img width="1552" height="261" alt="Screenshot 2025-09-17 at 19 30 16" src="https://github.com/user-attachments/assets/0d193ad9-82cb-4770-afbf-6895a4329aa5" />

# After
<img width="1600" height="555" alt="Screenshot 2025-09-17 at 19 43 31" src="https://github.com/user-attachments/assets/af95356e-778f-447b-b1f8-0533251f84df" />
