### PR TITLE
SF Ruby - Involvements: added a couple more volunteers that were originally missed

### DIFF
--- a/data/sfruby/sfruby-2025/involvements.yml
+++ b/data/sfruby/sfruby-2025/involvements.yml
@@ -71,6 +71,8 @@
     - Nathan Straub
     - Alexander Baygeldin
     - Albert Pazderin
+    - Gennady Shenker
+    - Emmanuel Delgado
 
 - name: Conference Software Developer
   users:


### PR DESCRIPTION
Added Gennady and Emmanuel, who volunteered during check-in

<img width="1568" height="568" alt="CleanShot 2025-12-01 at 10 41 03" src="https://github.com/user-attachments/assets/3e39dd89-75dd-40dd-8c57-59b1154389c2" />
