### PR TITLE
Add Adrianna Chang's Tropical on Rails keynote

### DIFF
--- a/data/tropicalrb/tropical-on-rails-2026/videos.yml
+++ b/data/tropicalrb/tropical-on-rails-2026/videos.yml
@@ -28,3 +28,16 @@
     Kinsey Durham Grace is an engineer on the Coding Agent Core team at GitHub. She has held various leadership positions in technology communities and employee affinity groups. Kinsey has presented at conferences around the world. Outside of work, she spends time with her family in the mountains and practicing fly fishing in the rivers of Colorado.
   video_provider: "scheduled"
   video_id: "kinsey-durham-grace-tropical-on-rails-2026"
+
+- title: "Keynote by Adrianna Chang"
+  raw_title: "Keynote by Adrianna Chang"
+  speakers:
+    - Adrianna Chang
+  event_name: "Tropical on Rails 2026"
+  date: "2026-04-10"
+  published_at: "TODO"
+  announced_at: "2025-10-22 12:30 UTC"
+  description: |-
+    Adrianna is a Staff Engineer at Shopify, a Rails Issues team member, and the meetup organizer for the WNB.rb community. She lives in Ottawa, Canada's capital, with her husband and Rottweiler, Jasper. Outside of work, she loves spending time outdoors and racing in triathlons.
+  video_provider: "scheduled"
+  video_id: "adrianna-chang-tropical-on-rails-2026"


### PR DESCRIPTION
I'm adding one more keynote that was announced this week: Adrianna Chang 🙌

<img width="1294" height="774" alt="Captura de Tela 2025-10-25 às 08 52 02" src="https://github.com/user-attachments/assets/e64a7630-4c30-4a78-9880-066f63a27c3e" />

Announcement: https://www.linkedin.com/posts/tropicalonrails_rubyonrails-tropicalonrails-activity-7386378248063987712-qScX