### PR TITLE
Create a new Generator for adding a CFP

### DIFF
--- a/app/schemas/cfp_schema.rb
+++ b/app/schemas/cfp_schema.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class CFPSchema < RubyLLM::Schema
+  string :link, description: "CFP link", required: true
+  string :name, description: 'Name for the CFP (default: "Call for Proposals")', required: false
+  string :open_date, description: "CFP open date (YYYY-MM-DD format)", required: false
+  string :close_date, description: "CFP close date (YYYY-MM-DD format)", required: false
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,7 +36,7 @@ module RubyEvents
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
     #
-    config.autoload_lib(ignore: %w[assets tasks protobuf guard])
+    config.autoload_lib(ignore: %w[assets tasks protobuf guard generators])
 
     config.active_job.queue_adapter = :solid_queue
     config.solid_queue.connects_to = {database: {writing: :queue}}

--- a/docs/ADDING_CFPS.md
+++ b/docs/ADDING_CFPS.md
@@ -1,0 +1,116 @@
+# Adding Call for Proposals to RubyEvents
+
+This guide explains how to add a CFP for conferences and events in the RubyEvents platform.
+
+## Overview
+
+CFP data is stored in YAML files within the conference/event directories. Each conference can have its own cfp file that describes multiple CFPs.
+
+## File Structure
+
+CFPs are stored in YAML files at:
+```
+data/{series-name}/{event-name}/cfp.yml
+```
+
+For example:
+- [`data/blue-ridge-ruby/blue-ridge-ruby-2026/cfp.yml`](/data/blue-ridge-ruby/blue-ridge-ruby-2026/cfp.yml)
+- [`data/sfruby/sfruby-2025/cfp.yml`](/data/sfruby/sfruby-2025/cfp.yml)
+
+All permitted fields are defined in [CFPSchema.](/app/schemas/cfp_schema.rb)
+
+## Generation
+
+Generate a CFP using the CfpGenerator!
+
+```
+bin/rails g cfp --event-series=blue-ridge-ruby --event=blue-ridge-ruby-2026 --name="Call for Proposals" --link=https://blueridgeruby.com/cfp --start-date=2025-12-15 --end-date=2026-02-03
+```
+
+Check the usage instructions using help.
+
+```
+bin/rails g cfp --help
+```
+
+This will create a cfp.yml with a single CFP in it.
+If you need to add additional CFPs for start-up demos or lightning talks, add another cfp using the same format to the array.
+
+## Step-by-Step Guide
+
+### 1. Check for Existing CFP File
+
+First, check if a cfp file already exists:
+
+```bash
+ls data/{series-name}/{event}/cfp.yml
+```
+
+### 2. Create or Edit the cfp File
+
+If the file doesn't exist, create it:
+
+```bash
+bin/rails g cfp --event-series=blue-ridge-ruby --event=blue-ridge-ruby-2026
+```
+
+### 3. Gather CFP Information
+
+Check the event website or social media!
+
+### 4. Structure the YAML
+
+Start with the basic structure and add additional CFPs if necessary.
+
+> [!TIP]
+> Dates are structured as YEAR-MM-DD and stored as strings.
+
+### 5. Format your yaml
+
+Run the linter to automatically format and verify all required properties are present.
+
+```bash
+bin/lint
+```
+
+### 5. Run seeds to load data
+
+Run the event series seed to load data.
+
+```bash
+bundle exec rake db:seed:event_series[event-series-slug]
+```
+
+### 6. Review on your dev server
+
+Start the dev server and review the event.
+
+```bash
+bin/dev
+```
+
+## Troubleshooting
+
+### Common Issues
+
+- **Invalid YAML syntax**: Check indentation (use spaces, not tabs)
+- **Missing required fields**: Ensure all required properties are present
+
+## Submission Process
+
+1. Fork the RubyEvents repository
+2. Setup your dev environment following the steps in [CONTRIBUTING](/CONTRIBUTING.md)
+3. Create your cfp file in the appropriate directory
+4. Run `bin/lint`
+5. Run `bin/rails db:seed` (or `bin/rails db:seed:all` if the event happened more than 6 months ago)
+6. Run `bin/dev` and review the event on your dev server
+7. Submit a pull request
+
+## Need Help?
+
+If you have questions about contributing cfps:
+- Open an issue on GitHub
+- Check existing cfp files for examples
+- Reference this documentation
+
+Your contributions help make RubyEvents a comprehensive resource for the Ruby community!

--- a/lib/generators/cfp/USAGE
+++ b/lib/generators/cfp/USAGE
@@ -1,0 +1,9 @@
+Description:
+    Generate a CFP for an event in an event series.
+
+Example:
+    bin/rails generate cfp --event-series=rubyconf --event=rubyconf-2026
+
+    This will create:
+        A CFP file in the correct directory for the event series and event.
+        The file will be pre-populated with a template for the CFP.

--- a/lib/generators/cfp/cfp_generator.rb
+++ b/lib/generators/cfp/cfp_generator.rb
@@ -1,0 +1,16 @@
+require "rails/generators"
+
+class CfpGenerator < Rails::Generators::Base
+  source_root File.expand_path("templates", __dir__)
+
+  class_option :event_series, type: :string, desc: "Event series folder name", required: true, group: "Fields"
+  class_option :event, type: :string, desc: "Event folder name", required: true, aliases: ["-e"], group: "Fields"
+  class_option :name, type: :string, desc: "CFP name", default: "Call for Proposals", group: "Fields"
+  class_option :link, type: :string, desc: "CFP link", default: "", group: "Fields"
+  class_option :open_date, type: :string, desc: "CFP open date (YYYY-MM-DD)", default: "2026-01-01", group: "Fields"
+  class_option :close_date, type: :string, desc: "CFP close date (YYYY-MM-DD)", default: "2026-12-31", group: "Fields"
+
+  def copy_cfp_file
+    template "cfp.yml.tt", File.join(["data", options[:event_series], options[:event], "cfp.yml"])
+  end
+end

--- a/lib/generators/cfp/templates/cfp.yml.tt
+++ b/lib/generators/cfp/templates/cfp.yml.tt
@@ -1,0 +1,6 @@
+# docs/ADDING_CFPS.md
+---
+- link: "<%= options[:link] %>"
+  name: "<%= options[:name] %>"
+  open_date: "<%= options[:open_date] %>"
+  close_date: "<%= options[:close_date] %>"

--- a/lib/tasks/validate.rake
+++ b/lib/tasks/validate.rake
@@ -99,6 +99,12 @@ namespace :validate do
     invalid_files.empty?
   end
 
+  desc "Validate all cfp.yml files against CFPSchema"
+  task cfps: :environment do
+    success = validate_array_files("data/**/cfp.yml", CFPSchema, "cfp.yml")
+    exit 1 unless success
+  end
+
   desc "Validate all event.yml files against EventSchema"
   task events: :environment do
     success = validate_files("data/**/event.yml", EventSchema, "event.yml") do |data, errors|
@@ -244,6 +250,9 @@ namespace :validate do
 
     puts Gum.style("Validating series.yml files", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
     results << validate_files("data/*/series.yml", SeriesSchema, "series.yml")
+
+    puts Gum.style("Validating cfp.yml files", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
+    results << validate_array_files("data/*/cfp.yml", CFPSchema, "cfp.yml")
 
     puts Gum.style("Validating venue.yml files", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
     results << validate_files("data/**/venue.yml", VenueSchema, "venue.yml")

--- a/test/lib/generators/cfp_generator_test.rb
+++ b/test/lib/generators/cfp_generator_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+require "generators/cfp/cfp_generator"
+require "#{Rails.root}/app/schemas/cfp_schema"
+require "json_schemer"
+require "yaml"
+
+class CFPGeneratorTest < Rails::Generators::TestCase
+  tests CfpGenerator
+  destination Rails.root.join("tmp/generators")
+  setup :prepare_destination
+
+  test "generator runs without errors" do
+    assert_nothing_raised do
+      run_generator ["--event-series", "rubyconf", "--event", "2024"]
+    end
+  end
+
+  test "creates cfp.yml in correct directory" do
+    run_generator ["--event-series", "rubyconf", "--event", "2024"]
+
+    assert_file "data/rubyconf/2024/cfp.yml" do |content|
+      assert_match(/\S/, content) # Verify file has content
+    end
+  end
+
+  test "cfp.yml passes schema validation" do
+    run_generator ["--event-series", "rubyconf", "--event", "2024"]
+
+    cfp_file_path = File.join(destination_root, "data/rubyconf/2024/cfp.yml")
+    data = YAML.load_file(cfp_file_path)
+
+    schema = JSON.parse(CFPSchema.new.to_json_schema[:schema].to_json)
+    schemer = JSONSchemer.schema(schema)
+
+    errors = []
+    Array(data).each_with_index do |item, index|
+      errs = schemer.validate(item).to_a
+      errors.append(errs) unless errs.empty?
+    end
+
+    assert_empty errors, "CFP YAML does not conform to schema: #{errors.join(", ")}"
+  end
+end


### PR DESCRIPTION
# Description

Usage:

```
  bin/rails generate cfp --event-series=series-name --event=event-name
    --name="Call for Proposals" --link="https://example.com/cfp"
    --open-date="2026-01-01" --close-date="2026-12-31"
```

The new Generator is validated against CFPSchema and documented in ADDING_CFPS.md which is included in the template CFP file.

Obviously, it's not particularly difficult to add a CFP file, but that's actually why I started here. My goal is to have generators for all our event files with overridden defaults.

Then, theoretically, we create an event with a generator, and it makes all the necessary files.

As these generators become more powerful, we could potentially replace some of the tools with calls to a generator, but right now, this one can only handle one CFP, not multiple.

# Benefits

- Idiomatic Rails interface for Contributors
- Available without MCP tools
- Formatted correctly and passes linter on generation
- Instead of templates in documentation that fall out of date, the template is verified against the schema

# Resources

- https://guides.rubyonrails.org/generators.html
- https://api.rubyonrails.org/v8.1.2/classes/Rails/Generators/Testing/Assertions.html
- https://www.rubydoc.info/gems/thor/Thor%2FBase%2FClassMethods:class_option
- https://garrettdimon.com/journal/posts/creating-custom-rails-generators