### PR TITLE
Rename Tropical.rb series to Tropical on Rails

### DIFF
--- a/data/tropicalrb/series.yml
+++ b/data/tropicalrb/series.yml
@@ -1,11 +1,11 @@
 ---
-name: Tropical.rb
-website: https://tropicalrb.com
-twitter: tropicalrb
+name: Tropical on Rails
+website: https://www.tropicalonrails.com
+twitter: tropicalonrails
 kind: conference
 frequency: yearly
 playlist_matcher:
 default_country_code: BR
-youtube_channel_name: tropicalrb
+youtube_channel_name: tropicalonrails
 language: english
 youtube_channel_id: UCC3ljLfioI4qN2_zmG_kseQ


### PR DESCRIPTION
Tropical.rb has been renamed to Tropical on Rails in the 2025 event, and that's also the case in 2026. All their social media handles and website changed to reflect this rename.

This PR updates the mentioned data.

The event series handle hasn't been updated, still being `tropicalrb`.