### PR TITLE
Refactor user to use preloaded associations

### DIFF
--- a/app/controllers/event_participations_controller.rb
+++ b/app/controllers/event_participations_controller.rb
@@ -46,7 +46,7 @@ class EventParticipationsController < ApplicationController
   end
 
   def set_participants
-    @participants = @event.participants.includes(:connected_accounts).order(:name)
+    @participants = @event.participants.preloaded.order(:name)
   end
 
   def participation_params

--- a/app/controllers/events/participants_controller.rb
+++ b/app/controllers/events/participants_controller.rb
@@ -3,7 +3,7 @@ class Events::ParticipantsController < ApplicationController
   before_action :set_event
 
   def index
-    @participants = @event.participants.includes(:connected_accounts).order(:name).distinct
+    @participants = @event.participants.preloaded.order(:name).distinct
     @participation = Current.user&.main_participation_to(@event)
   end
 

--- a/app/controllers/events/speakers_controller.rb
+++ b/app/controllers/events/speakers_controller.rb
@@ -10,7 +10,7 @@ class Events::SpeakersController < ApplicationController
       speaker_counts = speaker_ids.tally
 
       @speakers_with_counts = User
-        .includes(:connected_accounts)
+        .preloaded
         .where(id: speaker_counts.keys)
         .where("talks_count > 0")
         .map do |speaker|

--- a/app/controllers/locations/base_controller.rb
+++ b/app/controllers/locations/base_controller.rb
@@ -138,9 +138,9 @@ class Locations::BaseController < ApplicationController
 
   def location_users
     @location_users ||= if city? || state?
-      @location.users.geocoded.order(talks_count: :desc)
+      @location.users.geocoded.order(talks_count: :desc).preloaded
     else
-      @location.users.canonical.order(talks_count: :desc)
+      @location.users.canonical.order(talks_count: :desc).preloaded
     end
   end
 

--- a/app/controllers/locations/users_controller.rb
+++ b/app/controllers/locations/users_controller.rb
@@ -30,7 +30,7 @@ class Locations::UsersController < Locations::BaseController
     city_user_ids = @users.pluck(:id)
     nearby_user_ids = (@nearby_users || []).map { |n| n.is_a?(Hash) ? n[:user].id : n.id }
     exclude_ids = city_user_ids + nearby_user_ids
-    @state_users = @state.users.geocoded.where.not(id: exclude_ids).order(talks_count: :desc)
+    @state_users = @state.users.geocoded.preloaded.where.not(id: exclude_ids).order(talks_count: :desc)
   end
 
   def redirect_path_helper

--- a/app/controllers/profiles/wrapped_controller.rb
+++ b/app/controllers/profiles/wrapped_controller.rb
@@ -209,7 +209,7 @@ class Profiles::WrappedController < ApplicationController
 
     @is_contributor = @user.contributor?
     @contributor = @user.contributor
-    @has_passport = @user.passports.any?
+    @has_passport = @user.ruby_passport_claimed?
     @passports = @user.passports
 
     @involvements_in_year = @user.event_involvements

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -83,8 +83,8 @@ class ProfilesController < ApplicationController
   end
 
   def set_user
-    @user = User.includes(:talks, :passports).find_by_slug_or_alias(params[:slug])
-    @user = User.includes(:talks).find_by_github_handle(params[:slug]) unless @user.present?
+    @user = User.preloaded.includes(:talks).find_by_slug_or_alias(params[:slug])
+    @user = User.preloaded.includes(:talks).find_by_github_handle(params[:slug]) unless @user.present?
 
     if @user.blank?
       redirect_to speakers_path, status: :moved_permanently, notice: "User not found"

--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -249,6 +249,7 @@ class City
     User.geocoded
       .near(coordinates, radius_km, units: :km)
       .where.not(id: exclude_ids)
+      .preloaded
       .limit(limit)
       .map do |user|
         distance = Geocoder::Calculations.distance_between(

--- a/app/models/stamp.rb
+++ b/app/models/stamp.rb
@@ -72,7 +72,7 @@ class Stamp
         stamps << contributor_stamp
       end
 
-      if user.passports.any? && passport_stamp
+      if user.ruby_passport_claimed? && passport_stamp
         stamps << passport_stamp
       end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -198,6 +198,9 @@ class User < ApplicationRecord
   scope :not_marked_for_deletion, -> { where(marked_for_deletion: false) }
   scope :with_public_wrapped, -> { where("json_extract(settings, '$.wrapped_public') = ?", true) }
   scope :with_feedback_enabled, -> { where("json_extract(settings, '$.feedback_enabled') = ?", true) }
+  scope :with_location, -> { where.not(location: [nil, ""]) }
+  scope :without_location, -> { where(location: [nil, ""]) }
+  scope :preloaded, -> { includes(:connected_accounts) }
 
   def self.normalize_github_handle(value)
     value
@@ -262,7 +265,11 @@ class User < ApplicationRecord
   end
 
   def verified?
-    !suspicious? && connected_accounts.find { |account| account.provider == "github" }
+    !suspicious? && connected_accounts.any? { |account| account.provider == "github" }
+  end
+
+  def ruby_passport_claimed?
+    connected_accounts.any? { |account| account.provider == "passport" }
   end
 
   def possessive_pronoun

--- a/app/models/user/suspicion_detector.rb
+++ b/app/models/user/suspicion_detector.rb
@@ -59,7 +59,7 @@ class User::SuspicionDetector < ActiveRecord::AssociatedObject
   def calculate_suspicious?
     return false unless user.verified?
     return false if user.suspicion_cleared?
-    return false if user.passports.any?
+    return false if user.ruby_passport_claimed?
 
     signals.count(true) >= SIGNAL_THRESHOLD
   end

--- a/app/views/hover_cards/users/_content.html.erb
+++ b/app/views/hover_cards/users/_content.html.erb
@@ -14,7 +14,7 @@
           <%= fa("badge-check", class: "fill-blue-500 shrink-0", size: :xs) %>
         <% end %>
 
-        <% if user.passports.any? %>
+        <% if user.ruby_passport_claimed? %>
           <%= fa("passport", class: "fill-orange-800 shrink-0", size: :xs) %>
         <% end %>
       <% end %>

--- a/app/views/profiles/_header_content.html.erb
+++ b/app/views/profiles/_header_content.html.erb
@@ -22,7 +22,7 @@
           <% end %>
         <% end %>
 
-        <% if user.passports.any? %>
+        <% if user.ruby_passport_claimed? %>
           <%= ui_tooltip "#{user.name} claimed #{user.possessive_pronoun} Ruby Passport" do %>
             <%= fa("passport", class: "fill-orange-800") %>
           <% end %>

--- a/app/views/users/_card.html.erb
+++ b/app/views/users/_card.html.erb
@@ -10,7 +10,7 @@
           <%= fa("badge-check", class: "fill-blue-500", size: :xs) %>
         <% end %>
 
-        <% if user.passports.any? %>
+        <% if user.ruby_passport_claimed? %>
           <%= fa("passport", class: "fill-orange-800", size: :xs) %>
         <% end %>
       </div>

--- a/test/models/user/suspicion_detector_test.rb
+++ b/test/models/user/suspicion_detector_test.rb
@@ -406,7 +406,7 @@ class User::SuspicionDetectorTest < ActiveSupport::TestCase
     user.connected_accounts.create!(provider: "passport", uid: "ruby-passport-123")
 
     assert user.verified?
-    assert user.passports.any?
+    assert user.ruby_passport_claimed?
     assert_not user.suspicion_detector.calculate_suspicious?
   end
 end


### PR DESCRIPTION
Refactor user and event controllers to use preloaded associations and update passport checks

- adds a `preloaded` scope on the user to require associations, currently connected_accounts for the verified and passport badge
- adds ruby_passport_claimed? method to the user model to extract this logic and ensure we use a method that will use the preloaded association