### PR TITLE
Use github formatter for annotations in Standardrb

### DIFF
--- a/app/models/static/event.rb
+++ b/app/models/static/event.rb
@@ -310,7 +310,7 @@ module Static
 
       if event.venue.exist?
         event.update!(
-          latitude:  event.venue.latitude,
+          latitude: event.venue.latitude,
           longitude: event.venue.longitude
         )
       else
@@ -322,15 +322,9 @@ module Static
 
       event.sync_aliases_from_list(aliases) if aliases.present?
 
-      puts  event.slug unless Rails.env.test?
+      puts event.slug unless Rails.env.test?
 
       event
-
-
-
-
-
-
     rescue ActiveRecord::RecordInvalid => e
       error_location = ActiveSupport::BacktraceCleaner.new.clean_locations(e.backtrace_locations).first
       puts "::error file=#{error_location&.path},line=#{error_location&.lineno}::#{e.record.class} (#{e.record&.to_param}) - #{e.detailed_message}"


### PR DESCRIPTION
# Description

The context is that I'm trying to push a commit so we rerun the build and the
flaky docker image build finally passes.

The content is GitHub Actions annotations for issues in standardrb.

<img width="1050" height="758" alt="Screenshot 2026-01-13 at 11 56 05 PM" src="https://github.com/user-attachments/assets/6fc1778c-3ee9-4931-b5c4-80bcd348ba92" />
<img width="833" height="662" alt="Screenshot 2026-01-13 at 11 56 37 PM" src="https://github.com/user-attachments/assets/1f24ec11-3800-4171-98f7-074f2f36a5f2" />
