### PR TITLE
Add users to Volunteer involvement on SF Ruby Conference

### DIFF
--- a/data/sfruby/sfruby-2025/involvements.yml
+++ b/data/sfruby/sfruby-2025/involvements.yml
@@ -47,7 +47,27 @@
     - Steven Ancheta
 
 - name: Volunteer
-  users: []
+  users:
+    - Daniel Azuma
+    - Todd Kummer
+    - Ken Decanio
+    - Dave Doolin
+    - Varun Sanjay Shembekar
+    - Madeline Hou
+    - Joshue Osuna
+    - Dominic Lizarraga
+    - Alan Fung-Schwarz
+    - Yang Chung
+    - Andrew Ford
+    - Jon Kaplan
+    - Mark Valdez
+    - Mark de Dios
+    - Megan Wong
+    - Hector Miramontes
+    - Kenneth Ng
+    - Miles Georgi
+    - Zack Mariscal
+    - Nathan Straub
 
 - name: Software Developer
   users:


### PR DESCRIPTION
Added multiple users to the Volunteer involvement section.

<img width="1567" height="465" alt="CleanShot 2025-11-26 at 11 45 55" src="https://github.com/user-attachments/assets/9e7d1a36-ce65-4d5c-87d6-91163353789f" />
