### PR TITLE
correct event name, 'RubyKaigi Takeout YYYY'

### DIFF
--- a/data/rubykaigi/rubykaigi-2020/event.yml
+++ b/data/rubykaigi/rubykaigi-2020/event.yml
@@ -1,10 +1,10 @@
 ---
 id: "PLbFmgWm555yZeLpdOLhYwORIF9UjBAFHw"
-title: "RubyKaigi 2020 Takeout"
+title: "RubyKaigi Takeout 2020"
 kind: "conference"
 location: "online"
 description: |-
-  https://rubykaigi.org/2020-takeout
+  https://rubykaigi.org/2020-takeout/
 published_at: "2020-09-03"
 start_date: "2020-09-04"
 end_date: "2020-09-05"
@@ -13,4 +13,4 @@ year: 2020
 banner_background: "#7E0303"
 featured_background: "#7E0303"
 featured_color: "#FFFFFF"
-website: "https://rubykaigi.org/2020"
+website: "https://rubykaigi.org/2020-takeout/"

--- a/data/rubykaigi/rubykaigi-2020/videos.yml
+++ b/data/rubykaigi/rubykaigi-2020/videos.yml
@@ -9,7 +9,7 @@
   raw_title: "[EN] The State of Ruby 3 Typing / Soutaro Matsumoto @soutaro"
   speakers:
     - Soutaro Matsumoto
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09"
   video_provider: "youtube"
@@ -23,7 +23,7 @@
   raw_title: "[EN] The whys and hows of transpiling Ruby / Vladimir Dementyev @palkan_tula"
   speakers:
     - Vladimir Dementyev
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09"
   video_provider: "youtube"
@@ -42,7 +42,7 @@
   raw_title: "[EN] Reflecting on Ruby Reflection for Rendering RBIs / Ufuk Kayserilioglu @paracycle"
   speakers:
     - Ufuk Kayserilioglu
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09"
   video_provider: "youtube"
@@ -58,7 +58,7 @@
   raw_title: "[EN] Is it time run Ruby on Web via WebAssembly? / 蒼時弦也 @elct9620"
   speakers:
     - elct9620
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09"
   video_provider: "youtube"
@@ -72,7 +72,7 @@
   raw_title: "[EN] mruby machine: An Operating System for Microcontoller / Hitoshi HASUMI @hasumikin"
   speakers:
     - Hitoshi HASUMI
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09"
   video_provider: "youtube"
@@ -88,7 +88,7 @@
   raw_title: "[EN] Keyword Arguments: Past, Present, and Future / Jeremy Evans @jeremyevans0"
   speakers:
     - Jeremy Evans
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09"
   video_provider: "youtube"
@@ -102,7 +102,7 @@
   raw_title: "[EN] Live coding: Grepping Ruby code like a boss / Jônatas Davi Paganini @jonatas"
   speakers:
     - Jônatas Davi Paganini
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09"
   video_provider: "youtube"
@@ -119,7 +119,7 @@
   raw_title: "[EN] Now is the time to create your own (m)Ruby computer / Katsuhiko Kageyama @kishima"
   speakers:
     - Katsuhiko Kageyama
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09"
   video_provider: "youtube"
@@ -134,7 +134,7 @@
   raw_title: "[JA] Asynchronous Opal / Yoh Osaki @youchan"
   speakers:
     - Yoh Osaki
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09"
   video_provider: "youtube"
@@ -148,7 +148,7 @@
   raw_title: "[JA] Rinda in the real-world embedded systems / Masatoshi SEKI @m_seki"
   speakers:
     - Masatoshi SEKI
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09"
   video_provider: "youtube"
@@ -162,7 +162,7 @@
   raw_title: "[EN] mruby-rr: Time Traveling Debugger For mruby Using rr / Lin Yu Hsiang @johnlinvc"
   speakers:
     - Lin Yu Hsiang
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09"
   video_provider: "youtube"
@@ -178,7 +178,7 @@
   raw_title: "[EN] Developing your Dreamcast apps and games with mruby / Yuji Yokoo @yuji_yokoo"
   speakers:
     - Yuji Yokoo
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09"
   video_provider: "youtube"
@@ -194,7 +194,7 @@
   raw_title: "[EN] Don't @ me! Instance Variable Performance in Ruby / Aaron Patterson @tenderlove"
   speakers:
     - Aaron Patterson
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09"
   video_provider: "youtube"
@@ -211,7 +211,7 @@
   raw_title: "[JA] Don't @ me! Instance Variable Performance in Ruby / Aaron Patterson @tenderlove"
   speakers:
     - Aaron Patterson
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09"
   video_provider: "youtube"
@@ -228,7 +228,7 @@
   raw_title: "[JA] Ruby to C Translator by AI / Hideki Miura @miura1729"
   speakers:
     - Hideki Miura
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09"
   video_provider: "youtube"
@@ -242,7 +242,7 @@
   raw_title: "[EN] The Complex Nightmare of the Asian Cultural Area / ITOYANAGI Sakura @aycabta"
   speakers:
     - ITOYANAGI Sakura
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09"
   video_provider: "youtube"
@@ -256,7 +256,7 @@
   raw_title: "[JA] Dependency Resolution with Standard Libraries"
   speakers:
     - Hiroshi Shibata
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09"
   video_provider: "youtube"
@@ -272,7 +272,7 @@
   raw_title: "[JA] msgraph: Microsoft Graph API Client with Ruby / ODA Hirohito @jimlock"
   speakers:
     - ODA Hirohito
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09"
   video_provider: "youtube"
@@ -288,7 +288,7 @@
   raw_title: "[JA] Magic is organizing chaos / Shugo Maeda @shugomaeda"
   speakers:
     - Shugo Maeda
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09"
   video_provider: "youtube"
@@ -304,7 +304,7 @@
   raw_title: '[JA Keynote] Ruby3 and Beyond / Yukihiro "Matz" Matsumoto @yukihiro_matz'
   speakers:
     - Yukihiro "Matz" Matsumoto
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09"
   video_provider: "youtube"
@@ -317,7 +317,7 @@
   raw_title: "[JA] Road to RuboCop 1.0 / Koichi ITO @koic"
   speakers:
     - Koichi ITO
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09"
   video_provider: "youtube"
@@ -335,7 +335,7 @@
   raw_title: "[JA] Goodbye fat gem / Sutou Kouhei @ktou"
   speakers:
     - Sutou Kouhei
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09"
   video_provider: "youtube"
@@ -349,7 +349,7 @@
   raw_title: "[JA] On sending methods / Urabe, Shyouhei @shyouhei"
   speakers:
     - Urabe Shyouhei
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09"
   video_provider: "youtube"
@@ -363,7 +363,7 @@
   raw_title: "[JA] Type Profiler: a Progress Report of a Ruby 3 Type Analyzer / Yusuke Endoh @mametter"
   speakers:
     - Yusuke Endoh
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09"
   video_provider: "youtube"
@@ -377,7 +377,7 @@
   raw_title: "[JA] Ractor report / Koichi Sasada @ko1"
   speakers:
     - Koichi Sasada
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09"
   video_provider: "youtube"
@@ -393,7 +393,7 @@
   raw_title: "[EN] Running Rack and Rails Faster with TruffleRuby / Benoit Daloze @eregontp"
   speakers:
     - Benoit Daloze
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09"
   video_provider: "youtube"
@@ -409,7 +409,7 @@
   raw_title: "[EN] RubyMem: The Leaky Gems Database for Bundler / Ernesto Tagwerker @etagwerker"
   speakers:
     - Ernesto Tagwerker
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09"
   slides_url: "https://speakerdeck.com/etagwerker/rubymem-the-leaky-gems-database-for-bundler-at-ruby-kaigi-takeout-2020"
@@ -426,7 +426,7 @@
   raw_title: "[EN] Prettier Ruby / Kevin Deisz @kddeisz"
   speakers:
     - Kevin Newton
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09"
   video_provider: "youtube"
@@ -442,7 +442,7 @@
   raw_title: "[EN] Don't Wait For Me! Scalable Concurrency for Ruby 3! / Samuel Williams @ioquatix"
   speakers:
     - Samuel Williams
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09"
   video_provider: "youtube"
@@ -456,7 +456,7 @@
   raw_title: "Ruby committers vs the World - Day 1 (extended)"
   speakers:
     - Ruby Committers # TODO: list each person
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-15"
   video_provider: "youtube"
@@ -469,7 +469,7 @@
   raw_title: "Ruby committers vs the World - Day 2"
   speakers:
     - Ruby Committers # TODO: list each person
-  event_name: "RubyKaigi 2020 Takeout"
+  event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-10-10"
   video_provider: "youtube"

--- a/data/rubykaigi/rubykaigi-2021/event.yml
+++ b/data/rubykaigi/rubykaigi-2021/event.yml
@@ -1,6 +1,6 @@
 ---
 id: "PLbFmgWm555yYgc4sx2Dkb7WWcfflbt6AP"
-title: "RubyKaigi 2021 Takeout"
+title: "RubyKaigi Takeout 2021"
 kind: "conference"
 location: "online"
 description: ""
@@ -12,4 +12,4 @@ year: 2021
 banner_background: "#EBE0CE"
 featured_background: "#EBE0CE"
 featured_color: "#0B374D"
-website: "https://rubykaigi.org/2021"
+website: "https://rubykaigi.org/2021-takeout/"

--- a/data/rubykaigi/rubykaigi-2021/videos.yml
+++ b/data/rubykaigi/rubykaigi-2021/videos.yml
@@ -9,7 +9,7 @@
   raw_title: "[JA] How to develop the Standard Libraries of Ruby? / Hiroshi SHIBATA @hsbt"
   speakers:
     - Hiroshi SHIBATA
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11"
   video_provider: "youtube"
@@ -27,7 +27,7 @@
   raw_title: "[JA] Toycol: Define your own application protocol / Misaki Shioi @shioimm"
   speakers:
     - Misaki Shioi
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11"
   video_provider: "youtube"
@@ -47,7 +47,7 @@
   raw_title: "[EN] Do regex dream of Turing Completeness? / Daniel Magliola @dmagliola"
   speakers:
     - Daniel Magliola
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11"
   video_provider: "youtube"
@@ -67,7 +67,7 @@
   raw_title: "[EN] Optimizing Partial Backtraces in Ruby 3 / Jeremy Evans @jeremyevans"
   speakers:
     - Jeremy Evans
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11"
   video_provider: "youtube"
@@ -84,7 +84,7 @@
   speakers:
     - Masatoshi SEKI
     - Tatsuya Sonokawa
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11"
   video_provider: "youtube"
@@ -103,7 +103,7 @@
   raw_title: "[EN] It is time to build your mruby VM on the microcontroller? / 蒼時弦也 @elct9620"
   speakers:
     - elct9620
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11"
   video_provider: "youtube"
@@ -119,7 +119,7 @@
   raw_title: "[EN] Regular Expressions: Amazing and Dangerous / Martin J. Dürst @duerst"
   speakers:
     - Martin J. Dürst
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11"
   video_provider: "youtube"
@@ -136,7 +136,7 @@
   speakers:
     - Peter Zhu
     - Matt Valentine-House
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11"
   video_provider: "youtube"
@@ -155,7 +155,7 @@
   raw_title: "[EN] 10 years of Ruby-powered citizen science / Mat Schaffer @matschaffer"
   speakers:
     - Mat Schaffer
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11"
   video_provider: "youtube"
@@ -173,7 +173,7 @@
   raw_title: "[EN] YJIT - Building a new JIT Compiler inside CRuby / Maxime Chevalier-Boisvert @maximecb"
   speakers:
     - Maxime Chevalier-Boisvert
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11"
   video_provider: "youtube"
@@ -189,7 +189,7 @@
   raw_title: "[EN] Graphical Terminal User Interface of Ruby 3.1 / ITOYANAGI Sakura @aycabta"
   speakers:
     - ITOYANAGI Sakura
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11"
   video_provider: "youtube"
@@ -207,7 +207,7 @@
   raw_title: "[EN] Why Ruby's JIT was slow / Takashi Kokubun @k0kubun"
   speakers:
     - Takashi Kokubun
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11"
   video_provider: "youtube"
@@ -227,7 +227,7 @@
   raw_title: "[JA] Why Ruby's JIT was slow / Takashi Kokubun @k0kubun"
   speakers:
     - Takashi Kokubun
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11"
   video_provider: "youtube"
@@ -247,7 +247,7 @@
   raw_title: "[JA] The Art of Execution Control for Ruby's Debugger / Koichi Sasada @ko1"
   speakers:
     - Koichi Sasada
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11"
   video_provider: "youtube"
@@ -273,7 +273,7 @@
   raw_title: "[JA][Keynote] TypeProf for IDE: Enrich Dev-Experience without Annotations / Yusuke Endoh @mame"
   speakers:
     - Yusuke Endoh
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11"
   video_provider: "youtube"
@@ -289,7 +289,7 @@
   raw_title: "[EN] Building Native Extensions. This Could Take A While... / Mike Dalessio @flavorjones"
   speakers:
     - Mike Dalessio
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11"
   video_provider: "youtube"
@@ -307,7 +307,7 @@
   raw_title: "[EN] Parsing Ruby / Kevin Newton @kddnewton"
   speakers:
     - Kevin Newton
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11"
   video_provider: "youtube"
@@ -323,7 +323,7 @@
   raw_title: "[EN] Ruby Archaeology / Nick Schwaderer @schwad"
   speakers:
     - Nick Schwaderer
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11"
   video_provider: "youtube"
@@ -347,7 +347,7 @@
   raw_title: "[EN][Keynote] The Future Shape of Ruby Objects / Chris Seaton @chrisseaton"
   speakers:
     - Chris Seaton
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11"
   video_provider: "youtube"
@@ -363,7 +363,7 @@
   raw_title: "[EN] Demystifying DSLs for better analysis and understanding / Ufuk Kayserilioglu @paracycle"
   speakers:
     - Ufuk Kayserilioglu
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11"
   video_provider: "youtube"
@@ -381,7 +381,7 @@
   raw_title: "[EN] Parallel testing with Ractors: putting CPUs to work / Vinicius Stock @vinistock"
   speakers:
     - Vinicius Stock
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11"
   video_provider: "youtube"
@@ -399,7 +399,7 @@
   raw_title: "[JA] The newsletter of RBS updates / Masataka Kuwabara @pocke"
   speakers:
     - Masataka Kuwabara
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11"
   video_provider: "youtube"
@@ -417,7 +417,7 @@
   raw_title: '[EN] Ractor''s speed is not light-speed / Satoshi "moris" Tagomori @tagomoris'
   speakers:
     - Satoshi "moris" Tagomori
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11"
   video_provider: "youtube"
@@ -434,7 +434,7 @@
   speakers:
     - Benoit Daloze
     - Josef Haider
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11"
   video_provider: "youtube"
@@ -453,7 +453,7 @@
   raw_title: "[JA] Red Arrow - Ruby and Apache Arrow / Sutou Kouhei @kou"
   speakers:
     - Sutou Kouhei
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11"
   video_provider: "youtube"
@@ -481,7 +481,7 @@
   raw_title: "[JA] Charty: Statistical data visualization in Ruby / Kenta Murata @mrkn"
   speakers:
     - Kenta Murata
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11"
   video_provider: "youtube"
@@ -499,7 +499,7 @@
   raw_title: "[JA] RuboCop in 2021: Stable and Beyond / Koichi ITO @koic"
   speakers:
     - Koichi ITO
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11"
   video_provider: "youtube"
@@ -519,7 +519,7 @@
   raw_title: "[EN] Beware the Dead End!! / Richard Schneeman @schneems"
   speakers:
     - Richard Schneeman
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11"
   video_provider: "youtube"
@@ -535,7 +535,7 @@
   raw_title: "[JA] Falling down from FreeBSD / やもり @yamori813"
   speakers:
     - yamori813
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-12"
   video_provider: "youtube"
@@ -551,7 +551,7 @@
   raw_title: '[JA] Matz Keynote / Yukihiro "Matz" Matsumoto @matz'
   speakers:
     - Yukihiro "Matz" Matsumoto
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-12"
   video_provider: "youtube"
@@ -565,7 +565,7 @@
   raw_title: "[JA] PRK Firmware: Keyboard is Essentially Ruby / Hitoshi HASUMI @hasumikin"
   speakers:
     - Hitoshi HASUMI
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-12"
   video_provider: "youtube"
@@ -585,7 +585,7 @@
   raw_title: "Ruby Committers vs the World / CRuby Committers @rubylangorg"
   speakers:
     - Ruby Committers # TODO: list each person
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-12"
   video_provider: "youtube"
@@ -601,7 +601,7 @@
   raw_title: "[JA] Ruby, Ractor, QUIC / Yusuke Nakamura @unasuke"
   speakers:
     - Yusuke Nakamura
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-12"
   video_provider: "youtube"
@@ -617,7 +617,7 @@
   raw_title: "[JA] Dive into Encoding / Mari Imaizumi @ima1zumi"
   speakers:
     - Mari Imaizumi
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-12"
   video_provider: "youtube"
@@ -633,7 +633,7 @@
   raw_title: "[EN] Crafting exploits, tools and havoc with Ruby / Mauro Eldritch @MauroEldritch"
   speakers:
     - Mauro Eldritch
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-12"
   video_provider: "youtube"
@@ -655,7 +655,7 @@
   raw_title: '[EN] Story of Rucy - How to "compile" a BPF binary from Ruby / Uchio KONDO @udzura'
   speakers:
     - Uchio KONDO
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-12"
   video_provider: "youtube"
@@ -679,7 +679,7 @@
   raw_title: "[JA] Use Macro all the time ~ マクロを使いまくろ ~ / osyo @osyo-manga"
   speakers:
     - osyo
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-12"
   video_provider: "youtube"
@@ -699,7 +699,7 @@
   raw_title: "[JA] include/prepend in refinements should be prohibited / Shugo Maeda @shugo"
   speakers:
     - Shugo Maeda
-  event_name: "RubyKaigi 2021 Takeout"
+  event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-12"
   video_provider: "youtube"


### PR DESCRIPTION
Correcting the event names of our takeout series, which had happened during COVID-19 pandemic. Canonical form is that having year number after 'Takeout'. You can verify from its websites.

- @sorah on behalf of RubyKaigi Organizers