### PR TITLE
Don’t expand GB attendance to all country stamps

### DIFF
--- a/app/models/stamp.rb
+++ b/app/models/stamp.rb
@@ -199,59 +199,24 @@ class Stamp
   def self.create_stamp_from_code(stamp_code)
     stamp_upper = stamp_code.upcase
     file_path = "#{stamp_code}.webp"
+    country = ISO3166::Country.new(stamp_upper)
 
-    case stamp_upper
-    when "SCT", "SCOTLAND", "GB-SCT"
+    if country
       new(
-        code: "SCT",
-        name: "Scotland",
+        code: stamp_upper,
+        name: country.translations["en"],
         file_path: file_path,
-        country: ISO3166::Country.new("GB"),
-        has_country: true
-      )
-    when "ENG", "ENGLAND", "GB-ENG"
-      new(
-        code: "ENG",
-        name: "England",
-        file_path: file_path,
-        country: ISO3166::Country.new("GB"),
-        has_country: true
-      )
-    when "NIR", "NI", "NORTHERN-IRELAND", "GB-NIR"
-      new(
-        code: "NIR",
-        name: "Northern Ireland",
-        file_path: file_path,
-        country: ISO3166::Country.new("GB"),
-        has_country: true
-      )
-    when "WLS", "WALES", "GB-WLS"
-      new(
-        code: "WLS",
-        name: "Wales",
-        file_path: file_path,
-        country: ISO3166::Country.new("GB"),
+        country: country,
         has_country: true
       )
     else
-      country = ISO3166::Country.new(stamp_upper)
-      if country
-        new(
-          code: stamp_upper,
-          name: country.translations["en"],
-          file_path: file_path,
-          country: country,
-          has_country: true
-        )
-      else
-        new(
-          code: stamp_upper,
-          name: stamp_code.titleize,
-          file_path: file_path,
-          country: nil,
-          has_country: false
-        )
-      end
+      new(
+        code: stamp_upper,
+        name: stamp_code.titleize,
+        file_path: file_path,
+        country: nil,
+        has_country: false
+      )
     end
   end
 


### PR DESCRIPTION
We’ve been expanding attendance to any Great Britain conference to stamps for all the countries within it (England, Northern Ireland, Scotland, Wales).

This provides stamps that feel unearned/inaccurate, so let’s just use the default GB stamp. If there can be a way to flag events as being within specific GB countries, then the specific stamps can return.

As per discussion in #1073.