### PR TITLE
Replace broken RubyConf India 2025 video links

### DIFF
--- a/data/rubyconf-india/rubyconf-india-2025/videos.yml
+++ b/data/rubyconf-india/rubyconf-india-2025/videos.yml
@@ -12,7 +12,7 @@
   published_at: "2025-09-19"
   speakers:
     - Andrzej Krzywda
-  video_id: "3IlWgwkTV0s"
+  video_id: "DSXnpsal-vU"
   video_provider: "youtube"
   description: |-
     Discover how Domain-Driven Design, CQRS, and Event Sourcing can bring structure, clarity, and scalability — without over-engineering. Real-world lessons, battle-tested patterns, and tools like RailsEventStore.
@@ -24,7 +24,7 @@
   published_at: "2025-09-19"
   speakers:
     - Puneet Khushwani
-  video_id: "NEay_Fn9e18"
+  video_id: "Hu6EZHGv3Vw"
   video_provider: "youtube"
   description: |-
     Discover how Ruby reads your code! From lexing raw characters into tokens to parsing them into an Abstract Syntax Tree, explore Ruby’s flexible syntax with practical examples and Ripper.
@@ -38,7 +38,7 @@
   published_at: "2025-09-19"
   speakers:
     - Udbhav Gambhir
-  video_id: "pmUnwoGMqSM"
+  video_id: "RcpVqigDYPE"
   video_provider: "youtube"
   description: |-
     Trace what happens when you run `rails server`! From Rails boot to Puma launch, uncover how components load, signals fire, plugins initialize, and requests are handled.
@@ -50,7 +50,7 @@
   published_at: "2025-09-19"
   speakers:
     - Vishwajeetsingh Desurkar
-  video_id: "KFRiR2Kl4nE"
+  video_id: "1h5RZWSL4Oc"
   video_provider: "youtube"
   description: |-
     Discover Ruby’s hidden AI powers! See how to build intelligent, semantic features right in Rails — no language switch, no lost joy, just powerful simplicity.
@@ -64,7 +64,7 @@
   published_at: "2025-09-19"
   speakers:
     - Nandini Singhal
-  video_id: "0iR-HI7JWsg"
+  video_id: "5pbw1iLiRwA"
   video_provider: "youtube"
   description: |-
     Discover Ruby beyond web apps! See a real-time multiplayer world built with Ractors for state and Fiber-powered WebSockets for users — live demo with 50+ players, code on GitHub.
@@ -76,7 +76,7 @@
   published_at: "2025-09-19"
   speakers:
     - Prateek Choudhary
-  video_id: "YSMcgoDPu-Q"
+  video_id: "HPa9M19V8TA"
   video_provider: "youtube"
   description: |-
     Learn a zero-downtime, service-by-service migration from Redis to Rails 8’s Solid Queue, Solid Cache, and Solid Cable. Real-world strategies with parallel runs, dual writes, canary deployments, rollback, and monitoring.
@@ -88,7 +88,7 @@
   published_at: "2025-09-19"
   speakers:
     - Rakesh Jha
-  video_id: "SeEAOMAQT2s"
+  video_id: "Zimv_11s5lg"
   video_provider: "youtube"
   description: |-
     Discover how JRuby blends Java’s power with Ruby’s elegance! Explore its evolution, real-world use cases, and practical tips to harness scalability and expressiveness in one platform.
@@ -102,7 +102,7 @@
   published_at: "2025-09-19"
   speakers:
     - Sameer Kumar
-  video_id: "13lJ5_KeCq8"
+  video_id: "Xr8wsj3FTdQ"
   video_provider: "youtube"
   description: |-
     Discover the art of Ruby DSLs — balancing elegant abstraction with readable syntax. Avoid the perils of `method_missing`, explore live demos, and create code that reads like English.
@@ -114,7 +114,7 @@
   published_at: "2025-09-19"
   speakers:
     - Vlad Dyachenko
-  video_id: "URoSAc4rg0g"
+  video_id: "Rfjm8w0hwaY"
   video_provider: "youtube"
   description: |-
     Learn how Model Context Protocol works, its real-world attack vectors, and defense strategies — from poisoning and code injection to audits and safe remote MCPs.
@@ -133,7 +133,7 @@
   published_at: "2025-09-19"
   speakers:
     - Ratnadeep Deshmane
-  video_id: "vt6ULow-DRs"
+  video_id: "1lPRRLn8ehc"
   video_provider: "youtube"
   description: |-
     Get a visual roadmap to navigate Rails core components, demystify the magic, and use AI tools to explore, understand, and confidently contribute.
@@ -145,7 +145,7 @@
   published_at: "2025-09-19"
   speakers:
     - Charles Nutter
-  video_id: "sYM0yDcTwA8"
+  video_id: "10nArtB3LvA"
   video_provider: "youtube"
   description: |-
     For over 13 years, Charles Nutter has been at the forefront of the JRuby project. He will share lessons from JVM internals, programming language design, and the unpredictable adventures of JRuby.
@@ -157,7 +157,7 @@
   published_at: "2025-09-19"
   speakers:
     - Prathamesh Sonpatki
-  video_id: "kf9g0rHyX9c"
+  video_id: "MD3-_TRBOoQ"
   video_provider: "youtube"
   description: |-
     Discover AI-powered Rails debugging! Use MCP servers to link observability stack with AI for instant insights — query logs, trace slow queries, and spot performance issues.
@@ -171,7 +171,7 @@
   published_at: "2025-09-19"
   speakers:
     - Chikahiro Tokoro
-  video_id: "Foe9r0-sipI"
+  video_id: "irq7sjXLevQ"
   video_provider: "youtube"
   description: |-
     Discover the truth about monoliths vs microservices! Debunk myths, uncover real architectural differences, and learn strategies to fix real problems — not just follow trends.
@@ -183,7 +183,7 @@
   published_at: "2025-09-19"
   speakers:
     - Deepan Kumar
-  video_id: "GCVHuCnfLy4"
+  video_id: "kuOdCfLvhUs"
   video_provider: "youtube"
   description: |-
     Discover how to capture crashes, use AI to generate fixes, write tests, and patch code at runtime — creating an app that evolves like an engineer who never sleeps!


### PR DESCRIPTION
These are from the same channel as before. I'm not sure why the old ones disappeared. I found the new ones on [this playlist](https://www.youtube.com/playlist?list=PLbgP71NCXCqFZiVKZq5pFitVA7DELKJpA).