### PR TITLE
Build Docker Image in parallel to tests to deploy faster

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
         run: |
           bin/rails test
           bin/rails test:system
+
   seed_smoke_test:
     runs-on: ubuntu-latest
     env:
@@ -135,7 +136,6 @@ jobs:
 
   build:
     name: Build Docker Image
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
 
     permissions:
@@ -164,7 +164,14 @@ jobs:
         with:
           bundler-cache: true
 
+      - name: Build Docker image (PR)
+        if: ${{ github.event_name == 'pull_request' }}
+        run: docker build .
+        env:
+          DOCKER_BUILDKIT: 1
+
       - name: Build and push Docker image
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: bundle exec kamal build push
         env:
           KAMAL_RAILS_MASTER_KEY: ${{ secrets.KAMAL_RAILS_MASTER_KEY }}


### PR DESCRIPTION
This should make it so, that the docker image can be built in parallel along the `test` and `smoke_test` jobs. Consequently, the deploy action itself should be a lot faster since it doesn't have to build the container after it took 5-7m to run the first batch of jobs.


```
  PRs:
  ┌───────────────────┐
  │       lint        │
  ├───────────────────┤
  │       test        │ 
  ├───────────────────┤  (all run in parallel)
  │  seed_smoke_test  │
  ├───────────────────┤
  │  build (no push)  │
  └───────────────────┘

  main:
  ┌───────────────────┐
  │       lint        │──────────┐
  ├───────────────────┤          │
  │       test        │──────────┤
  ├───────────────────┤          ├────► deploy
  │  seed_smoke_test  │──────────┤
  ├───────────────────┤          │
  │   build + push    │──────────┘
  └───────────────────┘
```