### PR TITLE
Replace Maintainers heading with Authors

### DIFF
--- a/app/views/browse/_topic_row.html.erb
+++ b/app/views/browse/_topic_row.html.erb
@@ -18,7 +18,7 @@
     <% topics.each do |topic| %>
       <%= link_to topic_path(topic), class: "btn btn-outline btn-sm gap-2 hover:btn-primary", data: {turbo_frame: "_top"} do %>
         <% if topic.topic_gems.any? %>
-          <%= fa("gem", size: :xs) %>
+          <%= fa("gem", size: :xs, class: "fill-primary") %>
         <% end %>
 
         <%= topic.name %>

--- a/app/views/gems/show.html.erb
+++ b/app/views/gems/show.html.erb
@@ -110,7 +110,7 @@
 
   <% if maintainers.any? %>
     <section class="flex flex-col w-full gap-4 mt-4">
-      <h2 class="text-xl font-semibold">Maintainers on RubyEvents.org</h2>
+      <h2 class="text-xl font-semibold">Gem Authors on RubyEvents.org</h2>
 
       <div class="flex flex-wrap gap-4">
         <% maintainers.each do |user| %>

--- a/app/views/topics/_gem_info.html.erb
+++ b/app/views/topics/_gem_info.html.erb
@@ -42,7 +42,7 @@
 
     <% if maintainers.any? %>
       <div class="flex flex-col gap-2">
-        <span class="text-sm text-gray-500">Maintainers on RubyEvents.org</span>
+        <span class="text-sm text-gray-500">Authors on RubyEvents.org</span>
         <div class="flex flex-wrap gap-3">
           <% maintainers.each do |user| %>
             <%= link_to profile_path(user), class: "flex items-center gap-2 hover:opacity-80", data: {turbo_frame: "_top"} do %>


### PR DESCRIPTION
# Description

We source the list of maintainers from RubyGems, and we merge owners and authors into a single list. The goal of this feature is to help viewers identify talks where a gem author is speaking. Maintainer often implies active duty on the project, and people rotate in and out of that role. However, talks given by former maintainers are still relevant to viewers due to their experience with the gem.

Author is a neutral term that encompasses both current and former maintainers.

Old
<img width="850" height="383" alt="Screenshot 2026-01-14 at 1 33 13 PM" src="https://github.com/user-attachments/assets/ecf4883e-24d2-4813-a7fd-d62f84ad6d49" />