### PR TITLE
Remove search result counts and ranking

### DIFF
--- a/app/controllers/spotlight/events_controller.rb
+++ b/app/controllers/spotlight/events_controller.rb
@@ -1,12 +1,14 @@
 class Spotlight::EventsController < ApplicationController
+  LIMIT = 15
+
   disable_analytics
   skip_before_action :authenticate_user!
 
   def index
     @events = Event.includes(:series).canonical.order(date: :desc)
     @events = @events.ft_search(search_query) if search_query.present?
-    @events_count = @events.count
-    @events = @events.limit(5)
+    @events = @events.limit(LIMIT)
+
     respond_to do |format|
       format.turbo_stream
     end

--- a/app/controllers/spotlight/speakers_controller.rb
+++ b/app/controllers/spotlight/speakers_controller.rb
@@ -1,12 +1,14 @@
 class Spotlight::SpeakersController < ApplicationController
+  LIMIT = 15
+
   disable_analytics
   skip_before_action :authenticate_user!
 
   def index
     @speakers = User.speakers.canonical
     @speakers = @speakers.ft_search(search_query).with_snippets.ranked if search_query
-    @speakers_count = @speakers.count(:id)
-    @speakers = @speakers.limit(5)
+    @speakers = @speakers.limit(LIMIT)
+
     respond_to do |format|
       format.turbo_stream
     end

--- a/app/controllers/spotlight/talks_controller.rb
+++ b/app/controllers/spotlight/talks_controller.rb
@@ -1,12 +1,14 @@
 class Spotlight::TalksController < ApplicationController
+  LIMIT = 10
+
   disable_analytics
   skip_before_action :authenticate_user!
 
   def index
     @talks = Talk.watchable.includes(:speakers, event: :series)
-    @talks = @talks.ft_search(search_query).ranked if search_query.present?
-    @talks_count = @talks.count(:id)
-    @talks = @talks.limit(5)
+    @talks = @talks.ft_search(search_query) if search_query.present?
+    @talks = @talks.limit(LIMIT)
+
     respond_to do |format|
       format.turbo_stream
     end

--- a/app/views/spotlight/events/index.turbo_stream.erb
+++ b/app/views/spotlight/events/index.turbo_stream.erb
@@ -2,7 +2,7 @@
   <div class="flex items-center flex-wrap gap-2 py-4">
     <h2>Events</h2>
     <% if @events.size.positive? %>
-      <span class="text-sm text-gray-500">(<%= @events.size %> of <%= @events_count %>)</span>
+      <span class="text-sm text-gray-500">(<%= @events.size %><% if @events.size >= Spotlight::EventsController::LIMIT %>+<% end %> <%= "event".pluralize(@events.size) %>)</span>
       <%= link_to archive_events_path(s: search_query), class: "link text-sm text-gray-500", target: "_top" do %>
         see results
       <% end %>

--- a/app/views/spotlight/speakers/index.turbo_stream.erb
+++ b/app/views/spotlight/speakers/index.turbo_stream.erb
@@ -2,7 +2,7 @@
   <div class="flex items-center flex-wrap gap-2 py-4">
     <h2>Speakers</h2>
     <% if @speakers.size.positive? %>
-      <span class="text-sm text-gray-500">(<%= @speakers.size %> of <%= @speakers_count %>)</span>
+      <span class="text-sm text-gray-500">(<%= @speakers.size %><% if @speakers.size >= Spotlight::SpeakersController::LIMIT %>+<% end %> <%= "speaker".pluralize(@speakers.size) %>)</span>
       <%= link_to speakers_path(s: search_query), class: "link text-sm text-gray-500", target: "_top" do %>
         see results
       <% end %>

--- a/app/views/spotlight/talks/index.turbo_stream.erb
+++ b/app/views/spotlight/talks/index.turbo_stream.erb
@@ -3,7 +3,7 @@
   <div class="flex items-center flex-wrap gap-2 py-4">
     <h2>Talks</h2>
     <% if @talks.size.positive? %>
-      <span class="text-sm text-gray-500">(<%= @talks.size %> of <%= @talks_count %>)</span>
+      <span class="text-sm text-gray-500">(<%= @talks.size %><% if @talks.size >= Spotlight::TalksController::LIMIT %>+<% end %> <%= "talk".pluralize(@talks.size) %>)</span>
       <%= link_to talks_path(s: search_query), class: "link text-sm text-gray-500", target: "_top" do %>
         see results
       <% end %>

--- a/test/controllers/spotlight/events_controller_test.rb
+++ b/test/controllers/spotlight/events_controller_test.rb
@@ -19,13 +19,12 @@ class Spotlight::EventsControllerTest < ActionDispatch::IntegrationTest
     assert_equal @event.id, assigns(:events).first.id
   end
 
-  test "should limit results to 5 talks" do
-    6.times { |i| Event.create!(name: "Event #{i}", series: @series) }
+  test "should limit events results" do
+    20.times { |i| Event.create!(name: "Event #{i}", series: @series) }
 
     get spotlight_events_url(format: :turbo_stream)
     assert_response :success
-    assert_equal 5, assigns(:events).size
-    assert_equal Event.all.count, assigns(:events_count)
+    assert_equal 15, assigns(:events).size
   end
 
   test "should not track analytics" do

--- a/test/controllers/spotlight/speakers_controller_test.rb
+++ b/test/controllers/spotlight/speakers_controller_test.rb
@@ -18,13 +18,12 @@ class Spotlight::SpeakersControllerTest < ActionDispatch::IntegrationTest
     assert_equal @speaker.id, assigns(:speakers).first.id
   end
 
-  test "should limit results to 5 speakers" do
-    6.times { |i| User.create!(name: "Speaker #{i}", talks_count: 1, email: "speaker#{i}@rubyevents.org", password: "password") }
+  test "should limit speakers results" do
+    16.times { |i| User.create!(name: "Speaker #{i}", talks_count: 1, email: "speaker#{i}@rubyevents.org", password: "password") }
 
     get spotlight_speakers_url(format: :turbo_stream)
     assert_response :success
-    assert_equal 5, assigns(:speakers).size
-    assert assigns(:speakers_count).positive?
+    assert_equal 15, assigns(:speakers).size
   end
 
   test "should filter out unbalanced quotes" do

--- a/test/controllers/spotlight/talks_controller_test.rb
+++ b/test/controllers/spotlight/talks_controller_test.rb
@@ -37,8 +37,8 @@ class Spotlight::TalksControllerTest < ActionDispatch::IntegrationTest
     assert_equal "text/vnd.turbo-stream.html", @response.media_type
   end
 
-  test "should limit results to 5 talks" do
-    6.times do |i|
+  test "should limit talks results" do
+    15.times do |i|
       Talk.create!(
         title: "Talk #{i}",
         event: @event,
@@ -49,8 +49,7 @@ class Spotlight::TalksControllerTest < ActionDispatch::IntegrationTest
 
     get spotlight_talks_url(format: :turbo_stream)
     assert_response :success
-    assert_equal 5, assigns(:talks).size
-    assert_equal Talk.watchable.count, assigns(:talks_count)
+    assert_equal 10, assigns(:talks).size
   end
 
   test "should not track analytics" do


### PR DESCRIPTION
For some reason the `.count(:id)` on the `ActiveRecord::SQLite::Index` virtual tables got really slow out of a sudden.

This pull request removes that `.count(:id)` and removes the `.ranked` scope from the search results so the search stays usable for now.

<img width="3408" height="1708" alt="CleanShot 2025-12-05 at 10 15 19@2x" src="https://github.com/user-attachments/assets/115558f3-f117-4220-bcf1-0a5d3fcb8e41" />

<img width="3410" height="1712" alt="CleanShot 2025-12-05 at 10 15 24@2x" src="https://github.com/user-attachments/assets/235e5933-3630-4097-b8a2-7ad4b4da7924" />
