### PR TITLE
Fix seeding errors

### DIFF
--- a/app/models/static/speaker.rb
+++ b/app/models/static/speaker.rb
@@ -55,10 +55,10 @@ module Static
               user = ::User.new(
                 name: speaker.name,
                 slug: slug,
-                twitter: speaker.twitter.presence,
-                github_handle: speaker.github.presence,
-                website: speaker.website.presence,
-                bio: speaker.bio.presence
+                twitter: speaker.twitter.to_s,
+                github_handle: speaker.github.to_s,
+                website: speaker.website.to_s,
+                bio: speaker.bio.to_s
               )
 
               user.save(validate: false)


### PR DESCRIPTION
This fixes an error with seeding users 

```
Couldn't save: Joshua Timberman (), error: SQLite3::ConstraintException: NOT NULL constraint failed: users.bio
Couldn't save: Joshua Wehner (), error: SQLite3::ConstraintException: NOT NULL constraint failed: users.bio
Couldn't save: Joss Paling (), error: SQLite3::ConstraintException: NOT NULL constraint failed: users.bio
Couldn't save: Josua Schmid (schmijos), error: SQLite3::ConstraintException: NOT NULL constraint failed: users.twitter
Couldn't save: José Anchieta (anchietajunior), error: SQLite3::ConstraintException: NOT NULL constraint failed: users.twitter
Couldn't save: Joy Heron (joyheron), error: SQLite3::ConstraintException: NOT NULL constraint failed: users.twitter
Couldn't save: Joy Paas (), error: SQLite3::ConstraintException: NOT NULL constraint failed: users.bio
Couldn't save: Joël Quenneville (joelq), error: SQLite3::ConstraintException: NOT NULL constraint failed: users.bio
Couldn't save: Juan Barreneche (), error: SQLite3::ConstraintException: NOT NULL constraint failed: users.bio
Couldn't save: Juan C. Ruiz (), error: SQLite3::ConstraintException: NOT NULL constraint failed: users.bio
```

Root cause is using `presence`, which may return nil. Instead, we use an empty string if a field is not set. 