### PR TITLE
Add image proxy

### DIFF
--- a/app/controllers/image_proxy_controller.rb
+++ b/app/controllers/image_proxy_controller.rb
@@ -1,0 +1,47 @@
+class ImageProxyController < ApplicationController
+  disable_analytics
+  skip_before_action :authenticate_user!
+
+  def github_avatar
+    user = User.find(params[:id])
+    size = params[:size] || 200
+
+    cache_key = "image_proxy/github_avatar/#{user.id}/#{size}"
+    avatar_data = Rails.cache.fetch(cache_key, expires_in: 1.day) do
+      fetch_github_avatar(user, size) || fetch_fallback_avatar(user, size)
+    end
+
+    if avatar_data
+      expires_in 1.day, public: true
+      fresh_when etag: cache_key, last_modified: 1.day.ago, public: true
+      send_data avatar_data,
+        type: "image/png",
+        disposition: "inline"
+    else
+      head :not_found
+    end
+  end
+
+  private
+
+  def fetch_github_avatar(user, size)
+    username = user.github_handle
+    return if username.empty?
+
+    url = "https://github.com/#{username}.png?size=#{size}"
+    fetch_image(url)
+  end
+
+  def fetch_fallback_avatar(user, size)
+    url_safe_initials = user.name.split(" ").map(&:first).join("+")
+    url = "https://ui-avatars.com/api/?name=#{url_safe_initials}&size=#{size}&background=DC133C&color=fff"
+    fetch_image(url)
+  end
+
+  def fetch_image(url)
+    response = HTTParty.get(url)
+    response.success? ? response.body : nil
+  rescue
+    nil
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -206,11 +206,7 @@ class User < ApplicationRecord
   def github_avatar_url(size: 200)
     return nil if github_handle.blank?
 
-    metadata_avatar_url = github_metadata.dig("profile", "avatar_url")
-
-    return "#{metadata_avatar_url}&size=#{size}" if metadata_avatar_url.present?
-
-    "https://github.com/#{github_handle}.png?size=#{size}"
+    Router.github_avatar_proxy_path(id:, size: size)
   end
 
   def fallback_avatar_url(size: 200)

--- a/app/views/speakers/_speaker.html.erb
+++ b/app/views/speakers/_speaker.html.erb
@@ -1,7 +1,19 @@
 <%= link_to profile_path(speaker), id: dom_id(speaker), class: "flex justify-between items-center" do %>
-  <div class="flex items-center gap-3">
+  <div class="flex items-center gap-3 gap-y-4">
+    <div class="flex w-fit">
+      <%= ui_avatar(speaker, size: :sm) %>
+    </div>
+
     <span><%= sanitize speaker.name_with_snippet %></span>
   </div>
 
-  <%= ui_badge(speaker.talks_count, kind: :secondary, outline: true, size: :lg, class: "min-w-10") %>
+  <div class="flex items-center gap-2">
+    <%= ui_badge(
+          speaker.talks_count,
+          kind: :secondary,
+          outline: true,
+          size: :lg,
+          class: "min-w-10"
+        ) %>
+  </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@ Rails.application.routes.draw do
 
   extend Authenticator
 
+  # image proxy
+  get "image_proxy/github_avatar/:id", to: "image_proxy#github_avatar", as: :github_avatar_proxy
+
   # static pages
   get "uses", to: "page#uses"
   get "/privacy", to: "page#privacy"


### PR DESCRIPTION
This is a follow up to #1049.  Loading GitHub avatars en-masse results in rubyevents.org getting rate-limited by GitHub. To avoid this, we would want to serve the images ourselves. This could be accomplished by using ActiveStorage (as suggested in #881).

This PR instead adds a proxy for image requests to GitHub. Images are downloaded once and served from cache afterwards. This is much easier to set up, but has similar downsides to the ActiveStorage solution. 

## Considerations

1. Initially, loading images is slow because we request them from GitHub. Once the cache is populated, requests are speedy enough. 
2. I opted to query for the user, which allows us to centralize avatar serving (by caching fallback images), but this adds a small overhead to serving images.
3. We might serve stale avatars, which is why TTL is set to 1 day.  Downloading/serving images via ActiveStorage has this issue too. We _could_ manually invalidate the cache under certain conditions (e.g. when the user updates their profile/relinks their GitHub...) but I don't think that's worth the effort. 
3. Follow-ups include refactoring the user model & avatar helper, or maybe proxying images from Bsky as well :thinking: 
4. Heads up, locally Rack Mini Profiler screws with the browser cache, so images are never served from the browser cache locally. 

## Alternatives

Apart from using ActiveStorage, we could use something like Cloudflare workers to do much the same thing, as outlined [here](https://alistairshepherd.uk/writing/cloudflare-worker-image-proxy/). I don't know enough about rubyevents.org's infrastructure to know if that's viable. 