### PR TITLE
Annotate errors for GitHub actions in validate.rake

### DIFF
--- a/lib/tasks/validate.rake
+++ b/lib/tasks/validate.rake
@@ -32,7 +32,8 @@ namespace :validate do
       puts
       invalid_files.each do |file|
         puts Gum.style("❌ #{file[:path]}", foreground: "1")
-        file[:errors].each { |e| puts "   #{e["error"]} at #{e["data_pointer"]}" }
+        gh_action_anotation = (ENV["GITHUB_ACTIONS"] == "true") ? "::error file=#{file[:path]}::" : "::error::"
+        file[:errors].each { |e| puts "#{gh_action_anotation} #{e["error"]} at #{e["data_pointer"]}" }
         puts
       end
     end


### PR DESCRIPTION
# Description

The context of this PR is that I'm trying to fix seeds and our docker image
build step is flaky so I need a commit to bump it.

The actual effect of this PR is adding GitHub Actions annotations to errors,
and making them easier to see in the summary.