### PR TITLE
Generate assets for an event

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,9 @@ gem "thruster", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+# Image processing for event asset generation
+gem "mini_magick"
+
 # All sorts of useful information about every country packaged as convenient little country objects
 gem "countries"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -371,6 +371,8 @@ GEM
       actionpack (>= 6.0.0, < 8.2)
     method_source (1.1.0)
     metrics (0.15.0)
+    mini_magick (5.3.1)
+      logger
     mini_mime (1.1.5)
     minisky (0.4.0)
       base64 (~> 0.1)
@@ -762,6 +764,7 @@ DEPENDENCIES
   listen (~> 3.5)
   marksmith
   meta-tags
+  mini_magick
   minisky (~> 0.4.0)
   minitest-difftastic (~> 0.2)
   mission_control-jobs

--- a/docs/ADDING_VISUAL_ASSETS.md
+++ b/docs/ADDING_VISUAL_ASSETS.md
@@ -65,6 +65,94 @@ These colors support:
 - RGB/RGBA colors (e.g., `rgb(255, 0, 0)`)
 - CSS gradients (e.g., `linear-gradient(90deg, #FF0000, #0000FF)`)
 
+## Automated Asset Generation
+
+You can automatically generate all core assets from a single logo image using the `event:generate_assets` rake task. This is the fastest way to create consistent assets for a new event.
+
+### Prerequisites
+
+- **gum** - Interactive CLI tool (`brew install gum` on macOS)
+- **ImageMagick 7+** - Image processing (`brew install imagemagick` on macOS)
+- A logo image (PNG, SVG, or JPG with transparent background works best)
+- The event must already exist in the database
+
+The wizard will check for these dependencies and provide install instructions if missing.
+
+### Usage
+
+Run the interactive wizard:
+
+```bash
+bin/rails event:generate_assets
+```
+
+### Example Session
+
+```
+==================================================
+  Event Asset Generator
+==================================================
+
+Event slug (e.g., railsconf-2025): railsconf-2025
+  ✓ Found: RailsConf 2025
+Logo path: ~/Downloads/railsconf-logo.png
+  ✓ Found: 1024x1024 PNG
+Background color [#000000]: #CC342D
+  ✓ Background: #CC342D
+Text color [#FFFFFF - auto]:
+  ✓ Text color: #FFFFFF (auto-calculated)
+
+--------------------------------------------------
+Summary:
+  Event:      RailsConf 2025 (railsconf-2025)
+  Logo:       /Users/you/Downloads/railsconf-logo.png
+  Background: #CC342D
+  Text color: #FFFFFF
+
+Assets to generate:
+  - banner.webp (1300x350)
+  - card.webp (600x350)
+  - avatar.webp (256x256)
+  - featured.webp (615x350)
+  - poster.webp (600x350)
+
+Will update: data/railsconf/railsconf-2025/event.yml
+--------------------------------------------------
+
+Proceed with asset generation? [Y/n]: y
+```
+
+### What It Does
+
+1. **Generates all core image assets:**
+   - `avatar.webp` (256×256)
+   - `banner.webp` (1300×350)
+   - `card.webp` (600×350)
+   - `featured.webp` (615×350)
+   - `poster.webp` (600×350)
+
+2. **Updates `event.yml` with brand colors:**
+   - `banner_background`
+   - `featured_background`
+   - `featured_color`
+
+### Tips for Best Results
+
+- **Use a logo with transparent background** - The logo will be composited over the solid background color
+- **Use high-resolution source logos** - At least 1000px wide for best quality
+- **Square logos work best** - They scale well across all asset dimensions
+- **Choose contrasting colors** - If not specifying text color, the task auto-calculates white or black based on background luminance
+- **SVG logos produce the sharpest results** - They scale without quality loss
+
+### After Generation
+
+The generated assets are basic placeholders with centered logos. For events that need more elaborate designs:
+
+1. Use the generated assets as a starting point
+2. Edit them in your design tool (Sketch, Figma, etc.)
+3. Re-export as WebP at the same dimensions
+4. Replace the generated files
+
 ## Exporting Assets from Sketch
 
 If you're using the RubyEvents Sketch file, you can export assets using rake tasks:

--- a/lib/tasks/event_assets.rake
+++ b/lib/tasks/event_assets.rake
@@ -1,0 +1,384 @@
+require "mini_magick"
+require "fileutils"
+
+namespace :event do
+  desc "Generate event assets from a logo and background color (interactive wizard)"
+  task generate_assets: :environment do
+    wizard = EventAssetWizard.new
+    wizard.run
+  end
+end
+
+class EventAssetWizard
+  def run
+    check_dependencies!
+    print_header
+    event = prompt_for_event
+    logo_path = prompt_for_logo
+    background_color = prompt_for_background_color(event)
+    text_color = prompt_for_text_color(background_color)
+
+    print_summary(event, logo_path, background_color, text_color)
+
+    return unless gum_confirm("Proceed with asset generation?")
+
+    generator = EventAssetGenerator.new(
+      event: event,
+      logo_path: logo_path,
+      background_color: background_color,
+      text_color: text_color
+    )
+
+    generate_with_spinner(generator)
+
+    gum_style("✓ Asset generation complete!", border: "rounded", foreground: "2", padding: "0 1")
+  end
+
+  private
+
+  def check_dependencies!
+    check_gum_installed!
+    check_imagemagick_installed!
+  end
+
+  def check_gum_installed!
+    unless system("which gum > /dev/null 2>&1")
+      puts "Error: gum is required for this wizard"
+      puts ""
+      puts "Install with:"
+      puts "  brew install gum"
+      puts ""
+      puts "Or see: https://github.com/charmbracelet/gum"
+      exit 1
+    end
+  end
+
+  def check_imagemagick_installed!
+    unless system("which magick > /dev/null 2>&1")
+      puts "Error: ImageMagick 7+ is required"
+      puts ""
+      puts "Install with:"
+      puts "  brew install imagemagick"
+      puts ""
+      puts "Or see: https://imagemagick.org/script/download.php"
+      exit 1
+    end
+
+    version_output = `magick --version 2>&1`.lines.first.to_s
+    version_match = version_output.match(/ImageMagick (\d+)\./)
+
+    unless version_match && version_match[1].to_i >= 7
+      puts "Error: ImageMagick 7+ is required (found: #{version_output.strip})"
+      puts ""
+      puts "Upgrade with:"
+      puts "  brew upgrade imagemagick"
+      exit 1
+    end
+  end
+
+  def print_header
+    system("gum style --border rounded --padding '0 2' --margin '1 0' --border-foreground 5 'Event Asset Generator'")
+  end
+
+  def prompt_for_event
+    all_slugs = Event.order(:slug).pluck(:slug)
+
+    gum_style("Missing an event? Run bin/rails db:seed to sync from data/", foreground: "8")
+    slug = gum_filter(all_slugs, header: "Select event:", placeholder: "Type to filter...")
+
+    if slug.blank?
+      gum_style("No event selected", foreground: "1")
+      return prompt_for_event
+    end
+
+    event = Event.find_by(slug: slug)
+
+    gum_style("✓ #{event.name}", foreground: "2")
+    event
+  end
+
+  def prompt_for_logo
+    gum_style("Select logo file (ESC to enter path manually):", foreground: "6")
+    path = `gum file --height 15`.chomp
+
+    if path.blank?
+      path = gum_input("Enter logo path:", placeholder: "~/Downloads/logo.png")
+
+      if path.blank?
+        gum_style("No file selected", foreground: "1")
+        return prompt_for_logo
+      end
+    end
+
+    expanded_path = File.expand_path(path)
+
+    unless File.exist?(expanded_path)
+      gum_style("File not found: #{expanded_path}", foreground: "1")
+      return prompt_for_logo
+    end
+
+    begin
+      image = MiniMagick::Image.open(expanded_path)
+      gum_style("✓ #{File.basename(path)} (#{image.width}x#{image.height} #{image.type})", foreground: "2")
+    rescue => e
+      gum_style("Invalid image: #{e.message}", foreground: "1")
+      return prompt_for_logo
+    end
+
+    expanded_path
+  end
+
+  def prompt_for_background_color(event)
+    default = begin
+      event.static_metadata.featured_background
+    rescue
+      nil
+    end
+    default ||= "#000000"
+
+    color = gum_input("Background color:", placeholder: default, value: default)
+    color = default if color.blank?
+    color = "##{color}" unless color.start_with?("#")
+
+    unless valid_hex_color?(color)
+      gum_style("Invalid hex color. Use format like #CC342D", foreground: "1")
+      return prompt_for_background_color(event)
+    end
+
+    gum_style("✓ Background: #{color}", foreground: "2")
+    color
+  end
+
+  def prompt_for_text_color(background_color)
+    auto_color = calculate_text_color(background_color)
+
+    choice = gum_choose(["Auto (#{auto_color})", "Custom"])
+
+    if choice.start_with?("Auto")
+      gum_style("✓ Text color: #{auto_color} (auto)", foreground: "2")
+      return auto_color
+    end
+
+    color = gum_input("Text color:", placeholder: "#FFFFFF")
+    color = "##{color}" unless color.start_with?("#")
+
+    unless valid_hex_color?(color)
+      gum_style("Invalid hex color", foreground: "1")
+      return prompt_for_text_color(background_color)
+    end
+
+    gum_style("✓ Text color: #{color}", foreground: "2")
+    color
+  end
+
+  def print_summary(event, logo_path, background_color, text_color)
+    assets_list = EventAssetGenerator::ASSETS.map { |name, dims| "  • #{name}.webp (#{dims[:width]}x#{dims[:height]})" }.join("\n")
+
+    summary = <<~SUMMARY
+      Event:      #{event.name} (#{event.slug})
+      Logo:       #{File.basename(logo_path)}
+      Background: #{background_color}
+      Text:       #{text_color}
+
+      Assets to generate:
+      #{assets_list}
+
+      Output: #{event.data_folder}
+    SUMMARY
+
+    system("gum style --border rounded --padding '0 1' --margin '1 0' --border-foreground 6 '#{summary.gsub("'", "\\'")}'")
+  end
+
+  def generate_with_spinner(generator)
+    puts ""
+
+    generator.ensure_output_dir!
+
+    EventAssetGenerator::ASSETS.each do |name, dimensions|
+      system("gum spin --spinner dot --title 'Generating #{name}.webp...' -- sleep 0.1")
+      generator.generate_asset(name, dimensions[:width], dimensions[:height])
+    end
+
+    system("gum spin --spinner dot --title 'Updating event.yml...' -- sleep 0.1")
+    generator.update_event_yml
+  end
+
+  def gum_input(prompt, placeholder: "", value: "")
+    `gum input --header "#{prompt}" --placeholder "#{placeholder}" --value "#{value}"`.chomp
+  end
+
+  def gum_choose(options)
+    `echo "#{options.join("\n")}" | gum choose`.chomp
+  end
+
+  def gum_filter(options, header: "", placeholder: "")
+    `echo "#{options.join("\n")}" | gum filter --header "#{header}" --placeholder "#{placeholder}" --height 15`.chomp
+  end
+
+  def gum_confirm(message)
+    system("gum confirm '#{message}'")
+  end
+
+  def gum_style(text, border: nil, foreground: nil, padding: nil)
+    cmd = ["gum", "style"]
+    cmd += ["--border", border] if border
+    cmd += ["--foreground", foreground] if foreground
+    cmd += ["--padding", padding] if padding
+    cmd << text.to_s
+
+    system(*cmd)
+  end
+
+  def valid_hex_color?(color)
+    color.match?(/^#[0-9A-Fa-f]{6}$/)
+  end
+
+  def calculate_text_color(bg_color)
+    hex = bg_color.delete("#")
+    r = hex[0..1].to_i(16)
+    g = hex[2..3].to_i(16)
+    b = hex[4..5].to_i(16)
+
+    luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255
+
+    (luminance > 0.5) ? "#000000" : "#FFFFFF"
+  end
+end
+
+class EventAssetGenerator
+  ASSETS = {
+    banner: {width: 1300, height: 350},
+    card: {width: 600, height: 350},
+    avatar: {width: 256, height: 256},
+    featured: {width: 615, height: 350},
+    poster: {width: 600, height: 350}
+  }.freeze
+
+  LOGO_PADDING_RATIO = 0.15
+
+  attr_reader :event, :logo_path, :background_color, :text_color, :output_dir
+
+  def initialize(event:, logo_path:, background_color:, text_color: nil)
+    @event = event
+    @logo_path = logo_path
+    @background_color = normalize_color(background_color)
+    @text_color = text_color.present? ? normalize_color(text_color) : calculate_text_color(@background_color)
+    @output_dir = Rails.root.join("app", "assets", "images", "events", event.series.slug, event.slug)
+  end
+
+  def ensure_output_dir!
+    FileUtils.mkdir_p(output_dir)
+  end
+
+  def generate_all
+    ensure_output_dir!
+
+    puts "Generating assets for #{event.name}..."
+    puts "  Logo: #{logo_path}"
+    puts "  Background: #{background_color}"
+    puts "  Output: #{output_dir}"
+    puts ""
+
+    ASSETS.each do |name, dimensions|
+      generate_asset(name, dimensions[:width], dimensions[:height])
+    end
+
+    puts ""
+    puts "Done! Generated #{ASSETS.size} assets."
+  end
+
+  def generate_asset(name, width, height)
+    output_path = output_dir.join("#{name}.webp")
+
+    logo = MiniMagick::Image.open(logo_path)
+    logo_aspect = logo.width.to_f / logo.height.to_f
+
+    padding = [width, height].min * LOGO_PADDING_RATIO
+    max_logo_width = width - (padding * 2)
+    max_logo_height = height - (padding * 2)
+
+    if max_logo_width / logo_aspect <= max_logo_height
+      scaled_width = max_logo_width.round
+      scaled_height = (max_logo_width / logo_aspect).round
+    else
+      scaled_height = max_logo_height.round
+      scaled_width = (max_logo_height * logo_aspect).round
+    end
+
+    cmd = [
+      "magick",
+      "-size", "#{width}x#{height}",
+      "xc:#{background_color}",
+      "(", logo_path, "-resize", "#{scaled_width}x#{scaled_height}", ")",
+      "-gravity", "center",
+      "-composite",
+      "-quality", "90",
+      output_path.to_s
+    ]
+
+    system(*cmd, exception: true)
+
+    puts "  Created #{name}.webp (#{width}x#{height})"
+  rescue => e
+    puts "  Error creating #{name}.webp: #{e.message}"
+    puts "    #{e.backtrace.first(3).join("\n    ")}"
+  end
+
+  def update_event_yml
+    event_yml_path = event.data_folder.join("event.yml")
+
+    unless event_yml_path.exist?
+      puts "Warning: event.yml not found at #{event_yml_path}"
+      return
+    end
+
+    content = File.read(event_yml_path)
+
+    if content.match?(/^banner_background:/)
+      content.gsub!(/^banner_background:.*$/, "banner_background: \"#{background_color}\"")
+    else
+      content = content.rstrip + "\nbanner_background: \"#{background_color}\"\n"
+    end
+
+    if content.match?(/^featured_background:/)
+      content.gsub!(/^featured_background:.*$/, "featured_background: \"#{background_color}\"")
+    else
+      content = content.rstrip + "\nfeatured_background: \"#{background_color}\"\n"
+    end
+
+    if content.match?(/^featured_color:/)
+      content.gsub!(/^featured_color:.*$/, "featured_color: \"#{text_color.delete("#")}\"")
+    else
+      content = content.rstrip + "\nfeatured_color: \"#{text_color.delete("#")}\"\n"
+    end
+    updated = true
+
+    if updated
+      File.write(event_yml_path, content)
+      puts ""
+      puts "Updated event.yml:"
+      puts "  banner_background: #{background_color}"
+      puts "  featured_background: #{background_color}"
+      puts "  featured_color: #{text_color}"
+    end
+  end
+
+  private
+
+  def normalize_color(color)
+    return color if color.start_with?("#")
+
+    "##{color}"
+  end
+
+  def calculate_text_color(bg_color)
+    hex = bg_color.delete("#")
+    r = hex[0..1].to_i(16)
+    g = hex[2..3].to_i(16)
+    b = hex[4..5].to_i(16)
+
+    luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255
+
+    (luminance > 0.5) ? "#000000" : "#FFFFFF"
+  end
+end


### PR DESCRIPTION


https://github.com/user-attachments/assets/979999ee-522c-4909-a8c3-85fed1196284



```bash
bin/rails event:generate_assets
```

**Generated Assets**

| File          | Dimensions |
|---------------|------------|
| banner.webp   | 1300x350   |
| card.webp     | 600x350    |
| avatar.webp   | 256x256    |
| featured.webp | 615x350    |
| poster.webp   | 600x350    |

The assets are saved to `app/assets/images/events/{series-slug}/{event-slug}/` with the logo centered on the background color, maintaining aspect ratio with 15% padding.