### PR TITLE
don't set by default the modal turbo_temporary to true

### DIFF
--- a/app/components/ui/modal_component.rb
+++ b/app/components/ui/modal_component.rb
@@ -28,7 +28,6 @@ class Ui::ModalComponent < ApplicationComponent
     attributes[:data] = {
       controller: "modal",
       modal_open_value: open,
-      turbo_temporary: true,
       action: combined_action
     }.merge(attributes[:data] || {})
   end


### PR DESCRIPTION
Closes #1197

Modals were previously generated with the turbo temporary attribute by default.
This caused unexpected behavior in the Spotlight search when navigating back and forth.

This PR removes the temporary attribute from modals. After testing navigation throughout the app, I haven’t encountered any regressions or UI issues related to this change.