### PR TITLE
Fix Omada Health sponsor name at SF Ruby 2025

### DIFF
--- a/data/sf-bay-area-ruby/sfruby-2025/sponsors.yml
+++ b/data/sf-bay-area-ruby/sfruby-2025/sponsors.yml
@@ -38,9 +38,9 @@
           slug: intercom
           logo_url: https://sfruby.com/sponsor_intercom.png
 
-        - name: Omada
+        - name: Omada Health
           website: https://omadahealth.com/
-          slug: omada
+          slug: omada-health
           logo_url: https://sfruby.com/sponsor_omada.png
 
         - name: Avo


### PR DESCRIPTION
This PR fixes a sponsor name for the SF Ruby Conference: `Omada Health` instead of just `Omada`.
The rest of the information is correct.

