### PR TITLE
Clarify video entry requirements in contributing guide

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -48,6 +48,9 @@ FileUtils.chdir APP_ROOT do
   puts "\n== How to start the application =="
   puts "\n use 'bin/dev' to start the Rails server, solid_queue and Vite"
 
+  puts "\n== How to set up initial data =="
+  puts "\n use 'bin/rails db:seed' to set up initial data"
+
   unless ARGV.include?("--skip-server")
     puts "\n== Starting development server =="
     STDOUT.flush # flush the output before exec(2) so that it displays

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -81,7 +81,7 @@ Here is an example for RailsConf/RubyConf:
 
 ### Step 3 - Create the Videos
 
-Once your playlists are currated, you can run the next script to extract the video information. It will iterate the playlist and extract all videos.
+Once your playlists are curated, you can run the next script to extract the video information. It will iterate the playlist and extract all videos.
 
 ```bash
 rails runner scripts/extract_videos.rb
@@ -99,6 +99,23 @@ data/
 │   │   └── videos.yml
 │   ├── playlists.yml
 ├── speakers.yml
+```
+
+Each video entry in the `videos.yml` files must have the following required fields:
+- `speakers`: Array of speaker names. Videos without speakers will not be displayed in the app.
+- `date`: The date when the talk was presented (in YYYY-MM-DD format). Videos without dates will not be displayed in the app.
+
+Example of a valid video entry:
+```yaml
+- title: "What Rust can teach us about Ruby"
+  event_name: "RubyConf Example 2025"
+  published_at: "2025-10-12"
+  description: "A presentation about Rust and Ruby"
+  video_provider: youtube
+  video_id: "abc123xyz"
+  speakers:
+    - "Jane Doe"
+  date: "2025-10-11"
 ```
 
 To extract a maximum of information from the YouTube metadata, the raw video information is parsed by a class `YouTube::VideoMetadata`. This class will try to extract speakers from the title. This is the default parser but sometimes the speakers are not extracted correctly, you can create a new class and specify it in the `playlists.yml` file.


### PR DESCRIPTION
Include instructions for setting up initial data using `db:seed` in the setup script and clarify the required fields for video entries in the contributing guide. 