### PR TITLE
ensure we search the archive page of the events

### DIFF
--- a/app/helpers/spotlight_helper.rb
+++ b/app/helpers/spotlight_helper.rb
@@ -1,0 +1,18 @@
+module SpotlightHelper
+  def spotlight_resources
+    %w[talks speakers events]
+  end
+
+  def spotlight_main_resource
+    request.path.split("/").last.presence_in(%w[talks speakers events topics]) || "talks"
+  end
+
+  def spotlight_main_resource_path
+    {
+      "talks" => talks_path,
+      "speakers" => speakers_path,
+      "events" => archive_events_path,
+      "topics" => topics_path
+    }.fetch(spotlight_main_resource, spotlight_talks_path)
+  end
+end

--- a/app/javascript/controllers/spotlight_search_controller.js
+++ b/app/javascript/controllers/spotlight_search_controller.js
@@ -19,7 +19,7 @@ export default class extends Controller {
     urlSpotlightOrganizations: String,
     urlSpotlightLocations: String,
     urlSpotlightLanguages: String,
-    mainResource: String
+    mainResourcePath: String
   }
 
   // lifecycle
@@ -147,7 +147,7 @@ export default class extends Controller {
       this.selectedOption.click()
     } else {
       requestAnimationFrame(() => {
-        const url = new URL(`/${this.mainResourceValue}`, window.location.origin)
+        const url = new URL(this.mainResourcePathValue, window.location.origin)
         url.searchParams.set('s', this.searchInputTarget.value)
         window.location.href = url.toString()
       })

--- a/app/views/shared/_spotlight_search.html.erb
+++ b/app/views/shared/_spotlight_search.html.erb
@@ -1,6 +1,3 @@
-<% main_resource =
-     request.path.split("/").last.presence_in(%w[talks speakers events topics]) || "talks" %>
-<% resources = %w[talks speakers events] %>
 <%= ui_modal position: :top, size: :full, close_button: false, data: {action: "keydown.meta+k@window->modal#open spotlight@window->modal#open"}, class: "spotlight" do %>
   <div
     id="spotlight-search"
@@ -14,7 +11,7 @@
     data-spotlight-search-url-spotlight-organizations-value="<%= spotlight_organizations_path %>"
     data-spotlight-search-url-spotlight-locations-value="<%= spotlight_locations_path %>"
     data-spotlight-search-url-spotlight-languages-value="<%= spotlight_languages_path %>"
-    data-spotlight-search-main-resource-value="<%= main_resource %>">
+    data-spotlight-search-main-resource-path-value="<%= spotlight_main_resource_path %>">
     <div class="flex items-center gap-2 rounded-lg bg-white px-2 relative shrink-0">
       <%= fa("magnifying-glass", size: :md, style: :regular) %>
       <%= tag.input type: "text",
@@ -62,7 +59,7 @@
         class="flex items-center gap-2 border-b pb-4 hidden"
         data-spotlight-search-target="allSearchResults">
         <div role="option">search
-          <%= main_resource %>
+          <%= spotlight_main_resource %>
           for
           <strong class="text-base-content" data-spotlight-search-target="searchQuery"></strong></div>
         <kbd class="kbd kbd-sm text-base-content">⏎</kbd>
@@ -97,8 +94,8 @@
         data-spotlight-search-target="organizationsSearchResults"></div>
 
       <div class="grid md:grid-cols-3 md:divide-x gap-4 md:gap-0 h-full overflow-hidden pt-4 border-t">
-        <% resources.unshift(main_resource) %>
-        <% resources.uniq.each_with_index do |resource, index| %>
+        <% spotlight_resources.unshift(spotlight_main_resource) %>
+        <% spotlight_resources.uniq.each_with_index do |resource, index| %>
           <% padding = {"0" => "md:pr-4", "1" => "md:px-4", "2" => "md:pl-4"}.dig(index.to_s) %>
           <div
             id="<%= resource %>_search_results"


### PR DESCRIPTION
prior to this PR when visiting the events page, doing a spotlight search and pressing enter to see all results from the search we would be directed to the path `/events?s=query` but this route now don't have any search capabilities. 

This PR now routes to `/events/archive?s=query`

I cleaned up a bit the partial by putting the logic into an helper