### PR TITLE
Add YouTube video availability checking

### DIFF
--- a/app/avo/filters/video_availability.rb
+++ b/app/avo/filters/video_availability.rb
@@ -1,0 +1,32 @@
+class Avo::Filters::VideoAvailability < Avo::Filters::BooleanFilter
+  self.name = "Video Availability"
+
+  def apply(request, query, values)
+    if values["available"]
+      query = query.video_available
+    end
+
+    if values["unavailable"]
+      query = query.video_unavailable
+    end
+
+    if values["watchable"]
+      query = query.watchable
+    end
+
+    if values["marked_unavailable"]
+      query = query.where.not(video_unavailable_at: nil)
+    end
+
+    query
+  end
+
+  def options
+    {
+      available: "Watchable & Available",
+      unavailable: "Watchable & Unavailable",
+      watchable: "Watchable",
+      marked_unavailable: "Marked Unavailable"
+    }
+  end
+end

--- a/app/avo/resources/talk.rb
+++ b/app/avo/resources/talk.rb
@@ -57,6 +57,10 @@ class Avo::Resources::Talk < Avo::BaseResource
     field :year, as: :number, hide_on: :index
     field :video_id, as: :text, hide_on: :index
     field :video_provider, as: :text, hide_on: :index
+    field :video_available, name: "Video Available", as: :boolean do
+      record.video_available?
+    end
+    field :video_unavailable_at, as: :date_time, hide_on: :index
     field :external_player, as: :boolean, hide_on: :index
     field :date, as: :date, hide_on: :index
     field :like_count, as: :number, hide_on: :index
@@ -96,5 +100,6 @@ class Avo::Resources::Talk < Avo::BaseResource
     filter Avo::Filters::Slug
     filter Avo::Filters::Language
     filter Avo::Filters::VideoProvider
+    filter Avo::Filters::VideoAvailability
   end
 end

--- a/app/clients/youtube/video.rb
+++ b/app/clients/youtube/video.rb
@@ -1,5 +1,16 @@
 module YouTube
   class Video < Client
+    def available?(video_id)
+      path = "/videos"
+      query = {
+        part: "status",
+        id: video_id
+      }
+
+      response = all_items(path, query: query)
+      response.present?
+    end
+
     def get_statistics(video_id)
       path = "/videos"
       query = {

--- a/app/jobs/recurring/youtube_video_availability_job.rb
+++ b/app/jobs/recurring/youtube_video_availability_job.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Recurring::YouTubeVideoAvailabilityJob < ApplicationJob
+  include ActiveJob::Continuable
+
+  queue_as :low
+
+  RECHECK_INTERVAL = 1.month
+
+  def perform
+    step(:check_availability) do |step|
+      talks_to_check.find_each(start: step.cursor) do |talk|
+        talk.check_video_availability!
+        step.advance! from: talk.id
+      rescue => e
+        Rails.logger.error("Error checking availability for talk #{talk.id}: #{e.message}")
+        step.advance! from: talk.id
+      end
+    end
+  end
+
+  private
+
+  def talks_to_check
+    Talk.youtube.where(
+      "video_availability_checked_at IS NULL OR video_availability_checked_at < ?",
+      RECHECK_INTERVAL.ago
+    )
+  end
+end

--- a/app/views/talks/_card.html.erb
+++ b/app/views/talks/_card.html.erb
@@ -60,6 +60,17 @@
       </div>
     <% end %>
 
+    <% if talk.video_unavailable? %>
+      <div
+        class="
+          absolute top-0 right-0 z-20 flex gap-2 p-2 m-3 rounded-full bg-black/15
+          backdrop-blur-md
+        ">
+        <span class="items-center hidden ml-1 text-sm text-white lg:group-hover:flex">Unavailable</span>
+        <span><%= fa("video-slash", size: :sm, class: "fill-white") %></span>
+      </div>
+    <% end %>
+
     <% if talk.duration_in_seconds.present? || watched_talk&.watched? %>
       <div
         class="
@@ -122,7 +133,7 @@
       </div>
     <% end %>
 
-    <% if talk.published? && !watched_talk&.watched? %>
+    <% if talk.published? && !watched_talk&.watched? && talk.video_available? %>
       <div
         class="
           absolute inset-0 z-10 items-center justify-center hidden lg:group-hover:flex

--- a/app/views/talks/_talk.html.erb
+++ b/app/views/talks/_talk.html.erb
@@ -251,11 +251,18 @@
           </p>
 
           <p>
-            Date: <%= talk.formatted_date %><br>
+            Held on: <%= talk.formatted_date %><br>
 
             <span class="text-gray-400">
               Published: <% if talk.published_at %><%= l(talk.published_at&.to_date, default: "unknown") %><% elsif talk.published? %> unknown <% else %> not published <% end %><br>
-              Announced: <%= l(talk.announced_at&.to_date, default: "unknown") %>
+
+              <% if talk.video_unavailable? %>
+                Unavailable: <%= l(talk.video_unavailable_at.to_date) %><br>
+              <% end %>
+
+              <% if talk.announced_at.present? %>
+                Announced: <%= l(talk.announced_at&.to_date, default: "unknown") %><br>
+              <% end %>
             </span>
           </p>
 

--- a/app/views/talks/_video_player.html.erb
+++ b/app/views/talks/_video_player.html.erb
@@ -32,7 +32,9 @@
       <% end %>
 
     <% else %>
-      <% if video_provider.in?(["mp4", "youtube", "vimeo", "scheduled", "not_published", "not_recorded", "children"]) %>
+      <% if talk.video_unavailable? %>
+        <%= render partial: "talks/video_providers/video_unavailable", locals: {talk: talk, video_provider: video_provider, video_id: video_id, is_watched: is_watched} %>
+      <% elsif video_provider.in?(["mp4", "youtube", "vimeo", "scheduled", "not_published", "not_recorded", "children"]) %>
         <%= render partial: "talks/video_providers/#{video_provider}", locals: {talk: talk, video_provider: video_provider, video_id: video_id, is_watched: is_watched} %>
       <% else %>
         Provider <%= video_provider.inspect %> is not configured.
@@ -44,7 +46,7 @@
         <% end %>
       </div>
 
-      <% if current_user_watched_talk&.in_progress? && !is_watched %>
+      <% if current_user_watched_talk&.in_progress? && !is_watched && talk.video_available? %>
         <div class="absolute inset-0 cursor-pointer group/resume" data-video-player-target="resumeOverlay" data-action="click->video-player#resumePlayback">
           <%= image_tag talk.thumbnail_xl, class: "absolute inset-0 w-full h-full object-cover rounded-xl", style: "view-transition-name: #{dom_id(talk, :image)}" %>
           <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-black/20 rounded-xl"></div>
@@ -60,7 +62,7 @@
             </div>
           </div>
         </div>
-      <% elsif video_provider.in?(["mp4", "youtube", "vimeo"]) && !is_watched %>
+      <% elsif video_provider.in?(["mp4", "youtube", "vimeo"]) && !is_watched && talk.video_available? %>
         <div class="absolute inset-0 cursor-pointer group/play" data-video-player-target="playOverlay" data-action="click->video-player#startPlayback">
           <%= image_tag talk.thumbnail_xl, class: "absolute inset-0 w-full h-full object-cover rounded-xl", style: "view-transition-name: #{dom_id(talk, :image)}" %>
           <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-black/20 rounded-xl"></div>

--- a/app/views/talks/video_providers/_video_unavailable.html.erb
+++ b/app/views/talks/video_providers/_video_unavailable.html.erb
@@ -1,0 +1,22 @@
+<%# locals: (talk:, video_provider:, video_id:, is_watched: false) %>
+
+<div class="relative w-full h-full block">
+  <%= image_tag talk.thumbnail_xl, class: "w-full h-full object-cover rounded-xl" %>
+
+  <div class="absolute inset-0 flex flex-col items-center justify-center gap-3 p-6 text-center text-white bg-gradient-to-t from-black/80 via-black/50 to-black/30 rounded-xl">
+    <div class="p-4 bg-white/20 backdrop-blur-sm rounded-full">
+      <%= fa("video-slash", size: :xl, class: "fill-white") %>
+    </div>
+
+    <div class="flex flex-col gap-1">
+      <div class="text-lg font-semibold">Video Unavailable</div>
+      <div class="text-sm text-white/80">
+        This video is no longer available on <%= video_provider.humanize %>
+
+        <% if talk.video_unavailable_at.present? %>
+          as of <%= talk.video_unavailable_at.to_date.to_fs(:long) %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -7,6 +7,9 @@ youtube_video_duration_job:
 youtube_thumbnail_validation_job:
   class: Recurring::YouTubeThumbnailValidationJob
   schedule: every week on sunday at 4am
+youtube_video_availability_job:
+  class: Recurring::YouTubeVideoAvailabilityJob
+  schedule: every week on sunday at 5am
 rollup_aggregate_analytics:
   class: Recurring::RollupJob
   schedule: every hour

--- a/data/balticruby/balticruby-2025/videos.yml
+++ b/data/balticruby/balticruby-2025/videos.yml
@@ -278,6 +278,6 @@
     Our path to a more diverse Ruby, and the rewards from the journey.
   date: "2025-06-14"
   published_at: "2025-08-30"
-  video_provider: "not_published"
+  video_provider: "youtube"
   video_id: "6jUEmcezkBo"
   id: "tim-riley-baltic-ruby-2025"

--- a/db/migrate/20260112071922_add_video_availability_fields_to_talks.rb
+++ b/db/migrate/20260112071922_add_video_availability_fields_to_talks.rb
@@ -1,0 +1,6 @@
+class AddVideoAvailabilityFieldsToTalks < ActiveRecord::Migration[8.2]
+  def change
+    add_column :talks, :video_unavailable_at, :datetime
+    add_column :talks, :video_availability_checked_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_01_12_065507) do
+ActiveRecord::Schema[8.2].define(version: 2026_01_12_071922) do
+  create_table "_litestream_lock", id: false, force: :cascade do |t|
+    t.integer "id"
+  end
+
+  create_table "_litestream_seq", force: :cascade do |t|
+    t.integer "seq"
+  end
+
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -411,8 +419,10 @@ ActiveRecord::Schema[8.2].define(version: 2026_01_12_065507) do
     t.string "thumbnail_xs", default: "", null: false
     t.string "title", default: "", null: false
     t.datetime "updated_at", null: false
+    t.datetime "video_availability_checked_at"
     t.string "video_id", default: "", null: false
     t.string "video_provider", default: "", null: false
+    t.datetime "video_unavailable_at"
     t.integer "view_count", default: 0
     t.datetime "youtube_thumbnail_checked_at"
     t.index ["date"], name: "index_talks_on_date"

--- a/test/fixtures/talks.yml
+++ b/test/fixtures/talks.yml
@@ -4,41 +4,43 @@
 # Table name: talks
 # Database name: primary
 #
-#  id                           :integer          not null, primary key
-#  additional_resources         :json             not null
-#  announced_at                 :datetime
-#  date                         :date             indexed, indexed => [video_provider]
-#  description                  :text             default(""), not null
-#  duration_in_seconds          :integer
-#  end_seconds                  :integer
-#  external_player              :boolean          default(FALSE), not null
-#  external_player_url          :string           default(""), not null
-#  kind                         :string           default("talk"), not null, indexed
-#  language                     :string           default("en"), not null
-#  like_count                   :integer          default(0)
-#  meta_talk                    :boolean          default(FALSE), not null
-#  original_title               :string           default(""), not null
-#  published_at                 :datetime
-#  slides_url                   :string
-#  slug                         :string           default(""), not null, indexed
-#  start_seconds                :integer
-#  summarized_using_ai          :boolean          default(TRUE), not null
-#  summary                      :text             default(""), not null
-#  thumbnail_lg                 :string           default(""), not null
-#  thumbnail_md                 :string           default(""), not null
-#  thumbnail_sm                 :string           default(""), not null
-#  thumbnail_xl                 :string           default(""), not null
-#  thumbnail_xs                 :string           default(""), not null
-#  title                        :string           default(""), not null, indexed
-#  video_provider               :string           default("youtube"), not null, indexed => [date]
-#  view_count                   :integer          default(0)
-#  youtube_thumbnail_checked_at :datetime
-#  created_at                   :datetime         not null
-#  updated_at                   :datetime         not null, indexed
-#  event_id                     :integer          indexed
-#  parent_talk_id               :integer          indexed
-#  static_id                    :string           not null, uniquely indexed
-#  video_id                     :string           default(""), not null
+#  id                            :integer          not null, primary key
+#  additional_resources          :json             not null
+#  announced_at                  :datetime
+#  date                          :date             indexed, indexed => [video_provider]
+#  description                   :text             default(""), not null
+#  duration_in_seconds           :integer
+#  end_seconds                   :integer
+#  external_player               :boolean          default(FALSE), not null
+#  external_player_url           :string           default(""), not null
+#  kind                          :string           default("talk"), not null, indexed
+#  language                      :string           default("en"), not null
+#  like_count                    :integer          default(0)
+#  meta_talk                     :boolean          default(FALSE), not null
+#  original_title                :string           default(""), not null
+#  published_at                  :datetime
+#  slides_url                    :string
+#  slug                          :string           default(""), not null, indexed
+#  start_seconds                 :integer
+#  summarized_using_ai           :boolean          default(TRUE), not null
+#  summary                       :text             default(""), not null
+#  thumbnail_lg                  :string           default(""), not null
+#  thumbnail_md                  :string           default(""), not null
+#  thumbnail_sm                  :string           default(""), not null
+#  thumbnail_xl                  :string           default(""), not null
+#  thumbnail_xs                  :string           default(""), not null
+#  title                         :string           default(""), not null, indexed
+#  video_availability_checked_at :datetime
+#  video_provider                :string           default("youtube"), not null, indexed => [date]
+#  video_unavailable_at          :datetime
+#  view_count                    :integer          default(0)
+#  youtube_thumbnail_checked_at  :datetime
+#  created_at                    :datetime         not null
+#  updated_at                    :datetime         not null, indexed
+#  event_id                      :integer          indexed
+#  parent_talk_id                :integer          indexed
+#  static_id                     :string           not null, uniquely indexed
+#  video_id                      :string           default(""), not null
 #
 # Indexes
 #

--- a/test/jobs/recurring/youtube_video_availability_job_test.rb
+++ b/test/jobs/recurring/youtube_video_availability_job_test.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Recurring::YouTubeVideoAvailabilityJobTest < ActiveJob::TestCase
+  setup do
+    @talk = talks(:one)
+    @talk.update_columns(
+      video_provider: "youtube",
+      video_id: "dQw4w9WgXcQ",
+      video_availability_checked_at: nil,
+      video_unavailable_at: nil
+    )
+
+    # Make sure other talks don't interfere
+    Talk.where.not(id: @talk.id).update_all(video_provider: "vimeo")
+  end
+
+  test "skips non-YouTube talks" do
+    @talk.update_column(:video_provider, "vimeo")
+
+    Recurring::YouTubeVideoAvailabilityJob.perform_now
+
+    assert_nil @talk.reload.video_availability_checked_at
+  end
+
+  test "skips recently checked talks" do
+    @talk.update_column(:video_availability_checked_at, 1.week.ago)
+
+    Recurring::YouTubeVideoAvailabilityJob.perform_now
+
+    # Should not update the timestamp since it was recently checked
+    assert @talk.reload.video_availability_checked_at < 1.day.ago
+  end
+
+  test "rechecks talks older than 1 month" do
+    @talk.update_column(:video_availability_checked_at, 2.months.ago)
+
+    stub_video_available
+
+    Recurring::YouTubeVideoAvailabilityJob.perform_now
+
+    assert @talk.reload.video_availability_checked_at > 1.minute.ago
+  end
+
+  test "marks video as available when API returns data" do
+    @talk.update_column(:video_unavailable_at, 1.week.ago)
+
+    stub_video_available
+
+    Recurring::YouTubeVideoAvailabilityJob.perform_now
+
+    @talk.reload
+    assert_nil @talk.video_unavailable_at
+    assert @talk.video_availability_checked_at.present?
+  end
+
+  test "marks video as unavailable when API returns no data" do
+    stub_video_unavailable
+
+    Recurring::YouTubeVideoAvailabilityJob.perform_now
+
+    @talk.reload
+    assert @talk.video_unavailable_at.present?
+    assert @talk.video_availability_checked_at.present?
+  end
+
+  test "preserves original unavailable_at timestamp on subsequent checks" do
+    original_time = 1.week.ago
+    @talk.update_columns(video_unavailable_at: original_time, video_availability_checked_at: 2.months.ago)
+
+    stub_video_unavailable
+
+    Recurring::YouTubeVideoAvailabilityJob.perform_now
+
+    @talk.reload
+    assert_in_delta original_time, @talk.video_unavailable_at, 1.second
+  end
+
+  private
+
+  def stub_video_available
+    stub_request(:get, %r{youtube\.googleapis\.com/youtube/v3/videos})
+      .to_return(
+        status: 200,
+        body: {items: [{id: @talk.video_id, status: {privacyStatus: "public"}}]}.to_json,
+        headers: {"Content-Type" => "application/json"}
+      )
+  end
+
+  def stub_video_unavailable
+    stub_request(:get, %r{youtube\.googleapis\.com/youtube/v3/videos})
+      .to_return(
+        status: 200,
+        body: {items: []}.to_json,
+        headers: {"Content-Type" => "application/json"}
+      )
+  end
+end


### PR DESCRIPTION
This pull request introduces video availability checking for YouTube videos and follows the work from #555 which added thumbnail checking.

A new recurring background job checks whether YouTube videos are still available via the YouTube API. When a video is no longer accessible, the talk is marked with a `video_unavailable_at` timestamp. 

<img width="3236" height="1948" alt="CleanShot 2026-01-12 at 08 57 24@2x" src="https://github.com/user-attachments/assets/4d0ec044-3fe5-40f4-a53a-719e7e421793" />

<img width="2348" height="1038" alt="CleanShot 2026-01-12 at 08 57 36@2x" src="https://github.com/user-attachments/assets/14ed6f57-fb5a-4962-ba8b-c59e5327004a" />

<img width="50%" height="714" alt="CleanShot 2026-01-12 at 08 57 22@2x" src="https://github.com/user-attachments/assets/a6f732b1-ff7a-472c-97db-d3fa20507a86" />