### PR TITLE
import_involvements! mutates instead of destroys.

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -73,11 +73,14 @@ class Event < ApplicationRecord
   has_many :visitor_participants, -> { where(event_participations: {attended_as: :visitor}) },
     through: :event_participations, source: :user
 
+  # Event involvement associations
   has_many :event_involvements, dependent: :destroy
   has_many :involved_users, -> { where(event_involvements: {involvementable_type: "User"}) },
     through: :event_involvements, source: :involvementable, source_type: "User"
   has_many :involved_event_series, -> { where(event_involvements: {involvementable_type: "EventSeries"}) },
     through: :event_involvements, source: :involvementable, source_type: "EventSeries"
+
+  accepts_nested_attributes_for :event_involvements, allow_destroy: true, reject_if: :all_blank
 
   has_object :schedule
   has_object :static_metadata

--- a/app/models/static/event.rb
+++ b/app/models/static/event.rb
@@ -274,6 +274,20 @@ module Static
     def import!(index: SEARCH_INDEX_ON_IMPORT_DEFAULT)
       return if Rails.env.test? && !ENV["SEED_SMOKE_TEST"] # this method slowdown a lot of the test suite
 
+      event = import_event!
+
+      import_cfps!(event)
+      import_videos!(event, index: index)
+      import_sponsors!(event)
+      import_involvements!(event)
+      import_transcripts!(event)
+
+      Search::Backend.index(event) if index
+
+      event
+    end
+
+    def import_event!
       event = ::Event.find_or_create_by(slug: slug)
 
       event.update!(
@@ -305,14 +319,6 @@ module Static
       event.sync_aliases_from_list(aliases) if aliases.present?
 
       puts event.slug unless Rails.env.test?
-
-      import_cfps!(event)
-      import_videos!(event, index: index)
-      import_sponsors!(event)
-      import_involvements!(event)
-      import_transcripts!(event)
-
-      Search::Backend.index(event) if index
 
       event
     end
@@ -415,7 +421,10 @@ module Static
     def import_involvements!(event)
       return unless involvements_file?
 
-      event.event_involvements.destroy_all
+      event_involvements = event.event_involvements
+
+      # Mark existing involvements for destruction
+      event_involvements_attributes = event_involvements.map { it.attributes.merge(_destroy: true) }
 
       involvements = YAML.load_file(involvements_file_path)
 
@@ -428,17 +437,28 @@ module Static
           user = ::User.find_by_name_or_alias(user_name)
 
           unless user
+            # raise "User '#{user_name}' not found in speakers.yml" if Rails.env.development?
             puts "Creating user: #{user_name}" unless Rails.env.test?
             user = ::User.create!(name: user_name)
           end
 
-          involvement = ::EventInvolvement.find_or_initialize_by(
-            event: event,
-            involvementable: user,
-            role: role
-          )
-          involvement.position = index
-          involvement.save!
+          # Get index if involvement already exists in the attributes array
+          attributes_index = event_involvements_attributes.index do |attrs|
+            attrs["role"] == role && attrs["involvementable_type"] == "User" &&
+              attrs["involvementable_id"] == user.id
+          end
+
+          if attributes_index.present?
+            # Replace the involvement attributes to avoid destroying it (update position if necessary)
+            event_involvements_attributes[attributes_index].update(position: index, _destroy: false)
+          else
+            # Add new involvement
+            event_involvements_attributes << {
+              role: role,
+              involvementable: user,
+              position: index
+            }
+          end
         end
 
         user_count = involvement_data["users"]&.compact&.size || 0
@@ -449,19 +469,31 @@ module Static
           organization = ::Organization.find_by(name: org_name) || ::Organization.find_by(slug: org_name.parameterize)
 
           unless organization
+            # raise "Organization '#{org_name}' not found" if Rails.env.development?
             puts "Creating organization: #{org_name}" unless Rails.env.test?
             organization = ::Organization.create!(name: org_name)
           end
 
-          involvement = ::EventInvolvement.find_or_initialize_by(
-            event: event,
-            involvementable: organization,
-            role: role
-          )
-          involvement.position = user_count + index
-          involvement.save!
+          # Get index if involvement already exists in the attributes array
+          attributes_index = event_involvements_attributes.index do |attrs|
+            attrs["role"] == role && attrs["involvementable_type"] == "Organization" &&
+              attrs["involvementable_id"] == organization.id
+          end
+
+          if attributes_index.present?
+            # Replace the involvement attributes to avoid destroying it (update position if necessary)
+            event_involvements_attributes[attributes_index].update(position: index + user_count, _destroy: false)
+          else
+            # Add new involvement
+            event_involvements_attributes << {
+              role: role,
+              involvementable: organization,
+              position: index + user_count
+            }
+          end
         end
       end
+      event.update!(event_involvements_attributes: event_involvements_attributes)
     end
 
     def transcripts_file_path

--- a/test/models/static/event_test.rb
+++ b/test/models/static/event_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class Static::EventTest < ActiveSupport::TestCase
+  test "import_involvements!" do
+    event = Static::Event.find_by_slug("xoruby-portland-2025")
+    event.import_event!
+    event_record = event.event_record
+    event.import_involvements!(event_record)
+    involvements = event_record.reload.event_involvements.pluck(:id)
+    event.import_involvements!(event_record)
+    assert_equal involvements, event_record.reload.event_involvements.pluck(:id)
+    assert_equal 6, event_record.event_involvements.count
+  end
+
+  test "today? returns false if event is in the past" do
+    event = Static::Event.find_by_slug("railsconf-2025")
+    assert_not event.today?
+  end
+end


### PR DESCRIPTION
# Description

Use nested attributes to mutate the records instead of destroying them. As a bonus, we do fewer queries and saves!

# Tested

Renaming a role (sends it to bottom of the page)
Deleting a person
Adding new people