### PR TITLE
Refactor `Country` instances to be fully fledged

### DIFF
--- a/app/avo/resources/event.rb
+++ b/app/avo/resources/event.rb
@@ -47,6 +47,6 @@ class Avo::Resources::Event < Avo::BaseResource
   end
 
   def country_options
-    ISO3166::Country.all.map { |country| [country.translations["en"], country.alpha2] }.sort_by { |country| country.first }
+    Country.select_options
   end
 end

--- a/app/components/ui/stamp_component.rb
+++ b/app/components/ui/stamp_component.rb
@@ -35,7 +35,7 @@ class Ui::StampComponent < ApplicationComponent
   def url
     case kind
     when :country
-      country_path(stamp.country.translations["en"].parameterize)
+      stamp.country.path
     when :event
       stamp.event ? event_path(stamp.event) : nil
     when :contributor

--- a/app/controllers/countries_controller.rb
+++ b/app/controllers/countries_controller.rb
@@ -9,17 +9,15 @@ class CountriesController < ApplicationController
     end.uniq.group_by { |country| country&.continent || "Unknown" }.sort_by { |key, _value| key || "ZZ" }.to_h
     @events_by_country = Event.all.sort_by { |e| event_sort_date(e) }.reverse
       .group_by { |e| e.country || "Unknown" }
-      .sort_by { |key, _| (key.is_a?(String) ? key : key&.iso_short_name) || "ZZ" }.to_h
-    @users_by_country = {} # calculate_users_by_country TODO optimize this
+      .sort_by { |key, _| (key.is_a?(String) ? key : key&.name) || "ZZ" }.to_h
+    @users_by_country = calculate_users_by_country
     @event_map_markers = event_map_markers
   end
 
   def show
     @country = Country.find(params[:country])
     if @country.present?
-      @events = Event.includes(:series).all.select do |event|
-        event.country == @country
-      end.sort_by { |e| event_sort_date(e) }.reverse
+      @events = @country.events.includes(:series).sort_by { |e| event_sort_date(e) }.reverse
 
       @events_by_city = @events
         .select { |event| event.static_metadata&.location.present? }
@@ -27,8 +25,8 @@ class CountriesController < ApplicationController
         .sort_by { |city, _events| city }
         .to_h
 
-      @users = User.where("location LIKE ?", "%#{@country.translations["en"]}%").order(talks_count: :desc)
-      @stamps = Stamp.all.select { |stamp| stamp.has_country? && stamp.country == @country }
+      @users = @country.users.order(talks_count: :desc)
+      @stamps = @country.stamps
     else
       head :not_found
     end
@@ -36,17 +34,16 @@ class CountriesController < ApplicationController
 
   private
 
-  # TODO Geocode teh user and store the country code so that this query becomes faster
-  # def calculate_users_by_country
-  #   users_by_country = {}
+  def calculate_users_by_country
+    users_by_country = {}
 
-  #   User.where.not(location: [nil, ""]).find_each do |user|
-  #     if (country = user.location_info.country)
-  #       users_by_country[country] ||= Set.new
-  #       users_by_country[country] << user
-  #     end
-  #   end
+    User.where.not(location: [nil, ""]).find_each do |user|
+      if (country = user.location_info.country)
+        users_by_country[country] ||= Set.new
+        users_by_country[country] << user
+      end
+    end
 
-  #   users_by_country.transform_values(&:size)
-  # end
+    users_by_country.transform_values(&:size)
+  end
 end

--- a/app/controllers/events/cities_controller.rb
+++ b/app/controllers/events/cities_controller.rb
@@ -13,13 +13,13 @@ class Events::CitiesController < ApplicationController
     @cities_by_country = @events_by_city.keys.group_by { |city|
       events = @events_by_city[city]
       country = events.first.country
-      country&.translations&.dig("en") || "Unknown"
+      country&.name || "Unknown"
     }.sort_by { |country, _cities| country }.to_h
 
     @clean_city_names = {}
     @events_by_city.each do |city, events|
       country = events.first.country
-      country_name = country&.translations&.dig("en")
+      country_name = country&.name
       clean_name = city
 
       if country_name && city.include?(", #{country_name}")

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -15,10 +15,7 @@ class OrganizationsController < ApplicationController
     @events = @organization.events.includes(:series, :talks).order(start_date: :desc)
     @events_by_year = @events.group_by { |event| event.start_date&.year || "Unknown" }
 
-    @countries_with_events = @events.group_by(&:country_code)
-      .map { |code, events| [ISO3166::Country.new(code), events] }
-      .reject { |country, _| country.nil? }
-      .sort_by { |country, _| country.translations["en"] }
+    @countries_with_events = @events.grouped_by_country
 
     involvements = @organization.event_involvements.includes(:event).order(:position)
     @involvements_by_role = involvements.group_by(&:role)

--- a/app/controllers/profiles/map_controller.rb
+++ b/app/controllers/profiles/map_controller.rb
@@ -4,10 +4,7 @@ class Profiles::MapController < ApplicationController
 
   def index
     @events = @user.participated_events.includes(:series)
-    @countries_with_events = @events.group_by(&:country_code)
-      .map { |code, events| [ISO3166::Country.new(code), events] }
-      .reject { |country, _| country.nil? }
-      .sort_by { |country, _| country.translations["en"] }
+    @countries_with_events = @events.grouped_by_country
     @event_map_markers = event_map_markers(@events)
   end
 end

--- a/app/controllers/profiles/wrapped_controller.rb
+++ b/app/controllers/profiles/wrapped_controller.rb
@@ -57,7 +57,7 @@ class Profiles::WrappedController < ApplicationController
       .map { |wt| wt.talk.event&.country }
       .compact
       .uniq
-      .sort_by { |c| c.translations["en"] }
+      .sort_by(&:name)
 
     @languages_watched = @watched_talks_in_year
       .map { |wt| wt.talk.language }
@@ -110,7 +110,7 @@ class Profiles::WrappedController < ApplicationController
       .map(&:country)
       .compact
       .uniq
-      .sort_by { |c| c.translations["en"] }
+      .sort_by(&:name)
 
     @talks_given_in_year = @user.kept_talks
       .includes(:event)

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -46,10 +46,7 @@ class ProfilesController < ApplicationController
     @events_by_year = @events.group_by { |event| event.start_date&.year || "Unknown" }
 
     # Group events by country for the map tab
-    @countries_with_events = @events.group_by(&:country_code)
-      .map { |code, events| [ISO3166::Country.new(code), events] }
-      .reject { |country, _| country.nil? }
-      .sort_by { |country, _| country.translations["en"] }
+    @countries_with_events = @events.grouped_by_country
 
     @involved_events = @user.involved_events.includes(:series).distinct.order(start_date: :desc)
     event_involvements = @user.event_involvements.includes(:event).where(event: @involved_events)

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -1,32 +1,120 @@
 class Country
-  def self.find(term)
-    term = term.tr("-", " ")
+  attr_reader :record
 
-    return nil if term.blank?
-    return nil if term.downcase == "online"
-    return nil if term.downcase == "earth"
-    return nil if term.downcase == "unknown"
+  delegate :alpha2, :alpha3, :continent, :emoji_flag, :subdivisions, :iso_short_name, :common_name, :translations, to: :record
 
-    return ISO3166::Country.new("US") if ISO3166::Country.new("US").subdivisions.key?(term)
-    return ISO3166::Country.new("GB") if term == "UK"
-    return ISO3166::Country.new("GB") if term == "Scotland"
-
-    country = ISO3166::Country.find_country_by_iso_short_name(term) if country.nil?
-    country = ISO3166::Country.find_country_by_unofficial_names(term) if country.nil?
-    country = ISO3166::Country.search(term) if country.nil?
-
-    country
+  def initialize(record)
+    @record = record
   end
 
-  def self.find_by(country_code:)
-    ISO3166::Country.new(country_code)
+  def name
+    record.translations["en"] || record.common_name || record.iso_short_name
   end
 
-  def self.all
-    @all ||= ISO3166::Country.all.to_h { |country| [country.iso_short_name.parameterize, country] }
+  def slug
+    name.parameterize
   end
 
-  def self.slugs
-    all.keys
+  def path
+    "/countries/#{slug}"
+  end
+
+  def code
+    alpha2.downcase
+  end
+
+  def to_param
+    slug
+  end
+
+  def ==(other)
+    other.is_a?(Country) && alpha2 == other.alpha2
+  end
+
+  def eql?(other)
+    self == other
+  end
+
+  def hash
+    alpha2.hash
+  end
+
+  def events
+    Event.where(country_code: alpha2)
+  end
+
+  def users
+    User.where(country_code: alpha2)
+  end
+
+  def stamps
+    Stamp.all.select { |stamp| stamp.has_country? && stamp.country&.alpha2 == alpha2 }
+  end
+
+  def held_in_sentence
+    if name.starts_with?("United")
+      " held in the #{name}"
+    else
+      " held in #{name}"
+    end
+  end
+
+  class << self
+    def find(term)
+      term = term.to_s.tr("-", " ")
+
+      return nil if term.blank?
+      return nil if term.downcase.in?(%w[online earth unknown])
+
+      iso_record = find_iso_record(term)
+      iso_record ? new(iso_record) : nil
+    end
+
+    def find_by(country_code:)
+      return nil if country_code.blank?
+
+      iso_record = ISO3166::Country.new(country_code.upcase)
+      iso_record&.alpha2 ? new(iso_record) : nil
+    end
+
+    def all
+      @all ||= ISO3166::Country.all.map { |iso_record| new(iso_record) }
+    end
+
+    def all_by_slug
+      @all_by_slug ||= all.index_by(&:slug)
+    end
+
+    def slugs
+      all.map(&:slug)
+    end
+
+    def select_options
+      all.map { |country| [country.name, country.alpha2] }.sort_by(&:first)
+    end
+
+    def search(query)
+      return nil if query.blank?
+
+      results = Geocoder.search(query)
+      return nil if results.empty?
+
+      country_code = results.first.country_code
+      return nil if country_code.blank?
+
+      find_by(country_code: country_code)
+    end
+
+    private
+
+    def find_iso_record(term)
+      return ISO3166::Country.new("US") if ISO3166::Country.new("US").subdivisions.key?(term)
+
+      return ISO3166::Country.new("GB") if term.in?(%w[UK Scotland])
+
+      ISO3166::Country.find_country_by_iso_short_name(term) ||
+        ISO3166::Country.find_country_by_unofficial_names(term) ||
+        ISO3166::Country.search(term)
+    end
   end
 end

--- a/app/models/user/location_info.rb
+++ b/app/models/user/location_info.rb
@@ -1,7 +1,7 @@
 class User::LocationInfo < ActiveRecord::AssociatedObject
   def country
     @country ||= if user.country_code.present?
-      Country.find(user.country_code)
+      Country.find_by(country_code: user.country_code)
     else
       find_country_from_string(user.location)
     end
@@ -31,10 +31,6 @@ class User::LocationInfo < ActiveRecord::AssociatedObject
     user.latitude.present? && user.longitude.present?
   end
 
-  def country_name
-    country&.iso_short_name
-  end
-
   def to_s
     user.location
   end
@@ -44,9 +40,7 @@ class User::LocationInfo < ActiveRecord::AssociatedObject
   end
 
   def link_path
-    return nil unless country.present?
-
-    "/countries/#{country.translations["en"].parameterize}"
+    country&.path
   end
 
   private
@@ -54,14 +48,12 @@ class User::LocationInfo < ActiveRecord::AssociatedObject
   def find_country_from_string(location_string)
     return nil if location_string.blank?
 
-    country = Country.find(location_string)
-
-    return country if country.present?
+    found = Country.find(location_string)
+    return found if found.present?
 
     location_string.split(",").each do |part|
-      country = Country.find(part.strip)
-
-      return country if country.present?
+      found = Country.find(part.strip)
+      return found if found.present?
     end
 
     nil

--- a/app/views/countries/index.html.erb
+++ b/app/views/countries/index.html.erb
@@ -31,10 +31,10 @@
             <% users_count = @users_by_country[country] || 0 %>
             <% next if events.nil? %>
 
-            <%= link_to country_path(country.translations["en"].parameterize), id: "country-#{country.alpha2}", class: "event flex justify-between items-center" do %>
+            <%= link_to country_path(country.slug), id: "country-#{country.alpha2}", class: "event flex justify-between items-center" do %>
               <div class="flex items-center gap-2">
                 <span class="event-name"><%= country.emoji_flag %>
-                  <%= country.translations["en"] %></span>
+                  <%= country.name %></span>
               </div>
               <div class="flex gap-2">
                 <% if users_count > 0 %>

--- a/app/views/countries/show.html.erb
+++ b/app/views/countries/show.html.erb
@@ -6,11 +6,11 @@
       <span class="fi fi-<%= @country.alpha2.downcase %> border rounded w-36 text-[80pt]"></span>
       <div class="flex-col flex justify-center">
         <h1 class="mb-2 text-black font-bold">
-          <%= title @country.translations["en"] %>
+          <%= title @country.name %>
         </h1>
         <h3 class="hidden md:block text-[#636B74]">
           <% if @country.present? %>
-            <%= @country.translations["en"] %>, <%= @country.continent %>
+            <%= @country.name %>, <%= @country.continent %>
           <% end %>
         </h3>
       </div>
@@ -22,13 +22,13 @@
   </div>
 
   <p class="mt-3 md:mt-9 mb-6 text-[#636B74] max-w-[700px]">
-    We have indexed <%= pluralize(@users.count, "Rubyist") %> and <%= pluralize(@events.count, "event") %> in <%= @country.translations["en"] %>.
+    We have indexed <%= pluralize(@users.count, "Rubyist") %> and <%= pluralize(@events.count, "event") %> in <%= @country.name %>.
   </p>
 
   <div id="rubyists" class="mt-12">
     <section class="flex flex-col w-full gap-4">
       <div class="flex items-center justify-between w-full">
-        <h2 class="text-primary shrink-0">Rubyists in <%= @country.translations["en"] %></h2>
+        <h2 class="text-primary shrink-0">Rubyists in <%= @country.name %></h2>
       </div>
       <% if @users.any? %>
         <div class="grid min-w-full grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
@@ -37,7 +37,7 @@
           <% end %>
         </div>
       <% else %>
-        <p class="text-[#636B74]">No Rubyists with location set to <%= @country.translations["en"] %> yet.</p>
+        <p class="text-[#636B74]">No Rubyists with location set to <%= @country.name %> yet.</p>
       <% end %>
     </section>
   </div>

--- a/app/views/events/_header.html.erb
+++ b/app/views/events/_header.html.erb
@@ -27,10 +27,12 @@
         <h1 class="mb-2 text-black font-bold"><%= title event.name %></h1>
         <h3 class="text-[#636B74]">
           <% if event.static_metadata.location.present? && event.country.present? %>
-            <%= link_to event.static_metadata.location.gsub(", #{event.country.translations["en"]}", ""), city_path(event.static_metadata.location.parameterize), class: "link" %>,
-            <%= link_to event.country.translations["en"], event.country_path, class: "link" %>
+            <%= link_to event.static_metadata.location.gsub(", #{event.country.name}", ""), city_path(event.static_metadata.location.parameterize), class: "link" %>,
+            <%= link_to event.country.name, event.country.path, class: "link" %>
+          <% elsif event.country.present? %>
+            <%= link_to event.static_metadata.location, event.country.path, class: "link" %>
           <% else %>
-            <%= link_to event.static_metadata.location, event.country_path, class: "link" %>
+            <%= link_to event.static_metadata.location, countries_path, class: "link" %>
           <% end %>
           • <%= event.formatted_dates %>
         </h3>

--- a/app/views/events/cities/show.html.erb
+++ b/app/views/events/cities/show.html.erb
@@ -13,7 +13,7 @@
         <h3 class="hidden md:block text-[#636B74]">
           <% if @country.present? %>
             <%= @city.titleize %>,
-            <%= link_to @country.translations["en"], country_path(@country.translations["en"].parameterize), class: "hover:underline" %>
+            <%= link_to @country.name, @country.path, class: "hover:underline" %>
           <% end %>
         </h3>
       </div>
@@ -21,7 +21,7 @@
 
     <% if @country.present? %>
       <div class="flex flex-col gap-3 place-items-center">
-        <%= ui_button "View all events in #{@country.translations["en"]}", url: country_path(@country.translations["en"].parameterize), kind: :secondary, size: :sm, class: "w-full" %>
+        <%= ui_button "View all events in #{@country.name}", url: @country.path, kind: :secondary, size: :sm, class: "w-full" %>
       </div>
     <% end %>
   </div>

--- a/app/views/organizations/wrapped/index.html.erb
+++ b/app/views/organizations/wrapped/index.html.erb
@@ -80,9 +80,9 @@
         <div class="bg-white/10 backdrop-blur rounded-xl p-6 mb-8">
           <h3 class="text-lg font-bold text-white mb-4">🌍 Global Reach</h3>
           <div class="flex flex-wrap gap-2">
-            <% @countries_sponsored.sort_by { |c| c.translations["en"] }.each do |country| %>
-              <%= link_to country_path(country: country.alpha2.downcase), class: "inline-flex items-center gap-1 px-3 py-1 bg-white/10 rounded-full text-sm text-white hover:bg-white/20 transition" do %>
-                <%= country.emoji_flag %> <%= country.translations["en"] %>
+            <% @countries_sponsored.sort_by(&:name).each do |country| %>
+              <%= link_to country.path, class: "inline-flex items-center gap-1 px-3 py-1 bg-white/10 rounded-full text-sm text-white hover:bg-white/20 transition" do %>
+                <%= country.emoji_flag %> <%= country.name %>
               <% end %>
             <% end %>
           </div>

--- a/app/views/profiles/wrapped/pages/_top_events.html.erb
+++ b/app/views/profiles/wrapped/pages/_top_events.html.erb
@@ -19,7 +19,7 @@
       <div class="flex flex-wrap gap-2">
         <% countries_watched.first(8).each do |country| %>
           <span class="px-2 py-1 bg-red-50 text-red-700 rounded text-xs font-medium">
-            <%= country.translations["en"] %>
+            <%= country.name %>
           </span>
         <% end %>
       </div>

--- a/app/views/shared/_country_card.html.erb
+++ b/app/views/shared/_country_card.html.erb
@@ -4,8 +4,8 @@
       <div class="flex items-center gap-4">
         <span class="text-2xl"><%= country.emoji_flag %></span>
         <div>
-          <%= link_to country_path(country.translations["en"].parameterize), class: "hover:underline", data: {turbo_frame: "_top"} do %>
-            <h4 class="font-semibold"><%= country.translations["en"] %></h4>
+          <%= link_to country.path, class: "hover:underline", data: {turbo_frame: "_top"} do %>
+            <h4 class="font-semibold"><%= country.name %></h4>
           <% end %>
           <p class="text-sm text-gray-500"><%= pluralize(events.size, "event") %></p>
         </div>

--- a/app/views/stamps/index.html.erb
+++ b/app/views/stamps/index.html.erb
@@ -26,7 +26,7 @@
           <div class="flex flex-wrap gap-2">
             <% @missing_stamp_countries.each do |country| %>
               <div class="badge badge-warning badge-outline">
-                <%= country.translations["en"] %> (<%= country.alpha2 %>)
+                <%= country.name %> (<%= country.alpha2 %>)
               </div>
             <% end %>
           </div>
@@ -80,7 +80,7 @@
                   <% if stamp.has_country? %>
                     <div class="card-actions mt-2">
                       <%= link_to "View Events",
-                            country_path(country: stamp.country.alpha2.downcase),
+                            stamp.country.path,
                             class: "btn btn-xs btn-primary" %>
                     </div>
                   <% end %>

--- a/app/views/wrapped/index.html.erb
+++ b/app/views/wrapped/index.html.erb
@@ -202,9 +202,9 @@
           <h3 class="text-lg font-bold text-white mb-4">🌍 Events Across the Globe</h3>
           <p class="text-red-200 mb-4"><%= @countries_with_events.count %> countries hosted Ruby events</p>
           <div class="flex flex-wrap gap-2">
-            <% @countries_with_events.sort_by { |c| c.translations["en"] }.each do |country| %>
-              <%= link_to country_path(country: country.alpha2.downcase), class: "inline-flex items-center gap-1 px-3 py-1 bg-white/10 rounded-full text-sm text-white hover:bg-white/20 transition" do %>
-                <%= country.emoji_flag %> <%= country.translations["en"] %>
+            <% @countries_with_events.sort_by(&:name).each do |country| %>
+              <%= link_to country.path, class: "inline-flex items-center gap-1 px-3 py-1 bg-white/10 rounded-full text-sm text-white hover:bg-white/20 transition" do %>
+                <%= country.emoji_flag %> <%= country.name %>
               <% end %>
             <% end %>
           </div>

--- a/test/controllers/countries_controller_test.rb
+++ b/test/controllers/countries_controller_test.rb
@@ -91,4 +91,25 @@ class CountriesControllerTest < ActionDispatch::IntegrationTest
     assert_not_nil assigns(:events)
     assert_kind_of Array, assigns(:events)
   end
+
+  test "country_path helper works with Country instance via to_param" do
+    country = Country.find_by(country_code: "DE")
+
+    assert_equal "/countries/germany", country_path(country)
+  end
+
+  test "country_path helper works with multi-word country names" do
+    country = Country.find_by(country_code: "US")
+
+    assert_equal "/countries/united-states", country_path(country)
+  end
+
+  test "can navigate to country page using Country instance" do
+    country = Country.find_by(country_code: "US")
+
+    get country_path(country)
+
+    assert_response :success
+    assert_equal country.alpha2, assigns(:country).alpha2
+  end
 end

--- a/test/models/country_test.rb
+++ b/test/models/country_test.rb
@@ -17,9 +17,12 @@ class CountryTest < ActiveSupport::TestCase
   end
 
   test "find_by returns nil for invalid code" do
-    country = Country.find_by(country_code: "XX")
+    assert_nil Country.find_by(country_code: "XX")
+  end
 
-    assert_nil country
+  test "find_by returns nil for blank code" do
+    assert_nil Country.find_by(country_code: nil)
+    assert_nil Country.find_by(country_code: "")
   end
 
   test "find returns country by name" do
@@ -38,6 +41,10 @@ class CountryTest < ActiveSupport::TestCase
 
   test "find returns nil for empty string" do
     assert_nil Country.find("")
+  end
+
+  test "find returns nil for nil" do
+    assert_nil Country.find(nil)
   end
 
   test "find returns nil for online" do
@@ -83,12 +90,19 @@ class CountryTest < ActiveSupport::TestCase
     assert_equal "US", country.alpha2
   end
 
-  test "all returns hash of countries by slug" do
+  test "all returns array of Country instances" do
     countries = Country.all
+
+    assert countries.is_a?(Array)
+    assert countries.first.is_a?(Country)
+  end
+
+  test "all_by_slug returns hash of countries by slug" do
+    countries = Country.all_by_slug
 
     assert countries.is_a?(Hash)
     assert countries.key?("germany")
-    assert countries.key?("united-states-of-america-the")
+    assert countries["germany"].is_a?(Country)
   end
 
   test "slugs returns array of country slugs" do
@@ -96,5 +110,211 @@ class CountryTest < ActiveSupport::TestCase
 
     assert slugs.is_a?(Array)
     assert_includes slugs, "germany"
+  end
+
+  test "name returns English translation" do
+    country = Country.find_by(country_code: "DE")
+
+    assert_equal "Germany", country.name
+  end
+
+  test "name returns United States for US" do
+    country = Country.find_by(country_code: "US")
+
+    assert_equal "United States", country.name
+  end
+
+  test "slug returns parameterized name" do
+    country = Country.find_by(country_code: "DE")
+
+    assert_equal "germany", country.slug
+  end
+
+  test "slug handles multi-word names" do
+    country = Country.find_by(country_code: "US")
+
+    assert_equal "united-states", country.slug
+  end
+
+  test "path returns countries path with slug" do
+    country = Country.find_by(country_code: "DE")
+
+    assert_equal "/countries/germany", country.path
+  end
+
+  test "code returns lowercase alpha2" do
+    country = Country.find_by(country_code: "DE")
+
+    assert_equal "de", country.code
+  end
+
+  test "to_param returns slug for use in Rails path helpers" do
+    country = Country.find_by(country_code: "DE")
+
+    assert_equal "germany", country.to_param
+  end
+
+  test "two countries with same alpha2 are equal" do
+    country1 = Country.find_by(country_code: "DE")
+    country2 = Country.find_by(country_code: "DE")
+
+    assert_equal country1, country2
+  end
+
+  test "two countries with different alpha2 are not equal" do
+    country1 = Country.find_by(country_code: "DE")
+    country2 = Country.find_by(country_code: "US")
+
+    assert_not_equal country1, country2
+  end
+
+  test "country is not equal to non-Country objects" do
+    country = Country.find_by(country_code: "DE")
+
+    assert_not_equal country, "DE"
+    assert_not_equal country, nil
+  end
+
+  test "eql? returns true for countries with same alpha2" do
+    country1 = Country.find_by(country_code: "DE")
+    country2 = Country.find_by(country_code: "DE")
+
+    assert country1.eql?(country2)
+  end
+
+  test "hash is same for countries with same alpha2" do
+    country1 = Country.find_by(country_code: "DE")
+    country2 = Country.find_by(country_code: "DE")
+
+    assert_equal country1.hash, country2.hash
+  end
+
+  test "countries can be used as hash keys" do
+    country1 = Country.find_by(country_code: "DE")
+    country2 = Country.find_by(country_code: "DE")
+
+    hash = {country1 => "value"}
+
+    assert_equal "value", hash[country2]
+  end
+
+  test "record returns underlying ISO3166::Country" do
+    country = Country.find_by(country_code: "DE")
+
+    assert country.record.is_a?(ISO3166::Country)
+    assert_equal "DE", country.record.alpha2
+  end
+
+  test "delegates alpha2 to record" do
+    country = Country.find_by(country_code: "DE")
+
+    assert_equal "DE", country.alpha2
+  end
+
+  test "delegates continent to record" do
+    country = Country.find_by(country_code: "DE")
+
+    assert_equal "Europe", country.continent
+  end
+
+  test "delegates emoji_flag to record" do
+    country = Country.find_by(country_code: "DE")
+
+    assert_equal "🇩🇪", country.emoji_flag
+  end
+
+  test "select_options returns array of [name, alpha2] pairs" do
+    options = Country.select_options
+
+    assert options.is_a?(Array)
+    assert options.first.is_a?(Array)
+    assert_equal 2, options.first.size
+
+    names = options.map(&:first)
+    assert_equal names.sort, names
+  end
+
+  test "select_options contains expected countries" do
+    options = Country.select_options
+    option_map = options.to_h
+
+    assert_equal "DE", option_map["Germany"]
+    assert_equal "US", option_map["United States"]
+  end
+
+  test "events returns ActiveRecord::Relation" do
+    country = Country.find_by(country_code: "NL")
+
+    assert country.events.is_a?(ActiveRecord::Relation)
+  end
+
+  test "events returns events matching country_code" do
+    country = Country.find_by(country_code: "NL")
+    event = events(:rails_world_2023)
+    event.update!(country_code: "NL")
+
+    assert_includes country.events, event
+  end
+
+  test "events does not include events from other countries" do
+    country = Country.find_by(country_code: "NL")
+    event = events(:rails_world_2023)
+    event.update!(country_code: "DE")
+
+    assert_not_includes country.events, event
+  end
+
+  test "users returns ActiveRecord::Relation" do
+    country = Country.find_by(country_code: "US")
+
+    assert country.users.is_a?(ActiveRecord::Relation)
+  end
+
+  test "users returns users matching country_code" do
+    country = Country.find_by(country_code: "US")
+    user = User.create!(name: "Test User", country_code: "US")
+
+    assert_includes country.users, user
+  end
+
+  test "users does not include users from other countries" do
+    country = Country.find_by(country_code: "US")
+    user = User.create!(name: "Test User", country_code: "DE")
+
+    assert_not_includes country.users, user
+  end
+
+  test "stamps returns array of stamps for the country" do
+    country = Country.find_by(country_code: "NL")
+
+    assert country.stamps.is_a?(Array)
+  end
+
+  test "stamps returns stamps matching country" do
+    country = Country.find_by(country_code: "NL")
+    stamps = country.stamps
+
+    stamps.each do |stamp|
+      assert stamp.has_country?
+      assert_equal "NL", stamp.country.alpha2
+    end
+  end
+
+  test "held_in_sentence returns sentence for regular country" do
+    country = Country.find_by(country_code: "DE")
+
+    assert_equal " held in Germany", country.held_in_sentence
+  end
+
+  test "held_in_sentence returns sentence with 'the' for United countries" do
+    country = Country.find_by(country_code: "US")
+
+    assert_equal " held in the United States", country.held_in_sentence
+  end
+
+  test "held_in_sentence returns sentence with 'the' for United Kingdom" do
+    country = Country.find_by(country_code: "GB")
+
+    assert_equal " held in the United Kingdom", country.held_in_sentence
   end
 end

--- a/test/models/user/location_info_test.rb
+++ b/test/models/user/location_info_test.rb
@@ -16,13 +16,13 @@ class User::LocationInfoTest < ActiveSupport::TestCase
   test "country returns Country object from geocoded country_code" do
     user = User.create!(name: "Test User", country_code: "US")
 
-    assert_equal "United States of America (the)", user.location_info.country_name
+    assert_equal "United States", user.location_info.country.name
   end
 
   test "country falls back to parsing location when not geocoded" do
     user = User.create!(name: "Test User", location: "Berlin, Germany")
 
-    assert_equal "Germany", user.location_info.country_name
+    assert_equal "Germany", user.location_info.country.name
   end
 
   test "city returns geocoded city" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -324,7 +324,7 @@ class UserTest < ActiveSupport::TestCase
 
     assert_not_nil user.country
     assert_equal "US", user.country.alpha2
-    assert_equal "United States of America (the)", user.country.iso_short_name
+    assert_equal "United States", user.country.name
   end
 
   test "country returns Country object for different country codes" do
@@ -332,7 +332,7 @@ class UserTest < ActiveSupport::TestCase
 
     assert_not_nil user.country
     assert_equal "DE", user.country.alpha2
-    assert_equal "Germany", user.country.iso_short_name
+    assert_equal "Germany", user.country.name
   end
 
   test "country returns nil when country_code is blank" do


### PR DESCRIPTION
This pull request refactors how countries are represented and accessed throughout the codebase. 

`Country` was refactored from a class with static lookup methods returning raw `ISO3166::Country` records to a fully-fledged wrapper class with instance methods.


  Example usage:
```ruby
country = Country.find("United States")
country.name          # => "United States"
country.slug          # => "united-states"
country.path          # => "/countries/united-states"
country.code          # => "us"
country.alpha2        # => "US"
country.emoji_flag    # => "🇺🇸"
```

```ruby
Country.find("US")        # => Country instance
Country.find("usa")       # => Country instance
Country.find("GB")        # => Country instance
```
```ruby
country.events        # => Event.where(country_code: "DE")
country.users         # => User.where(country_code: "DE")
country.stamps        # => [Stamp, ...] stamps for this country
```

This change really simplifies our view logic and how we display country information. This is in preparation to utilize #1247 and to update all our views which richer location information. 