### PR TITLE
Use Gum gem for generating Event Assets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -263,3 +263,5 @@ group :test do
   gem "vcr", "~> 6.1"
   gem "webmock"
 end
+
+gem "gum", "~> 0.3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -332,6 +332,12 @@ GEM
       pry (>= 0.13.0)
       shellany (~> 0.0)
       thor (>= 0.18.1)
+    gum (0.3.0)
+    gum (0.3.0-aarch64-linux)
+    gum (0.3.0-arm64-darwin)
+    gum (0.3.0-arm64-linux)
+    gum (0.3.0-x86_64-darwin)
+    gum (0.3.0-x86_64-linux)
     hana (1.3.7)
     hashdiff (1.2.1)
     hashie (5.0.0)
@@ -781,6 +787,7 @@ DEPENDENCIES
   google-protobuf
   groupdate
   guard
+  gum (~> 0.3.0)
   herb (~> 0.8)
   hotwire_combobox (~> 0.4.0)
   httparty


### PR DESCRIPTION
# Description

Instead of installing gum, use the gum ruby gem to generate assets.
I hit a minor roadbump while installing gum, and decided rewriting the rake task to use the ruby gem was easier then figuring out apt-get.