### PR TITLE
improve talks search query

### DIFF
--- a/app/models/search/backend/sqlite_fts.rb
+++ b/app/models/search/backend/sqlite_fts.rb
@@ -10,7 +10,7 @@ class Search::Backend::SQLiteFTS
       talks = talks.for_speaker(options[:speaker_slug]) if options[:speaker_slug].present?
       talks = talks.where(kind: options[:kind]) if options[:kind].present?
       talks = talks.where(language: options[:language]) if options[:language].present?
-      talks = talks.watchable unless options[:include_unwatchable]
+      talks = talks.ft_watchable unless options[:include_unwatchable]
 
       total_count = talks.except(:select).count
 
@@ -26,7 +26,7 @@ class Search::Backend::SQLiteFTS
       talks = talks.where(kind: options[:kind]) if options[:kind].present?
       talks = talks.where(language: options[:language]) if options[:language].present?
       talks = talks.where("created_at >= ?", options[:created_after]) if options[:created_after].present?
-      talks = talks.watchable unless options[:include_unwatchable]
+      talks = talks.ft_watchable unless options[:include_unwatchable]
       talks = talks.scheduled if options[:status] == "scheduled"
 
       talks = apply_sort(talks, query, options[:sort])

--- a/app/models/talk/index.rb
+++ b/app/models/talk/index.rb
@@ -28,7 +28,12 @@ class Talk::Index < ApplicationRecord
   end
 
   def reindex
-    update! id: talk.id, title: talk.title, summary: talk.summary, speaker_names: talk.speaker_names, event_names: talk.event_names
+    update!(id: talk.id,
+      title: talk.title,
+      summary: talk.summary,
+      speaker_names: talk.speaker_names,
+      event_names: talk.event_names,
+      video_provider: talk.video_provider)
   end
 
   def self.remove_invalid_search_characters(query)

--- a/app/models/talk/searchable.rb
+++ b/app/models/talk/searchable.rb
@@ -19,6 +19,12 @@ module Talk::Searchable
         .order(combined_score: :asc)
     end
 
+    # Filter on FTS table directly for better performance with search
+    # This allows FTS5 to optimize the query when combined with MATCH
+    scope :ft_watchable, -> do
+      joins(:index).where("talks_search_index.video_provider IN (?)", Talk::WATCHABLE_PROVIDERS)
+    end
+
     after_save_commit :reindex
   end
 

--- a/db/migrate/20260105120000_add_video_provider_to_talks_search_index.rb
+++ b/db/migrate/20260105120000_add_video_provider_to_talks_search_index.rb
@@ -1,0 +1,57 @@
+class AddVideoProviderToTalksSearchIndex < ActiveRecord::Migration[8.0]
+  def up
+    # Drop and recreate FTS table with video_provider as unindexed column
+    # Unindexed columns are stored but not searchable - perfect for filtering
+    drop_table :talks_search_index
+
+    create_virtual_table :talks_search_index, :fts5, [
+      "title",
+      "summary",
+      "speaker_names",
+      "event_names",
+      "video_provider UNINDEXED", # For filtering, not searching
+      "tokenize = porter"
+    ]
+
+    # Reindex all talks (this will be slow but only runs once)
+    Talk.includes(:speakers, :event).find_each do |talk|
+      execute <<~SQL.squish
+        INSERT INTO talks_search_index (rowid, title, summary, speaker_names, event_names, video_provider)
+        VALUES (
+          #{talk.id},
+          #{connection.quote(talk.title)},
+          #{connection.quote(talk.summary.to_s)},
+          #{connection.quote(talk.speaker_names)},
+          #{connection.quote(talk.event_names)},
+          #{connection.quote(talk.video_provider)}
+        )
+      SQL
+    end
+  end
+
+  def down
+    drop_table :talks_search_index
+
+    create_virtual_table :talks_search_index, :fts5, [
+      "title",
+      "summary",
+      "speaker_names",
+      "event_names",
+      "tokenize = porter"
+    ]
+
+    # Reindex all talks
+    Talk.includes(:speakers, :event).find_each do |talk|
+      execute <<~SQL.squish
+        INSERT INTO talks_search_index (rowid, title, summary, speaker_names, event_names)
+        VALUES (
+          #{talk.id},
+          #{connection.quote(talk.title)},
+          #{connection.quote(talk.summary.to_s)},
+          #{connection.quote(talk.speaker_names)},
+          #{connection.quote(talk.event_names)}
+        )
+      SQL
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_01_05_100000) do
+ActiveRecord::Schema[8.2].define(version: 2026_01_05_120000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -528,6 +528,6 @@ ActiveRecord::Schema[8.2].define(version: 2026_01_05_100000) do
   # Virtual tables defined in this database.
   # Note that virtual tables may not work with other database engines. Be careful if changing database.
   create_virtual_table "speakers_search_index", "fts5", ["name", "github", "tokenize = porter"]
-  create_virtual_table "talks_search_index", "fts5", ["title", "summary", "speaker_names", "event_names", "tokenize = porter"]
+  create_virtual_table "talks_search_index", "fts5", ["title", "summary", "speaker_names", "event_names", "video_provider UNINDEXED", "tokenize = porter"]
   create_virtual_table "users_search_index", "fts5", ["name", "github_handle", "tokenize = porter"]
 end

--- a/test/controllers/talks_controller_test.rb
+++ b/test/controllers/talks_controller_test.rb
@@ -158,7 +158,7 @@ class TalksControllerTest < ActionDispatch::IntegrationTest
     assert assigns(:talks).all? { |talk| talk.created_at >= Date.parse("2024-01-01") }
   end
 
-  test "should get index with invalide created_after" do
+  test "should get index with invalid created_after" do
     get talks_url(created_after: "wrong-date")
     assert_response :success
     assert assigns(:talks).size.positive?


### PR DESCRIPTION
this should largely speed up talks index search for route like `/talks?s=test` 

those query are currently killing the database a creating huge memory bloat and CPU spike