### PR TITLE
Improve country page map to show full country/continent bounds

### DIFF
--- a/app/controllers/concerns/geo_map_layers.rb
+++ b/app/controllers/concerns/geo_map_layers.rb
@@ -60,22 +60,22 @@ module GeoMapLayers
   def add_country_layer(layers)
     return unless @country.present?
 
-    maybe_add_layer(layers, id: "geo-country", label: @country.name, emoji: @country.emoji_flag, events: @country.events.includes(:series))
+    maybe_add_layer(layers, id: "geo-country", label: @country.name, emoji: @country.emoji_flag, bounds: @country.bounds, events: @country.events.includes(:series))
   end
 
   def add_continent_layer(layers)
     return unless @continent.present?
 
-    maybe_add_layer(layers, id: "geo-continent", label: @continent.name, emoji: @continent.emoji_flag, events: @continent.events.includes(:series))
+    maybe_add_layer(layers, id: "geo-continent", label: @continent.name, emoji: @continent.emoji_flag, bounds: @continent.bounds, events: @continent.events.includes(:series))
   end
 
-  def maybe_add_layer(layers, id:, label:, emoji:, events:)
+  def maybe_add_layer(layers, id:, label:, emoji:, events:, bounds: nil)
     current_marker_count = layers.last&.dig(:markers)&.size || 0
     markers = event_map_markers(filter_events_by_time(events.to_a).select(&:geocoded?))
 
     return unless markers.any? && markers.size > current_marker_count
 
-    layers << build_layer(id: id, label: label, emoji: emoji, markers: markers)
+    layers << build_layer(id: id, label: label, emoji: emoji, markers: markers, bounds: bounds)
   end
 
   def build_layer(id:, label:, emoji:, events: nil, markers: nil, bounds: nil, city_pin: nil, always_visible: false)

--- a/app/views/shared/_location_sidebar.html.erb
+++ b/app/views/shared/_location_sidebar.html.erb
@@ -38,7 +38,7 @@
       <% if geo_layers.empty? %>
         data-map-markers-value="<%= event_map_markers.to_json %>"
       <% end %>
-      <% if geo_layers.empty? && location.bounds.present? %>
+      <% if location.bounds.present? %>
         data-map-bounds-value="<%= location.bounds.to_json %>"
       <% end %>>
       <div class="flex items-center justify-between mb-4">


### PR DESCRIPTION
- Always pass location bounds to map when available
- Use visible layer's bounds on initial load (e.g., continent bounds when country has no events)
- Fit to selected layer's bounds when switching tabs
- Add continent bounds to geo-continent layer