### PR TITLE
City must be imported first

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,10 +1,10 @@
 Search::Backend.without_indexing do
+  Static::City.import_all!
   Static::Speaker.import_all!
   Static::EventSeries.import_all_series!
   Static::Event.import_recent!
   Static::Event.import_meetups!
   Static::Topic.import_all!
-  Static::City.import_all!
 end
 
 Search::Backend.reindex_all

--- a/lib/tasks/seed.rake
+++ b/lib/tasks/seed.rake
@@ -3,11 +3,11 @@ namespace :db do
     desc "Seed all contributions, event, speaker, and more data"
     task all: :environment do
       Search::Backend.without_indexing do
+        Static::City.import_all!
         Static::Speaker.import_all!
         Static::EventSeries.import_all!
         Static::Event.import_all!
         Static::Topic.import_all!
-        Static::City.import_all!
       end
 
       Search::Backend.reindex_all


### PR DESCRIPTION
# Description

Right now we're running into issues where the city isn't an exact match for the featured city we created, so a duplicate is made.

Then, when we try to create the featured city, it sees the dupe and cries out ActiveRecord::RecordInvalid.

Events can make a city if it's missing, so we have to import the city first, and then the event will find the city instead of creating one.

# Details

- This does not affect `bundle exec db:reset` because that only runs the last 6 months and meetups, so we create featured cities before getting to our troublesome records
- I have no idea why we can reliably reproduce it in codespaces. Can't be volumes because sqlite is in the image. I've destroyed and rebuilt so there should be no cache. Maybe concurrency?
- I have no idea why we're not seeing it in the seeds smoke test.