### PR TITLE
Split future/past events on "Mutual Events" tab

### DIFF
--- a/app/views/profiles/_mutual_events.html.erb
+++ b/app/views/profiles/_mutual_events.html.erb
@@ -10,7 +10,7 @@
           <div class="mb-6">
             <% if events.upcoming.any? %>
               <div>
-                <h3 class="text-lg font-semibold mb-4">Future Events <%= user.name %> and <%= Current.user.name %> both attended</h3>
+                <h3 class="text-lg font-semibold mb-4">Future Events <%= user.name %> and <%= Current.user.name %> are attending</h3>
                 <div class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
                   <%= render partial: "events/card", collection: events.upcoming, as: :event, cached: true %>
                 </div>


### PR DESCRIPTION
- Hide mutual event tab if there is not mutual events for users
- Show separately future and past events

**No Mutual Event**
<img width="831" height="752" alt="Screenshot 2025-10-12 at 22 52 56" src="https://github.com/user-attachments/assets/8e7c359f-5491-4a13-8e94-d0cb416fec32" />

**Has past and future mutual events**
<img width="917" height="1100" alt="Screenshot 2025-10-12 at 22 52 50" src="https://github.com/user-attachments/assets/3da9e7c0-920a-452a-a29a-dee898522611" />

**Has just past mutual event**
<img width="699" height="761" alt="Screenshot 2025-10-12 at 22 52 53" src="https://github.com/user-attachments/assets/2d3c063c-14b0-497b-81cf-c0d97c8a6910" />


Resolves https://github.com/rubyevents/rubyevents/issues/1045