### PR TITLE
Add Kinsey Durham Grace's Tropical on Rails 2026 Keynote

### DIFF
--- a/data/tropicalrb/tropical-on-rails-2026/videos.yml
+++ b/data/tropicalrb/tropical-on-rails-2026/videos.yml
@@ -14,3 +14,15 @@
     My name is Vladimir (or Вова), I am a mathematician and software developer passionate about open source technologies.
   video_provider: "scheduled"
   video_id: "vladimir-dementyev-tropical-on-rails-2026"
+
+- title: "Keynote by Kinsey Durham Grace"
+  raw_title: "Keynote by Kinsey Durham Grace"
+  speakers:
+    - Kinsey Durham Grace
+  event_name: "Tropical on Rails 2026"
+  date: "2026-04-10"
+  published_at: "TODO"
+  description: |-
+    Kinsey Durham Grace is an engineer on the Coding Agent Core team at GitHub. She has held various leadership positions in technology communities and employee affinity groups. Kinsey has presented at conferences around the world. Outside of work, she spends time with her family in the mountains and practicing fly fishing in the rivers of Colorado.
+  video_provider: "scheduled"
+  video_id: "kinsey-durham-grace-tropical-on-rails-2026"


### PR DESCRIPTION
Recently, Tropical on Rails announced a new keynote: Kinsey Durham Grace! I took this opportunity to help Ruby Events by adding more information about the event.

<img width="1297" height="766" alt="Captura de Tela 2025-10-18 às 09 04 23" src="https://github.com/user-attachments/assets/972cef2c-f373-452d-b454-d4ba193182b4" />

Announcement: https://www.linkedin.com/posts/tropicalonrails_rubyonrails-tropicalonrails-activity-7384928705846091776-nIKg/