### PR TITLE
Fix bug when there's a meetup and event involvement with the same role.

### DIFF
--- a/app/controllers/profiles/involvements_controller.rb
+++ b/app/controllers/profiles/involvements_controller.rb
@@ -2,17 +2,12 @@ class Profiles::InvolvementsController < ApplicationController
   include ProfileData
 
   def index
-    @involved_events = @user.involved_events.includes(:series).distinct.order(start_date: :desc)
-    event_involvements = @user.event_involvements.includes(:event).where(event: @involved_events)
-    involvement_lookup = event_involvements.group_by(&:event_id)
-
-    @involvements_by_role = {}
-    @involved_events.each do |event|
-      involvements = involvement_lookup[event.id] || []
-      involvements.each do |involvement|
-        @involvements_by_role[involvement.role] ||= []
-        @involvements_by_role[involvement.role] << event
+    event_involvements = @user.event_involvements.includes(:event)
+    @involvements_by_role = event_involvements.group_by(&:role)
+      .each do |role, involvements|
+        involvements.map!(&:event)
+          .sort_by!(&:sort_date)
+          .reverse!
       end
-    end
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -382,6 +382,10 @@ class Event < ApplicationRecord
     event_image_or_default_for("poster.webp")
   end
 
+  def sort_date
+    start_date || end_date || Time.at(0)
+  end
+
   def stickers
     Sticker.for_event(self)
   end

--- a/app/views/profiles/_involvements.html.erb
+++ b/app/views/profiles/_involvements.html.erb
@@ -1,5 +1,7 @@
-<% cache [user, events, Current.user] do %>
-  <% if events.any? %>
+<%# locals: (events:, user:, involvements_by_role:) %>
+
+<% cache [user, involvements_by_role, Current.user] do %>
+  <% if involvements_by_role.any? %>
     <div class="space-y-8">
         <% if involvements_by_role.any? %>
           <% involvements_by_role.each do |role, events| %>
@@ -9,7 +11,6 @@
               </h3>
               <div class="mb-6">
                 <div class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
-                  <% events = events.sort_by(&:start_date).reverse.uniq %>
                   <%= cache events do %>
                     <%= render partial: "events/card", collection: events, as: :event, cached: true %>
                   <% end %>

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -22,7 +22,7 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should get index and return events in the correct order" do
-    event_names = %i[brightonruby_2024 future_conference rails_world_2023 tropical_rb_2024 railsconf_2017 rubyconfth_2022].map { |event| events(event) }.map(&:name)
+    event_names = %i[brightonruby_2024 future_conference rails_world_2023 tropical_rb_2024 railsconf_2017 rubyconfth_2022 wnb_rb_meetup].map { |event| events(event) }.map(&:name)
 
     get archive_events_url
 

--- a/test/controllers/profiles/involvements_controller_test.rb
+++ b/test/controllers/profiles/involvements_controller_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class Profiles::InvolvementsControllerTest < ActionDispatch::IntegrationTest
+  test "user with event involvements" do
+    user = users(:one)
+    event = events(:railsconf_2017)
+    EventInvolvement.create!(involvementable: user, event: event, role: "volunteer")
+
+    get profile_involvements_path(user)
+
+    assert_response :success
+  end
+
+  test "user without involvements" do
+    user = users(:one)
+
+    get profile_involvements_path(user)
+
+    assert_response :success
+  end
+
+  test "user with event and meetup involvements" do
+    user = users(:one)
+    event = events(:tropical_rb_2024)
+    meetup = events(:wnb_rb_meetup)
+    EventInvolvement.create!(involvementable: user, event: event, role: "organizer")
+    EventInvolvement.create!(involvementable: user, event: meetup, role: "organizer")
+
+    get profile_involvements_path(user)
+
+    assert_response :success
+  end
+end

--- a/test/fixtures/event_series.yml
+++ b/test/fixtures/event_series.yml
@@ -65,3 +65,11 @@ brightonruby:
   kind: 1
   frequency: 1
   slug: brightonruby
+
+wnb_rb:
+  name: WNB.rb
+  description: A virtual community for women & non-binary Rubyists.
+  website: https://www.wnb-rb.dev
+  kind: 2
+  frequency: 3
+  slug: wnb-rb

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -81,3 +81,9 @@ future_conference:
   name: Future Conference
   kind: conference
   slug: future-conference
+
+wnb_rb_meetup:
+  series: wnb_rb
+  kind: meetup
+  name: WNB.rb Meetup
+  slug: wnb-rb-meetup


### PR DESCRIPTION
# Description

When there's a profile with event and meetup involvements of the same role, we're not displaying anything.

<img width="827" height="409" alt="Screenshot 2026-01-03 at 10 27 03 AM" src="https://github.com/user-attachments/assets/5965cbbf-ab42-45ab-9a9f-93e3836b1835" />

Meetups do not have a start_date and events do. The involvements sort by start_date, so this ends up comparing nil to date and we raise an error. When there's only one record for 

I sorted based on a new method on the event called `sort_date`. Empty values are replaced with `Time.at(0)`, so meetups will show last until we populate them.