### PR TITLE
Remove location, languages, and series from sqlite search

### DIFF
--- a/app/helpers/spotlight_helper.rb
+++ b/app/helpers/spotlight_helper.rb
@@ -15,4 +15,20 @@ module SpotlightHelper
       "topics" => topics_path
     }.fetch(spotlight_main_resource, spotlight_talks_path)
   end
+
+  def spotlight_search_backend
+    @spotlight_search_backend ||= Search::Backend.resolve.name
+  end
+
+  def spotlight_can_search_locations?
+    spotlight_search_backend != :sqlite_fts
+  end
+
+  def spotlight_can_search_languages?
+    spotlight_search_backend != :sqlite_fts
+  end
+
+  def spotlight_can_search_series?
+    spotlight_search_backend != :sqlite_fts
+  end
 end

--- a/app/views/shared/_spotlight_search.html.erb
+++ b/app/views/shared/_spotlight_search.html.erb
@@ -7,10 +7,10 @@
     data-spotlight-search-url-spotlight-speakers-value="<%= spotlight_speakers_path %>"
     data-spotlight-search-url-spotlight-events-value="<%= spotlight_events_path %>"
     data-spotlight-search-url-spotlight-topics-value="<%= spotlight_topics_path %>"
-    data-spotlight-search-url-spotlight-series-value="<%= spotlight_series_index_path %>"
+    data-spotlight-search-url-spotlight-series-value="<%= spotlight_can_search_series? ? spotlight_series_index_path : nil %>"
     data-spotlight-search-url-spotlight-organizations-value="<%= spotlight_organizations_path %>"
-    data-spotlight-search-url-spotlight-locations-value="<%= spotlight_locations_path %>"
-    data-spotlight-search-url-spotlight-languages-value="<%= spotlight_languages_path %>"
+    data-spotlight-search-url-spotlight-locations-value="<%= spotlight_can_search_locations? ? spotlight_locations_path : nil %>"
+    data-spotlight-search-url-spotlight-languages-value="<%= spotlight_can_search_languages? ? spotlight_languages_path : nil %>"
     data-spotlight-search-main-resource-path-value="<%= spotlight_main_resource_path %>">
     <div class="flex items-center gap-2 rounded-lg bg-white px-2 relative shrink-0">
       <%= fa("magnifying-glass", size: :md, style: :regular) %>


### PR DESCRIPTION
I think it is ok if the search experience with Sqlite is not on par with Typesense. As we are looking into preventing search bloats let's disable location, languages and series searches when we are using Sqlite backend