### PR TITLE
Fix whitespace break for Rubyist count

### DIFF
--- a/app/views/countries/index.html.erb
+++ b/app/views/countries/index.html.erb
@@ -23,7 +23,7 @@
         <div
           id="events-<%= continent %>"
           class="
-            grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-x-8 lg:gap-x-12 gap-y-2
+            grid sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-x-8 lg:gap-x-12 gap-y-2
             min-w-full pt-4 pb-8
           ">
           <% countries.sort_by(&:iso_short_name).each do |country| %>
@@ -36,13 +36,13 @@
                 <span class="event-name"><%= country.emoji_flag %>
                   <%= country.name %></span>
               </div>
-              <div class="flex gap-2">
+              <div class="flex gap-2 items-center">
                 <% if users_count > 0 %>
                   <%= ui_badge(
                         "#{users_count} #{"Rubyist".pluralize(users_count)}",
                         kind: :primary,
                         outline: true,
-                        size: :lg,
+                        size: :md,
                         class: "whitespace-nowrap"
                       ) %>
                 <% end %>


### PR DESCRIPTION
## Before
<img width="2616" height="1248" alt="CleanShot 2026-01-08 at 13 59 12@2x" src="https://github.com/user-attachments/assets/3c1cbfd4-7ca0-449c-9b2e-01a4bfd31e2d" />


## After

#### Laptop
<img width="1256" height="1048" alt="CleanShot 2026-01-08 at 13 57 27@2x" src="https://github.com/user-attachments/assets/a6274be8-3079-4128-9d15-139f513ec9db" />

#### 4k 
<img width="1458" height="962" alt="CleanShot 2026-01-08 at 13 57 39@2x" src="https://github.com/user-attachments/assets/e2bd9668-b701-412d-880e-7a61316aa34d" />
