### PR TITLE
Fix the 'Future Events' section being empty when the user has no future events

### DIFF
--- a/app/views/profiles/_events.html.erb
+++ b/app/views/profiles/_events.html.erb
@@ -28,7 +28,6 @@
             <h3 class="text-lg font-semibold mb-4">Past Events</h3>
             <div class="mb-6">
               <div class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
-                <% past_events = events.past.sort_by(&:start_date).reverse %>
                 <% past_events.each do |event| %>
                   <%= cache event do %>
                     <%= render partial: "events/card", locals: {event: event, participation: participations[event.id]} %>


### PR DESCRIPTION
Resolves #1092

I forgot to hide the "Future Events" section when the user has no upcoming events. 
Thanks to @marcoroth for pointing this out!

Without future events:
<img width="1048" height="452" alt="Captura de Tela 2025-10-21 às 12 57 25" src="https://github.com/user-attachments/assets/6ce8ba21-18b7-417d-9461-fdf72d6c9ca9" />

With future events:
<img width="1028" height="761" alt="Captura de Tela 2025-10-21 às 13 02 30" src="https://github.com/user-attachments/assets/62c883e1-e2c9-4686-8919-11a9ab8cc426" />
