### PR TITLE
New details for Ruby for Good - Belgium

### DIFF
--- a/data/ruby-for-good/ruby-for-good-belgium-2026/event.yml
+++ b/data/ruby-for-good/ruby-for-good-belgium-2026/event.yml
@@ -1,8 +1,11 @@
 ---
 id: "ruby-for-good-belgium-2026"
 title: "Ruby for Good - Belgium 2026"
-description: ""
+description: |-
+  A code retreat where Ruby programmers (and others!) from all over the globe get together to build and contribute to projects that help our communities.
 location: "Ghent, Belgium"
+aliases:
+  - Ruby in Ghent
 kind: "retreat"
 start_date: "2026-02-02"
 end_date: "2026-02-04"

--- a/data/ruby-for-good/ruby-for-good-belgium-2026/venue.yml
+++ b/data/ruby-for-good/ruby-for-good-belgium-2026/venue.yml
@@ -1,0 +1,15 @@
+---
+name: "Jam Ghent Hotel"
+address:
+  street: "Gaspar de Craeyerstraat 2"
+  city: "Ghent"
+  region: "Flanders"
+  postal_code: "9000"
+  country: "Belgium"
+  country_code: "BE"
+  display: "Gaspar de Craeyerstraat 2, 9000 Gent, Belgium"
+coordinates:
+  latitude: 51.0418937834923
+  longitude: 3.722846025921733
+maps:
+  google: "https://maps.app.goo.gl/mD6wXQkyCZ88ejsg6"


### PR DESCRIPTION
# Description

Added venue and description from website for Ruby for Good - Belgium aka Ruby in Ghent. It looks like the description won't update even with a new seed run, but when we fix the seeds it'll be ready!