### PR TITLE
Add @ChaelCodes to RubyEvents.org Team! 🎉

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,14 +25,15 @@ module ApplicationHelper
 
   def footer_credits
     maintainers = [
-      link_to("@adrienpoly", "https://github.com/adrienpoly", target: "_blank", class: "link", alt: "Adrien Poly"),
-      link_to("@marcoroth", "https://github.com/marcoroth", target: "_blank", class: "link", alt: "Marco Roth")
-    ].shuffle.join(" and ")
+      link_to("@adrienpoly", "https://www.rubyevents.org/profiles/adrienpoly", class: "link", alt: "Adrien Poly"),
+      link_to("@chaelcodes", "https://www.rubyevents.org/profiles/chaelcodes", class: "link", alt: "Rachael Wright-Munn"),
+      link_to("@marcoroth", "https://www.rubyevents.org/profiles/marcoroth", class: "link", alt: "Marco Roth")
+    ].shuffle.join(", ")
+
     output = ["Made with"]
     output << fa(:heart, size: :sm, class: "fill-red-700 inline")
     output << "for the Ruby community by"
-    output << maintainers
-    output << "and wonderful"
+    output << "#{maintainers}, and wonderful"
     output << link_to("contributors", contributors_path, class: "link")
     output << "using an"
     output << link_to("edge stack.", uses_path, class: "link")

--- a/app/views/page/about.md
+++ b/app/views/page/about.md
@@ -14,7 +14,7 @@ RubyVideo was [launched in June 2023](https://x.com/adrienpoly/status/1669944383
 
 [Marco Roth](https://github.com/marcoroth), maintainer of [RubyConferences.org](https://rubyconferences.org/), significantly [contributed](https://github.com/adrienpoly/rubyvideo/graphs/contributors) to RubyVideo by providing extensive new content and innovative ideas. Marco's vision revealed the project's potential extended far beyond simply indexing videos, prompting the merger of **RubyConferences.org** and **RubyVideo.dev** into **RubyEvents.org**.
 
-As of today more than 6000 talks from 3000+ speakers are indexed.
+As of today more than 8000+ talks from 3000+ speakers are indexed.
 
 ## Open Source
 
@@ -24,4 +24,8 @@ RubyEvents.org is entirely open-source and distributed under the [MIT License](h
 
 ## Maintainers
 
-RubyEvents.org is jointly maintained by [Marco Roth](https://github.com/marcoroth) and [Adrien Poly](https://github.com/adrienpoly).
+RubyEvents.org is jointly maintained by:
+
+* [Adrien Poly](https://www.rubyevents.org/profiles/adrienpoly)
+* [Marco Roth](https://github.com/marcoroth)
+* [Rachael Wright-Munn](https://www.rubyevents.org/profiles/chaelcodes)


### PR DESCRIPTION
Welcome @ChaelCodes to the RubyEvents.org Team! 🎉

Rachael has been building new features, improving docs, smoothing onboarding, and spreading the word at events.

She is all-in and also built [MeetAnother.day](https://meetanother.day/), which shares our mission of connecting Rubyists around the world.

We can't wait to build together!

<img width="1200" height="630" alt="chaelcodes" src="https://github.com/user-attachments/assets/43aa1ac0-3d29-4cd3-b0d0-e177090a7e84" />
