### PR TITLE
Add Schedule to SF Ruby Conference

### DIFF
--- a/data/rubyconf/rubyconf-2024/videos.yml
+++ b/data/rubyconf/rubyconf-2024/videos.yml
@@ -239,7 +239,7 @@
 - title: "Breaking nil to fix bugs: experimental approach"
   raw_title: "RubyConf 2024 Breaking nil to fix bugs: experimental approach by Enrique Mogollan"
   speakers:
-    - Enrique Mogollan
+    - Enrique Mogollán
   event_name: "RubyConf 2024"
   published_at: "2024-12-10"
   date: "2024-11-13"

--- a/data/rubyconfth/rubyconfth-2019/videos.yml
+++ b/data/rubyconfth/rubyconfth-2019/videos.yml
@@ -75,7 +75,7 @@
 - title: "The Developer Who Wanted To Refactor The Moon"
   raw_title: "RubyConf TH 2019 - The developer who wanted to refactor the moon by Enrique Mogollan"
   speakers:
-    - Enrique Mogollan
+    - Enrique Mogollán
   event_name: "RubyConf TH 2019"
   date: "2019-09-06"
   published_at: "TODO"

--- a/data/sf-bay-area-ruby/sfruby-2025/schedule.yml
+++ b/data/sf-bay-area-ruby/sfruby-2025/schedule.yml
@@ -1,0 +1,170 @@
+# Schedule: https://sfruby.com/schedule
+
+days:
+  - name: "Day 1"
+    date: "2025-11-19"
+    grid:
+      - start_time: "08:00"
+        end_time: "08:50"
+        slots: 1
+        items:
+          - Doors Open & Registration
+
+      - start_time: "08:50"
+        end_time: "09:00"
+        slots: 1
+        items:
+          - Welcome & Opening Remarks
+
+      - start_time: "09:00"
+        end_time: "09:30"
+        slots: 1
+
+      - start_time: "09:40"
+        end_time: "10:10"
+        slots: 2
+
+      - start_time: "9:40"
+        end_time: "11:30"
+        slots: 1
+
+      - start_time: "10:20"
+        end_time: "10:50"
+        slots: 2
+
+      - start_time: "11:00"
+        end_time: "11:30"
+        slots: 2
+
+      - start_time: "11:40"
+        end_time: "1:10"
+        slots: 1
+        items:
+          - Lunch
+
+      - start_time: "1:20"
+        end_time: "1:50"
+        slots: 2
+
+      - start_time: "1:20"
+        end_time: "3:10"
+        slots: 1
+
+      - start_time: "2:00"
+        end_time: "2:30"
+        slots: 2
+
+      - start_time: "2:40"
+        end_time: "3:10"
+        slots: 2
+
+      - start_time: "3:20"
+        end_time: "3:50"
+        slots: 2
+
+      - start_time: "4:10"
+        end_time: "4:40"
+        slots: 1
+
+      - start_time: "4:50"
+        end_time: "5:50"
+        slots: 1
+
+      - start_time: "5:30"
+        end_time: "8:30"
+        slots: 1
+        items:
+          - title: 🎉 GitButler Afterparty 🍻
+            description: "Join us at San Francisco Brewing Co. (3150 Polk St, San Francisco, CA 94109) for an evening of food, drinks, and great conversations with fellow Rubyists! Sponsored by our Ruby friends from GitButler!"
+
+  - name: "Day 2"
+    date: "2025-11-20"
+    grid:
+      - start_time: "08:00"
+        end_time: "08:50"
+        slots: 1
+        items:
+          - Doors Open & Coffee
+
+      - start_time: "09:00"
+        end_time: "09:30"
+        slots: 1
+
+      - start_time: "09:40"
+        end_time: "10:10"
+        slots: 2
+
+      - start_time: "9:40"
+        end_time: "11:30"
+        slots: 1
+
+      - start_time: "10:20"
+        end_time: "10:50"
+        slots: 2
+
+      - start_time: "11:00"
+        end_time: "11:30"
+        slots: 2
+
+      - start_time: "11:40"
+        end_time: "1:10"
+        slots: 1
+        items:
+          - Lunch
+
+      - start_time: "1:20"
+        end_time: "1:50"
+        slots: 1
+
+      - start_time: "1:20"
+        end_time: "1:50"
+        slots: 1
+        items:
+          - title: "Open Mic"
+            description: "Our tradition at SF Ruby is a session where anyone can grab a mic for a couple minutes to share their announcements, news, or ask a question."
+
+      - start_time: "1:20"
+        end_time: "3:10"
+        slots: 1
+
+      - start_time: "2:00"
+        end_time: "2:30"
+        slots: 1
+
+      - start_time: "2:40"
+        end_time: "4:00"
+        slots: 1
+        items:
+          - title: "Startup Demos (Session 1)"
+            description: "Live demonstrations from innovative startups building with Ruby and Rails."
+
+      - start_time: "4:00"
+        end_time: "5:10"
+        slots: 1
+        items:
+          - title: "Startup Demos (Session 2)"
+            description: "Live demonstrations from innovative startups building with Ruby and Rails."
+
+      - start_time: "5:40"
+        end_time: "6:10"
+        slots: 1
+        items:
+          - title: "VC Roundtable"
+            description: "A roundtable discussion with venture capitalists interested in Ruby-based startups."
+
+      - start_time: "6:20"
+        end_time: "6:50"
+        slots: 1
+
+tracks:
+  - name: "Main Stage"
+    color: "#ffe3df"
+    text_color: "#a9000a"
+
+  - name: "Blackbox Theater"
+    color: "#d8f2ff"
+    text_color: "#0055ab"
+
+  - name: "Workshop Studio"
+    color: "#d1fae5"
+    text_color: "#065f46"

--- a/data/sf-bay-area-ruby/sfruby-2025/videos.yml
+++ b/data/sf-bay-area-ruby/sfruby-2025/videos.yml
@@ -1,126 +1,32 @@
 ---
-- title: "Keynote by Obie Fernandez"
-  raw_title: "SF Ruby 2025 - Keynote by Obie Fernandez"
-  speakers:
-    - Obie Fernandez
-  event_name: "SF Ruby 2025"
-  date: "2025-11-19"
-  published_at: "TODO"
-  description: |-
-    Obie Fernandez is a Ruby and Rails pioneer, and best-selling author of The Rails Way. With three decades in software and a string of successful startups—including Hashrocket and Andela—he's helped shape the Rails community from the start. Obie now leads AI and developer experience initiatives at Shopify, and still finds time to DJ and make music in Mexico City.
-  video_provider: "scheduled"
-  video_id: "obie-fernandez-sfruby-2025"
-
-- title: "Keynote by Vladimir Dementyev"
-  raw_title: "SF Ruby 2025 - Keynote by Vladimir (Vova) Dementyev"
-  speakers:
-    - Vladimir Dementyev
-  event_name: "SF Ruby 2025"
-  date: "2025-11-19"
-  published_at: "TODO"
-  description: |-
-    A mathematician who found his happiness in programming Ruby and Erlang, contributing to open source and being an Evil Martian. Author of AnyCable, TestProf, Action Policy and many yet unknown ukulele melodies.
-  video_provider: "scheduled"
-  video_id: "vladimir-dementyev-sfruby-2025"
-
-- title: "Keynote by Carmine Paolino"
-  raw_title: "SF Ruby 2025 - Keynote by Carmine Paolino"
-  speakers:
-    - Carmine Paolino
-  event_name: "SF Ruby 2025"
-  date: "2025-11-19"
-  published_at: "TODO"
-  description: |-
-    AI engineer and open source contributor, Carmine has built large-scale systems at OLX, Capgemini, and the Alan Turing Institute. He's the creator of RubyLLM, bringing modern AI tooling to Ruby, and has co-founded startups like Freshflow, and Chat with Work. Carmine loves Ruby, deep learning, and producing electronic music in Berlin.
-  video_provider: "scheduled"
-  video_id: "carmine-paolino-sfruby-2025"
-
-- title: "Keynote by Marco Roth"
-  raw_title: "SF Ruby 2025 - Keynote by Marco Roth"
+- title: "ReActionView: An ActionView-Compatible ERB Engine"
+  raw_title: "ReActionView: An ActionView-Compatible ERB Engine"
   speakers:
     - Marco Roth
   event_name: "SF Ruby 2025"
   date: "2025-11-19"
   published_at: "TODO"
   description: |-
-    Full-stack Ruby on Rails developer and open source enthusiast, Marco is a core contributor to Hotwire and StimulusReflex. He's passionate about pushing the boundaries of real-time, server-rendered apps with HTML-over-the-wire, and maintains several key libraries in the Hotwire and Rails ecosystem.
+    This talk is the conclusion of a journey I’ve been sharing throughout 2025. At RubyKaigi, I introduced Herb: a new HTML-aware ERB parser and tooling ecosystem. At RailsConf, I released developer tools built on Herb, including a formatter, linter, and language server, alongside a vision for modernizing and improving the Rails view layer.
+  track: "Main Stage"
   video_provider: "scheduled"
   video_id: "marco-roth-sfruby-2025"
 
-- title: "Talk by Dave Thomas"
-  raw_title: "SF Ruby 2025 - Talk by Dave Thomas"
+- title: "Play with your code"
+  raw_title: "Play with your code"
   speakers:
-    - Dave Thomas
+    - Rachael Wright-Munn
   event_name: "SF Ruby 2025"
   date: "2025-11-19"
   published_at: "TODO"
   description: |-
-    Dave Thomas is likely the oldest living Ruby developer.
+    Why are programming games more fun than our day jobs? We're going to dig into this exact question and see what lessons we can learn from them, and how we can bring it back to our developer experience. Also, we're going to talk about some rad programming games you should play!
+  track: "Main Stage"
   video_provider: "scheduled"
-  video_id: "dave-thomas-sfruby-2025"
+  video_id: "rachael-wright-munn-sfruby-2025"
 
-- title: "Talk by Sam Poder"
-  raw_title: "SF Ruby 2025 - Talk by Sam Poder"
-  speakers:
-    - Sam Poder
-  event_name: "SF Ruby 2025"
-  date: "2025-11-19"
-  published_at: "TODO"
-  description: |-
-    Sam is a software engineer at Hack Club and a third-year Computer Science & Linguistics student at UC Berkeley. He enjoys making things, hackathons and going on random adventures (often using public transit).
-  video_provider: "scheduled"
-  video_id: "sam-poder-sfruby-2025"
-
-- title: "Talk by Ben Sheldon"
-  raw_title: "SF Ruby 2025 - Talk by Ben Sheldon"
-  speakers:
-    - Ben Sheldon
-  event_name: "SF Ruby 2025"
-  date: "2025-11-19"
-  published_at: "TODO"
-  description: |-
-    Ben is the author of GoodJob, an Active Job backend. A Rails developer for over 10 years, he has worked at GitHub, OkCupid Labs, and Code for America. Ben is currently co-founder and CTO of Frontdoor Benefits.
-  video_provider: "scheduled"
-  video_id: "ben-sheldon-sfruby-2025"
-
-- title: "Talk by Adrian Marin"
-  raw_title: "SF Ruby 2025 - Talk by Adrian Marin"
-  speakers:
-    - Adrian Marin
-  event_name: "SF Ruby 2025"
-  date: "2025-11-19"
-  published_at: "TODO"
-  description: |-
-    Adrian is a product-minded engineer, open-source maintainer, the author of Avo and Marksmith for Rails, and co-host of Friendly.rb conference and Friendly.show podcast.
-  video_provider: "scheduled"
-  video_id: "adrian-marin-sfruby-2025"
-
-- title: "Talk by Ngan Pham"
-  raw_title: "SF Ruby 2025 - Talk by Ngan Pham"
-  speakers:
-    - Ngan Pham
-  event_name: "SF Ruby 2025"
-  date: "2025-11-19"
-  published_at: "TODO"
-  description: |-
-    Ngan is a prolific open source contributor and Rubyist with a knack for scaling systems and building strong engineering teams. He's known for mentoring developers and sharing insights on everything from Rails architecture to developer happiness. Outside of work he loves traveling with his family.
-  video_provider: "scheduled"
-  video_id: "ngan-pham-sfruby-2025"
-
-- title: "Talk by Noel Rappin"
-  raw_title: "SF Ruby 2025 - Talk by Noel Rappin"
-  speakers:
-    - Noel Rappin
-  event_name: "SF Ruby 2025"
-  date: "2025-11-19"
-  published_at: "TODO"
-  description: |-
-    Noel is the co-author of Programming Ruby 3.3 and other technical books in the Ruby Community. He's dedicated to making Ruby joyful and productive for developers, and is known for building community and championing better tools and practices. You can find Noel online at noelrappin.com.
-  video_provider: "scheduled"
-  video_id: "noel-rappin-sfruby-2025"
-
-- title: "Talk by Fito von Zastrow and Alan Ridlehoover"
-  raw_title: "SF Ruby 2025 - Talk by Alan Ridlehoover"
+- title: "Derailing Our Application: How and Why We Are Decoupling Our Code from Rails"
+  raw_title: "Derailing Our Application: How and Why We Are Decoupling Our Code from Rails"
   speakers:
     - Fito von Zastrow
     - Alan Ridlehoover
@@ -128,206 +34,114 @@
   date: "2025-11-19"
   published_at: "TODO"
   description: |-
-    Fito is a Staff Software Engineer @ Cisco's Network Platform. He is a SF Bay Area transplant from Asunción, Paraguay. He enjoys hiking, watching soccer, video games, and pair-programming.
+    Successful Rails apps tend to become massive monoliths over time. Our's is no exception. Our team is over 1000 engineers. Our codebase is over 4 million lines of Ruby.
 
-    Alan is a Passionate Rubyist. Empathetic leader. Fallible human. Swell photographer. Rusty drummer. Loving husband & twins dad. Owner of too many hats, given I only have the one head.
+    But, Rails doesn't tell you how to manage that many developers working on that large a codebase. So, we're encouraging modularization and boundaries within our codebase. Our approach is lightweight and actually producing results.
+
+    We're the right ones to talk about this because we're the one's issuing the guidance internally.
+  track: "Blackbox Theater"
   video_provider: "scheduled"
   video_id: "fito-von-zastrow-alan-ridlehoover-sfruby-2025"
 
-- title: "Talk by JP Camara"
-  raw_title: "SF Ruby 2025 - Talk by JP Camara"
-  speakers:
-    - JP Camara
-  event_name: "SF Ruby 2025"
-  date: "2025-11-19"
-  published_at: "TODO"
-  description: |-
-    Ruby committer. Blog writer. Concurrency enthusiast. Principal Engineer at Wealthbox CRM.
-  video_provider: "scheduled"
-  video_id: "jp-camara-sfruby-2025"
-
-- title: "Talk by Paweł Strzałkowski"
-  raw_title: "SF Ruby 2025 - Talk by Paweł Strzałkowski"
-  speakers:
-    - Paweł Strzałkowski
-  event_name: "SF Ruby 2025"
-  date: "2025-11-19"
-  published_at: "TODO"
-  description: |-
-    CTO, consultant and full-stack developer since the 90s. Author of many articles showing a creative approach to using Rails. Currently excited about AI's potential and cross-tech discoveries. Frequent speaker at conferences/meetups and a big supporter of the European Ruby scene. Builds games for fun.
-  video_provider: "scheduled"
-  video_id: "pawel-strzalkowski-sfruby-2025"
-
-- title: "Talk by Takashi Kokubun"
-  raw_title: "SF Ruby 2025 - Talk by Takashi Kokubun"
-  speakers:
-    - Takashi Kokubun
-  event_name: "SF Ruby 2025"
-  date: "2025-11-19"
-  published_at: "TODO"
-  description: |-
-    Takashi Kokubun is a Ruby committer and a member of Shopify's Ruby Infrastructure team. He's currently working on ZJIT, the next generation of YJIT. He has been working on JIT compilers for Ruby since 2017.
-  video_provider: "scheduled"
-  video_id: "takashi-kokubun-sfruby-2025"
-
-- title: "Talk by Justin Bowen"
-  raw_title: "SF Ruby 2025 - Talk by Justin Bowen"
+- title: "Building Agents with Rails"
+  raw_title: "Building Agents with Rails"
   speakers:
     - Justin Bowen
   event_name: "SF Ruby 2025"
   date: "2025-11-19"
   published_at: "TODO"
   description: |-
-    Justin is the creator of Active Agent, the first truly Rails-native AI framework, where Agents are Controllers. Since 2015, he's been building real-world AI products in agriculture, healthcare, HR tech, and more, with a specialization in computer vision. His work with Active Agent combines his extensive experience in Python and Next.js, bringing it to Rails with the goal of making Ruby the language of choice for new startups in the AI age.
+    Hands-on workshop for building AI agents using Rails framework and modern AI tools.
+  track: "Workshop Studio"
   video_provider: "scheduled"
   video_id: "justin-bowen-sfruby-2025"
 
-- title: "Talk by Colleen Schnettler"
-  raw_title: "SF Ruby 2025 - Talk by Colleen Schnettler"
+- title: "Real-time collaboration with Rails, AnyCable and Yjs"
+  raw_title: "Real-time collaboration with Rails, AnyCable and Yjs"
   speakers:
-    - Colleen Schnettler
+    - JP Camara
   event_name: "SF Ruby 2025"
   date: "2025-11-19"
   published_at: "TODO"
   description: |-
-    Colleen is a Rails dev, AI consultant, and startup founder. She built Simple File Upload and HelloQuery (a TinySeed-backed startup), then started SaaS Marketing Gym to help technical founders grow. When she's not building or teaching, she's climbing mountains because they're the only thing that won't pivot.
-  video_provider: "scheduled"
-  video_id: "colleen-schnettler-sfruby-2025"
+    Real-time collaboration is a powerful tool for web apps, but difficult to implement. Most Ruby developers lack CRDT exposure and collaborative software challenges like conflict resolution and distributed consistency. This talk shows how to leverage Rails while adding sophisticated collaborative features using AnyCable to boost ActionCable performance and Yjs to simplify collaborative editing.
 
-- title: "Talk by Mike Perham"
-  raw_title: "SF Ruby 2025 - Talk by Mike Perham"
-  speakers:
-    - Mike Perham
-  event_name: "SF Ruby 2025"
-  date: "2025-11-19"
-  published_at: "TODO"
-  description: |-
-    Mike is the author and maintainer of Sidekiq, the leading background job framework for Ruby. He's developed open source software for Ruby since 2005 and lives in Portland, OR.
+    I've specifically been implementing this approach in a production Rails setting, giving me a solid perspective on the challenges involved.
+  track: "Main Stage"
   video_provider: "scheduled"
-  video_id: "mike-perham-sfruby-2025"
+  video_id: "jp-camara-sfruby-2025"
 
-- title: "Talk by Brandon Weaver"
-  raw_title: "SF Ruby 2025 - Talk by Brandon Weaver"
+- title: "Rails Expertise, Distilled: AI Agents That Get Your Monolith"
+  raw_title: "Rails Expertise, Distilled: AI Agents That Get Your Monolith"
   speakers:
     - Brandon Weaver
   event_name: "SF Ruby 2025"
   date: "2025-11-19"
   published_at: "TODO"
   description: |-
-    Brandon is an artist turned programmer who teaches Ruby with a series of colorful cartoon lemurs going on storybook adventures. This time though? He's going deep on AI and Rails.
+    New developers face months of unproductive confusion when dropped into massive codebases they can't navigate or understand. What if they could get instant answers about how systems work, identify what code needs changing, and understand complex business logic without waiting for help? This talk demonstrates how Rails' built-in introspection transforms into expert AI tools that understand your specific codebase, making institutional knowledge accessible 24/7. Instead of 3-month ramp-ups, developers contribute meaningfully in days while the entire team stays productive.
+  track: "Blackbox Theater"
   video_provider: "scheduled"
   video_id: "brandon-weaver-sfruby-2025"
 
-- title: "Talk by Enrique Carlos Mogollán"
-  raw_title: "SF Ruby 2025 - Talk by Enrique Carlos Mogollán"
+- title: "Master the Rails Asset Pipeline: Best Practices for Apps & Gems"
+  raw_title: "Master the Rails Asset Pipeline: Best Practices for Apps & Gems"
   speakers:
-    - Enrique Carlos Mogollán
+    - Adrian Marin
   event_name: "SF Ruby 2025"
   date: "2025-11-19"
   published_at: "TODO"
   description: |-
-    Enrique enjoys writing software, reading, traveling and it's a big fan of spicy food.
-  video_provider: "scheduled"
-  video_id: "enrique-carlos-mogollan-sfruby-2025"
+    I toyed around with asset handling a lot in the last 4 years. I started in the pre-webpacker era, and came all the way to importmaps, esbuild and vite.
 
-- title: "Talk by Rachael Wright-Munn"
-  raw_title: "SF Ruby 2025 - Talk by Rachael Wright-Munn"
+    I ship a gem (Avo), which is used in hundreds of different applications with different asset pipeline configurations, and use several techniques to ship my assets.
+
+    Now I'm developing a plugin system and have hit all the roadblocks I can hit and have a better understanding of how things work.
+  track: "Main Stage"
+  video_provider: "scheduled"
+  video_id: "adrian-marin-sfruby-2025"
+
+- title: "Performance starts at boot"
+  raw_title: "Performance starts at boot"
   speakers:
-    - Rachael Wright-Munn
+    - Ben Sheldon
   event_name: "SF Ruby 2025"
   date: "2025-11-19"
   published_at: "TODO"
   description: |-
-    Rachael wants to share the joy and beauty of programming through programming games and regular open-source streams on Twitch. She's been a software engineer since 2012, 3x Team Lead, and manages a few small open-source projects.
+    Everyone can better understand how their Ruby code performs, regardless of whether they're using Rails or Hanami or just scripting with Ruby. As applications grow, I frequently see inside-out application performance work ignored or unacceptably tolerated ("that's just the way it is [sigh]").
+  track: "Blackbox Theater"
   video_provider: "scheduled"
-  video_id: "rachael-wright-munn-sfruby-2025"
+  video_id: "ben-sheldon-sfruby-2025"
 
-- title: "Talk by Naijeria Toweett"
-  raw_title: "SF Ruby 2025 - Talk by Naijeria Toweett"
+- title: "ZJIT: The Future of Ruby Performance"
+  raw_title: "ZJIT: The Future of Ruby Performance"
   speakers:
-    - Naijeria Toweett
+    - Takashi Kokubun
   event_name: "SF Ruby 2025"
   date: "2025-11-19"
   published_at: "TODO"
   description: |-
-    Naijeria entered the Ruby world at Friendly.rb 2023. Since then, she's grown from newcomer to community builder—now serving on the Ruby Central board and helping lead WNB.rb Africa Chapter. She's a product manager turned product engineer, focused on inclusive, user-centered tech.
+    Since Rails 7.2 enabled YJIT by default, it has been widely adopted by the Ruby community, delivering a 10-20% speedup in various production workloads. To enhance Ruby's speed even further, we're developing the next generation of YJIT for Ruby 3.5: ZJIT. In this talk, we'll delve into the exciting future of Ruby performance that ZJIT will unlock.
+  track: "Main Stage"
   video_provider: "scheduled"
-  video_id: "naijeria-toweett-sfruby-2025"
+  video_id: "takashi-kokubun-sfruby-2025"
 
-- title: "Talk by Tia Anderson"
-  raw_title: "SF Ruby 2025 - Talk by Tia Anderson"
+- title: "Peace, Love, and CRUD: Finding Calm in the Chaos—With Ruby, AI, and a Little Garden Magic"
+  raw_title: "Peace, Love, and CRUD: Finding Calm in the Chaos—With Ruby, AI, and a Little Garden Magic"
   speakers:
     - Tia Anderson
   event_name: "SF Ruby 2025"
   date: "2025-11-19"
   published_at: "TODO"
   description: |-
-    Tia is a Ruby on Rails developer, RailsConf 2025 Scholar, and creator of Peace of Mind—a journaling and gardening app powered by CRUD and calm. She's on a mission to build tools that heal, not just hustle. When not coding, you'll find her in the garden… or journaling about it.
+    This talk matters because we are enduring death by a thousand quiet cuts. The world asks us to go faster while our spirits beg us to slow down. Emotional exhaustion has become the norm, but it doesn't have to be. I built Peace of Mind not just with Rails, but with urgency and heart. As a newer dev and RailsConf Scholar, I've lived the tension between burnout and beauty. Choosing peace...in our work, our lives, and our code creates ripples. It starts with one. One you. One me.
+  track: "Blackbox Theater"
   video_provider: "scheduled"
   video_id: "tia-anderson-sfruby-2025"
 
-- title: "Talk by Sarah Mei"
-  raw_title: "SF Ruby 2025 - Talk by Sarah Mei"
-  speakers:
-    - Sarah Mei
-  event_name: "SF Ruby 2025"
-  date: "2025-11-19"
-  published_at: "TODO"
-  description: |-
-    Sarah is a software engineer, writer, and technical advisor with over two decades of experience building & leading development teams. Formerly Head of Eng at BackerKit, she now focuses on the intersection of AI & software development, exploring how emerging tools are reshaping how we build.
-  video_provider: "scheduled"
-  video_id: "sarah-mei-sfruby-2025"
-
-- title: "Workshop by Kasper Timm Hansen"
-  raw_title: "SF Ruby 2025 - Workshop by Kasper Timm Hansen"
-  speakers:
-    - Kasper Timm Hansen
-  event_name: "SF Ruby 2025"
-  date: "2025-11-19"
-  published_at: "TODO"
-  description: |-
-    Kasper is a staff-level Rails consultant, who runs Rails source deep-dives for teams helping them level up faster. He was on the Rails core team from 2016 to 2022 and the top 11th contributor when he left. He shipped several major features, and reviewed & merged over a thousand contributor PRs.
-  video_provider: "scheduled"
-  video_id: "kasper-timm-hansen-sfruby-2025"
-
-- title: "Talk by André Arko"
-  raw_title: "SF Ruby 2025 - Talk by André Arko"
-  speakers:
-    - André Arko
-  event_name: "SF Ruby 2025"
-  date: "2025-11-19"
-  published_at: "TODO"
-  description: |-
-    André thinks Ruby is pretty neat. He's been using Ruby since 2003, Rails since 2004, and on the Bundler team since 2009, and wrote _The Ruby Way_ (3rd Ed.) in 2015. These days, he's a principal engineer for hire at cloudcity.io while building tools to make on-call better at sunchaser.io.
-  video_provider: "scheduled"
-  video_id: "andre-arko-sfruby-2025"
-
-- title: "Talk by Jeremy Evans"
-  raw_title: "SF Ruby 2025 - Talk by Jeremy Evans"
-  speakers:
-    - Jeremy Evans
-  event_name: "SF Ruby 2025"
-  date: "2025-11-19"
-  published_at: "TODO"
-  description: |-
-    Jeremy Evans is a Ruby committer who focuses on fixing bugs in Ruby. He the lead developer of Sequel, Roda, Rodauth, and many other Ruby libraries. He is the author of "Polished Ruby Programming".
-  video_provider: "scheduled"
-  video_id: "jeremy-evans-sfruby-2025"
-
-- title: "Talk by Evgeny Li"
-  raw_title: "SF Ruby 2025 - Talk by Evgeny Li"
-  speakers:
-    - Evgeny Li
-  event_name: "SF Ruby 2025"
-  date: "2025-11-19"
-  published_at: "TODO"
-  description: |-
-    Evgeny created popular open-source Ruby and Rails projects used by companies like GitLab, Netflix, and AngelList. A passionate speaker, he's presented at RailsConf, on Ruby Rogues, and at local meetups. After a decade of Ruby experience at various companies, he decided to build his own startup.
-  video_provider: "scheduled"
-  video_id: "evgeny-li-sfruby-2025"
-
-- title: "Workshop: Inertia Rails"
-  raw_title: "SF Ruby 2025 - Talk by Svyatoslav Kryukov"
+- title: "Inertia Rails Workshop"
+  raw_title: "Inertia Rails Workshop"
   speakers:
     - Brandon Shar
     - Brian Knoles
@@ -336,22 +150,290 @@
   date: "2025-11-19"
   published_at: "TODO"
   description: |-
-    Brandon is a Staff Software Engineer focused on AI product development. Co-creator of Inertia Rails and Inertia Django. Passionate about full-stack engineering, product focused development, and expressive, simple, and changeable code. Currently hooked on MCP servers and AI-enabled productivity boosts.
-
-    Brian leads development at Bellawatt, a software consultancy that works with energy companies. He's a co-author of Inertia Rails and loves using Rails and React together. He's known to say "I wonder..." a lot, and he often spends the daily walks with his inexhaustible dog lost in thought.
-
-    Svyat is passionate about bridging backend and frontend worlds in Ruby. He's the creator of Skooma for strong interfaces and TurboMount for bringing modern widgets to Hotwire, and a key contributor to Inertia Rails. When he's not coding, Svyat is a true coffee geek, always searching for the perfect pour over setup.
+    Inertia.js solves a huge pain point for server side MVC frameworks: clean integration with rich client-side libraries like React, Vue, and Svelte. Inertia Rails allows both sides of this equation to shine. The Rails code looks almost exactly like vanilla Rails code (without the view layer), which keeps existing Rails teams productive. On the client, Inertia Rails takes away a lot of the headaches in gluing React and Rails together: session based auth, server side global state management, and Inertia form submissions make life much easier on teams.
+  track: "Workshop Studio"
   video_provider: "scheduled"
   video_id: "inertia-rails-workshop-sfruby-2025"
 
-- title: "CTO Panel"
-  raw_title: "SF Ruby 2025 - CTO Panel featuring Edward Kim"
+- title: "Navigating programming language evolution in the AI era"
+  raw_title: "Navigating programming language evolution in the AI era - SF Ruby 2025"
   speakers:
-    - Edward Kim
+    - José Valim
   event_name: "SF Ruby 2025"
   date: "2025-11-19"
   published_at: "TODO"
   description: |-
-    Edward leads the long-term technology roadmap for Gusto, including major platform initiatives such as Artificial Intelligence. He also empowers Security and IT. Before co-founding Gusto, Edward was the CEO and co-founder of Picwing, a Y Combinator startup and photo-printing platform. Edward holds bachelor's and master's degrees in Electrical Engineering from Stanford University.
+    As AI becomes increasingly integrated into software development, we find ourselves facing questions about how our programming languages and tools should evolve - questions that don't yet have clear answers. Rather than prescribing solutions, this talk explores the open questions and possible directions that developers and tooling authors should be grappling with.
+  track: "Main Stage"
   video_provider: "scheduled"
-  video_id: "cto-panel-edward-kim-sfruby-2025"
+  video_id: "jose-valim-sfruby-2025"
+
+- title: "AI Interface in 5 Minutes - Model Context Protocol on Rails"
+  raw_title: "AI Interface in 5 Minutes - Model Context Protocol on Rails"
+  speakers:
+    - Paweł Strzałkowski
+  event_name: "SF Ruby 2025"
+  date: "2025-11-19"
+  published_at: "TODO"
+  description: |-
+    This talk delivers a low-risk, high-value AI strategy that applies to any Rails app, new or old. It proves the ecosystem's power to modernize existing assets in the AI era without the need for expensive rewrites. It teaches one of the key aspects of the modern AI tech stack, giving a competitive advantage.
+
+    I'm a CTO, a veteran Rails developer and a vetted conference speaker. My expertise on a similar topic is validated by my upcoming talks at Rails World and EuRuKo this year. I'm excited to bring this timely material to the US community
+  track: "Blackbox Theater"
+  video_provider: "scheduled"
+  video_id: "pawel-strzalkowski-sfruby-2025"
+
+- title: "Start Writing Ruby (Stop Using Classes)"
+  raw_title: "Start Writing Ruby (Stop Using Classes)"
+  speakers:
+    - Dave Thomas
+  event_name: "SF Ruby 2025"
+  date: "2025-11-19"
+  published_at: "TODO"
+  description: |-
+    We are writing our Ruby code wrongly. We're using classes as the unit of design; we needn't, and we shouldn't. We use design patterns as recipes; they're largely irrelevant. We come up with arcane project structures and convoluted deployment systems; we needn't.
+
+    For the last half-decade, I've been writing Ruby very differently to my previous style. Almost no classes. Creating structure as it grows, rather than before I start. Drastically cutting down dependencies. The result: my code seems drastically easier to write, maintain, and reuse.
+
+    I'd like the opportunity the spread the word.
+  track: "Main Stage"
+  video_provider: "scheduled"
+  video_id: "dave-thomas-sfruby-2025"
+
+- title: "The MCP Fog Made Me Do It: A Ruby Inspector's Unexpected Journey"
+  raw_title: "The MCP Fog Made Me Do It: A Ruby Inspector's Unexpected Journey"
+  speakers:
+    - Enrique Mogollán
+  event_name: "SF Ruby 2025"
+  date: "2025-11-19"
+  published_at: "TODO"
+  description: |-
+    MCP is still pretty foggy for most developers, and Ruby shouldn't be left out of the AI tooling party. This story shows how a simple "let me figure this out" project can accidentally become something fun and interesting to share. I've been learning about MCP, from the official ruby SDK, and stumbled onto this idea of self-generating UI interfaces. If you've ever stared a new project and wondered "how do I even start?", this talk is one example from foggy confusion to sunshine moment of "holy smokes, I didn't know that was possible." Besides, Ruby deserves a seat at the AI table.
+  track: "Blackbox Theater"
+  video_provider: "scheduled"
+  video_id: "enrique-carlos-mogollan-sfruby-2025"
+
+- title: "Debugging Gusto at scale"
+  raw_title: "Debugging Gusto at scale"
+  speakers:
+    - Ngan Pham
+  event_name: "SF Ruby 2025"
+  date: "2025-11-19"
+  published_at: "TODO"
+  description: |-
+    Real-world strategies for debugging large-scale Rails applications at Gusto.
+  track: "Main Stage"
+  video_provider: "scheduled"
+  video_id: "ngan-pham-sfruby-2025"
+
+- title: "Building Cloud Data Infrastructure with Ruby"
+  raw_title: "Building Cloud Data Infrastructure with Ruby"
+  speakers:
+    - Evgeny Li
+  event_name: "SF Ruby 2025"
+  date: "2025-11-19"
+  published_at: "TODO"
+  description: |-
+    Ruby isn't just for web development. Discover why Ruby is a great choice for building and automating modern cloud data infrastructure. Learn real-world lessons from BemiDB, a data analytics platform. You'll gain practical skills and be inspired to leverage Ruby for your next infrastructure project!
+  track: "Blackbox Theater"
+  video_provider: "scheduled"
+  video_id: "evgeny-li-sfruby-2025"
+
+- title: "Ruby & AI conversation"
+  raw_title: "Ruby & AI conversation"
+  speakers:
+    - Obie Fernandez
+  event_name: "SF Ruby 2025"
+  date: "2025-11-19"
+  published_at: "TODO"
+  description: |-
+    A conversation about the intersection of Ruby and AI technologies, exploring opportunities and challenges.
+  track: "Main Stage"
+  video_provider: "scheduled"
+  video_id: "obie-fernandez-sfruby-2025"
+
+- title: "CTO Panel"
+  raw_title: "CTO Panel"
+  speakers:
+    - Edward Kim
+    - Ryan King
+  event_name: "SF Ruby 2025"
+  date: "2025-11-19"
+  published_at: "TODO"
+  description: |-
+    A roundtable discussion with CTOs from the Ruby community.
+  track: "Main Stage"
+  video_provider: "scheduled"
+  video_id: "cto-panel-sfruby-2025"
+
+- title: "RubyLLM: One API, One Person, One Machine for AI"
+  raw_title: "RubyLLM: One API, One Person, One Machine for AI"
+  speakers:
+    - Carmine Paolino
+  event_name: "SF Ruby 2025"
+  date: "2025-11-20"
+  published_at: "TODO"
+  description: |-
+    The Merchants of Complexity have sold the AI world a lie. You need their frameworks. Their SDKs. Their enterprise architectures. Bullshit. AI today is just API calls. That's it. And when the game becomes building products instead of training models, complexity is death and simplicity is everything. Rails proved it.
+
+    RubyLLM: one API for every model, every vendor. One developer on one machine serving thousands. While Python developers debug their 14-line "Hello World," we're shipping. Ruby's time in AI isn't coming - it's here.
+  track: "Main Stage"
+  video_provider: "scheduled"
+  video_id: "carmine-paolino-sfruby-2025"
+
+- title: "From code to customers: technical marketing for people who'd rather be building"
+  raw_title: "From code to customers: technical marketing for people who'd rather be building"
+  speakers:
+    - Colleen Schnettler
+  event_name: "SF Ruby 2025"
+  date: "2025-11-20"
+  published_at: "TODO"
+  description: |-
+    Too many brilliant Rails developers build great products and then quit when customers don't appear.
+
+    They're missing one skill: marketing. I want to change that.
+
+    The Rails renaissance is here (huge thanks to Evil Martians!), and I believe helping Rails builders become successful entrepreneurs is crucial for our community's future. This might be the conference's most impactful talk.
+
+    Why me? I'm a technical founder who's built three startups and now coach technical founders on marketing. I've lived this journey and help others navigate it daily.
+  track: "Main Stage"
+  video_provider: "scheduled"
+  video_id: "colleen-schnettler-sfruby-2025"
+
+- title: "Operating rails: what about after you deploy?"
+  raw_title: "Operating rails: what about after you deploy?"
+  speakers:
+    - André Arko
+  event_name: "SF Ruby 2025"
+  date: "2025-11-20"
+  published_at: "TODO"
+  description: |-
+    Running a web service requires you to do so many things that aren't included in any programming books or tutorials. We need more developers able to ship services that work, rather than expecting each developer to figure out the entire list by trial and error, one at a time, by themselves. Blog posts with individual tips about isolated problems don't cut it either, because no one is creating a field survey or a checklist of the overall process and making sure developers are aware of and ready for what they'll face in production.
+  track: "Blackbox Theater"
+  video_provider: "scheduled"
+  video_id: "andre-arko-sfruby-2025"
+
+- title: "Upskill Your Team by Diving into Rails itself & other Gems"
+  raw_title: "Upskill Your Team by Diving into Rails itself & other Gems"
+  speakers:
+    - Kasper Timm Hansen
+  event_name: "SF Ruby 2025"
+  date: "2025-11-20"
+  published_at: "TODO"
+  description: |-
+    There's a ton of untapped potential in Rails and other gem source for upskilling that teams aren't leveraging because they don't know how. And there's almost no content showing how.
+
+    This problem hurts Ruby open source, because teams don't know how to contribute or make gems (exposure to real open source code is the first step IMO).
+
+    I've given several Rails source deep-dive workshops over Zoom that 70+ people have attended. I've shown a live-demo of this on stage at RailsConf that attendees raved about.
+  track: "Workshop Studio"
+  video_provider: "scheduled"
+  video_id: "kasper-timm-hansen-sfruby-2025"
+
+- title: "The Thin CLIent Approach"
+  raw_title: "The Thin CLIent Approach"
+  speakers:
+    - Jeremy Evans
+  event_name: "SF Ruby 2025"
+  date: "2025-11-20"
+  published_at: "TODO"
+  description: |-
+    This presentation will discuss a novel approach to CLI development, where the command line arguments are passed to an endpoint instead of being parsed by the client program, and the advantages and disadvantages doing so. It will discuss the development of a new command line argument parsing library, cross compiling client line programs, and how this approach enabled usage of the CLI without installation, by integrating support for it into a web application.
+  track: "Main Stage"
+  video_provider: "scheduled"
+  video_id: "jeremy-evans-sfruby-2025"
+
+- title: "Shipping Solo with Rails 8: Building Dada the African Menopause Companion"
+  raw_title: "Shipping Solo with Rails 8: Building Dada the African Menopause Companion"
+  speakers:
+    - Naijeria Toweett
+  event_name: "SF Ruby 2025"
+  date: "2025-11-20"
+  published_at: "TODO"
+  description: |-
+    This talk shows what Ruby and Rails do best: enabling solo developers to build meaningful, user-focused apps with speed, clarity, and joy. I've spent 15 years in the NGO and social impact space, where I've seen huge amounts of money wasted on overbuilt tech that communities didn't need. I'm now using Rails 8, open-source tools, and user-driven design to build DADA — a real product for a deeply underserved audience. I'm living proof that Ruby still empowers builders to move fast, stay lean, and create software that actually helps people.
+  track: "Blackbox Theater"
+  video_provider: "scheduled"
+  video_id: "naijeria-toweett-sfruby-2025"
+
+- title: "The Role of Software Design in an AI World"
+  raw_title: "The Role of Software Design in an AI World"
+  speakers:
+    - Sarah Mei
+  event_name: "SF Ruby 2025"
+  date: "2025-11-20"
+  published_at: "TODO"
+  description: |-
+    Ruby devs, like all devs, are nervous about their worth in an AI world. This talk gives them reason to be optimistic, & will start to open for them a vista in which they are enhanced by AI rather than being replaced.
+
+    For 10+ years I've spoken, written, & thought deeply about software design. For the last 6 months I've worked with code assistants to see what they can do in real Rails codebases - not new projects or toy apps. I've got some initial conclusions that are worth sharing widely.
+  track: "Main Stage"
+  video_provider: "scheduled"
+  video_id: "sarah-mei-sfruby-2025"
+
+- title: "How to open-source your Rails startup"
+  raw_title: "How to open-source your Rails startup"
+  speakers:
+    - Sam Poder
+  event_name: "SF Ruby 2025"
+  date: "2025-11-20"
+  published_at: "TODO"
+  description: |-
+    As Rails developers, we develop on the shoulders of giants. We can do what we can do because of the work of thousands of open source contributors; I want to encourage more developers to give back through open sourcing their work.
+
+    This also isn't a subject talked about often and having just taken a codebase from open to closed source, I can offer a unique perspective. I remember struggling with a lack of resources of the subject when we started the project. Hopefully this talk can make it easier for the next person who open sources their codebase.
+  track: "Blackbox Theater"
+  video_provider: "scheduled"
+  video_id: "sam-poder-sfruby-2025"
+
+- title: "Open source as a business with Sidekiq"
+  raw_title: "Open source as a business with Sidekiq"
+  speakers:
+    - Mike Perham
+  event_name: "SF Ruby 2025"
+  date: "2025-11-20"
+  published_at: "TODO"
+  description: |-
+    Learn how to build a successful open source business model from the creator of Sidekiq.
+  track: "Main Stage"
+  video_provider: "scheduled"
+  video_id: "mike-perham-sfruby-2025"
+
+- title: "The Dynamic Ruby Toolkit"
+  raw_title: "The Dynamic Ruby Toolkit"
+  speakers:
+    - Noel Rappin
+  event_name: "SF Ruby 2025"
+  date: "2025-11-20"
+  published_at: "TODO"
+  description: |-
+    Ruby rewards thinking about types with a dynamic mindset instead of a static one. In this workshop, we’ll show how use Ruby’s dynamism to your advantage. From the humble comment to runtime type checking, from tests to debugging techniques, from data management to true object-oriented design, this workshop will give you the tools you need to bring out Ruby’s full power.
+  track: "Workshop Studio"
+  video_provider: "scheduled"
+  video_id: "noel-rappin-sfruby-2025"
+
+- title: "Scaling Rails to two million MySQL requests per second"
+  raw_title: "Scaling Rails to two million MySQL requests per second"
+  speakers:
+    - Eugene Kenny
+  event_name: "SF Ruby 2025"
+  date: "2025-11-20"
+  published_at: "TODO"
+  description: |-
+    I whistle stop tour of various patterns and techniques Intercom's monolith used to go from rails new intercom to comfortably scaling to over two million MySQL requests per second. Expect practical takeaways on replication, sharding, caching, connection routing, and upgrade strategy, plus the bumps and trade‑offs we hit along the way.
+  track: "Main Stage"
+  video_provider: "scheduled"
+  video_id: "eugene-kenny-sfruby-2025"
+
+- title: "Keynote by Vladimir Dementyev"
+  raw_title: "SF Ruby 2025 - Keynote by Vladimir (Vova) Dementyev"
+  speakers:
+    - Vladimir Dementyev
+  event_name: "SF Ruby 2025"
+  date: "2025-11-20"
+  published_at: "TODO"
+  description: |-
+    A mathematician who found his happiness in programming Ruby and Erlang, contributing to open source and being an Evil Martian. Author of AnyCable, TestProf, Action Policy and many yet unknown ukulele melodies.
+  track: "Main Stage"
+  video_provider: "scheduled"
+  video_id: "vladimir-dementyev-sfruby-2025"

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -7200,14 +7200,7 @@
   website: https://enricoteotti.com
   slug: enrico-teotti
   canonical_slug:
-- name: Enrique Carlos Mogollán
-  twitter: ""
-  github: ""
-  bio: ""
-  website: ""
-  slug: enrique-carlos-mogollan
-  canonical_slug:
-- name: Enrique Mogollan
+- name: Enrique Mogollán
   twitter: ""
   github: mogox
   bio: ""
@@ -7530,6 +7523,13 @@
   website: ""
   slug: eugene-kalenkovich
   canonical_slug:
+- name: Eugene Kenny
+  twitter: ""
+  github: eugeneius
+  bio: ""
+  website: ""
+  slug: eugene-kenny
+  canonical_slug:
 - name: Evan D. Light
   twitter: ""
   github: ""
@@ -7595,7 +7595,7 @@
   canonical_slug:
 - name: Evgeny Li
   twitter: ""
-  github: ""
+  github: exAspArk
   bio: ""
   website: ""
   slug: evgeny-li
@@ -17876,7 +17876,7 @@
   canonical_slug:
 - name: Ngan Pham
   twitter: ""
-  github: ""
+  github: ngan
   bio: ""
   website: ""
   slug: ngan-pham


### PR DESCRIPTION
# Description

This PR adds the schedule to SF Ruby Conference and updates the talk titles and descriptions now that they are available.

- I made the raw_title match the talk title. If this should be formatted differently, please lmk.
- I kept the slugs that were `speaker-name-sf-ruby-2025`. Some of the titles are pretty long. If you want that updated, lmk.
- I added the rooms as tracks. I didn't see any prior art on this, but I think it looks good, so if you want it changed, lmk.

### Event schedule updates:

* Added a detailed schedule for the SF Bay Area Ruby 2025 event in `sfruby-2025/schedule.yml`, including session times, special events, and track information.

### Speaker name and profile corrections:

* Standardized the spelling of "Enrique Mogollán" (with accent) in both `rubyconf-2024/videos.yml` and `rubyconfth-2019/videos.yml`. [[1]](diffhunk://#diff-ad2883d376fb42c9759c57b319fb4b76227f2098395276839d49c861ecdec212L242-R242) [[2]](diffhunk://#diff-af8d5f1ec7d759602e2c414e8b722b4744a11a1edcfab6f8c33d474958a179e0L78-R78)
* Updated the speaker entry in `speakers.yml` to use "Enrique Mogollán" (with accent) and provided the correct GitHub username.
* Added a new speaker profile for "Eugene Kenny" with GitHub handle `eugeneius` in `speakers.yml`.

### Speaker GitHub handle updates:

* Added or corrected GitHub handles for "Evgeny Li" (`exAspArk`) and "Ngan Pham" (`ngan`) in `speakers.yml`. [[1]](diffhunk://#diff-d13a94c0d4dd2e58d7028039900069fbc9b4f84281312987841b8211e4aae46cL7598-R7598) [[2]](diffhunk://#diff-d13a94c0d4dd2e58d7028039900069fbc9b4f84281312987841b8211e4aae46cL17879-R17879)

# Screenshots
Day 1 | Day 2
---|---
<img width="2972" height="8684" alt="127 0 0 1_3000_events_sfruby-2025_schedule" src="https://github.com/user-attachments/assets/0b6b0678-060d-4a63-8ced-5c98d66afe7f" /> | <img width="2972" height="7998" alt="127 0 0 1_3000_events_sfruby-2025_schedule (1)" src="https://github.com/user-attachments/assets/f99cec87-034c-4041-95f4-9b27981ee090" />

