### PR TITLE
Add a new `hackathon` kind for events and organizations

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -97,7 +97,7 @@ class Event < ApplicationRecord
   scope :upcoming, -> { where(start_date: Date.today..).order(start_date: :asc) }
 
   # enums
-  enum :kind, ["event", "conference", "meetup", "retreat"].index_by(&:itself), default: "event"
+  enum :kind, ["event", "conference", "meetup", "retreat", "hackathon"].index_by(&:itself), default: "event"
   enum :date_precision, ["day", "month", "year"].index_by(&:itself), default: "day"
 
   def assign_canonical_event!(canonical_event:)

--- a/app/models/event/static_metadata.rb
+++ b/app/models/event/static_metadata.rb
@@ -21,6 +21,10 @@ class Event::StaticMetadata < ActiveRecord::AssociatedObject
     kind == "retreat"
   end
 
+  def hackathon?
+    kind == "hackathon"
+  end
+
   def frequency
     static_repository&.frequency || event.organisation.frequency
   end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -42,7 +42,7 @@ class Organisation < ApplicationRecord
   validates :name, presence: true
 
   # enums
-  enum :kind, {conference: 0, meetup: 1, organisation: 2, retreat: 3}
+  enum :kind, {conference: 0, meetup: 1, organisation: 2, retreat: 3, hackathon: 4}
   enum :frequency, {unknown: 0, yearly: 1, monthly: 2, biyearly: 3, quarterly: 4, irregular: 5}
 
   def title

--- a/app/models/static/playlist.rb
+++ b/app/models/static/playlist.rb
@@ -73,6 +73,10 @@ module Static
       kind == "retreat"
     end
 
+    def hackathon?
+      kind == "hackathon"
+    end
+
     def event_record
       @event_record ||= Event.find_by(slug: slug)
     end

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -23,7 +23,7 @@ Add the following information to the `data_preparation/organisations.yml` file:
   website: https://railsconf.org/
   twitter: railsconf
   youtube_channel_name: confreaks
-  kind: conference # Choose either 'conference' or 'meetup' or 'retreat'
+  kind: conference # Choose either 'conference', 'meetup', 'retreat', or 'hackathon'
   frequency: yearly # Specify if it's 'yearly' or 'monthly'; if you need something else, open a PR with this new frequency
   language: english # Default language of the talks from this conference
   default_country_code: AU # default country to be assigned to the associated events


### PR DESCRIPTION
Similar to #1067, this pull request introduces a new `hackathon` kind for events and organizations. This will be useful for Events like #1079.