### PR TITLE
Add some GitHub Actions annotations to surface errors

### DIFF
--- a/app/models/static/event.rb
+++ b/app/models/static/event.rb
@@ -323,11 +323,7 @@ module Static
 
         event.sync_aliases_from_list(aliases) if aliases.present?
       rescue ActiveRecord::RecordInvalid => e
-        puts <<~HEREDOC
-          \e[31m----------
-          Couldn't save event #{title} (#{slug}): #{e.message}
-          ----------\e[0m
-        HEREDOC
+        puts "::error::Couldn't save event #{title} (#{slug}): #{e.message}"
         raise e
       end
 


### PR DESCRIPTION
# Description

The context of this work is that I'm trying to get our seeds working consistently (or at all) in production. I need a commit so that we rebuild the flaky Docker image and it happens to pass this time, so I can even run the seeds on the new code.

The actual changes are an attempt to get errors to show up in GitHub Action's annotate panel.

<img width="1047" height="235" alt="Screenshot 2026-01-13 at 3 02 30 PM" src="https://github.com/user-attachments/assets/07e9e672-6d0e-4998-aec2-e1bbf6fbe265" />

# References

- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-an-error-message