### PR TITLE
Add Hackathons and Workshops to Events Archive header

### DIFF
--- a/app/views/events/archive/index.html.erb
+++ b/app/views/events/archive/index.html.erb
@@ -5,6 +5,8 @@
       <span class="text-base text-gray-500">
         (<%= pluralize(@events.includes(:series).where(series: {kind: "conference"}).count, "conference") %>,
         <%= pluralize(@events.includes(:series).where(series: {kind: "meetup"}).count, "meetup") %>,
+        <%= pluralize(@events.includes(:series).where(series: {kind: "hackathon"}).count, "hackathon") %>,
+        <%= pluralize(@events.includes(:series).where(series: {kind: "workshop"}).count, "workshop") %>,
         <%= pluralize(@events.includes(:series).where(series: {kind: "retreat"}).count, "retreat") %>)
       </span>
     </h1>


### PR DESCRIPTION
# Description
We added kinds of Hackathon and Workshop but we didn't add them to the header, so the count on the front page and the count on the archive don't match up!

It's still off by 15, but I think that might be the canonical filter.

# Screenshots
<img width="1290" height="150" alt="Screenshot 2025-12-30 at 3 59 00 PM" src="https://github.com/user-attachments/assets/7deb1acf-c298-44db-86fc-61258c8f2f4a" />
<img width="1278" height="113" alt="Screenshot 2025-12-30 at 3 59 14 PM" src="https://github.com/user-attachments/assets/16e8b62f-7983-4a83-a3be-83ef44ce0d16" />
