### PR TITLE
Add Speaker GitHub profiles

### DIFF
--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -25,7 +25,7 @@
   website: "http://icanthascheezburger.com"
   slug: "aaron-harpole"
 - name: "Aaron Kalin"
-  github: ""
+  github: "martinisoft"
   slug: "aaron-kalin"
 - name: "Aaron Lasseigne"
   github: ""


### PR DESCRIPTION
# Description

Add GitHub profiles to speakers. GitHub profiles are how we uniquely identify users.