### PR TITLE
Speaker GitHub

### DIFF
--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -200,7 +200,7 @@
   website: "https://adrianthedev.com"
   slug: "adrian-marin"
 - name: "Adrian Pike"
-  github: ""
+  github: "adrianpike"
   slug: "adrian-pike"
 - name: "Adrian Zankich"
   github: ""


### PR DESCRIPTION
# Description

Add Speaker GitHub profile to RubyEvents.
We use the GitHub profile to uniquely identify speakers.