### PR TITLE
Adapt button participant text if event happened

### DIFF
--- a/app/views/events/participants/_list.html.erb
+++ b/app/views/events/participants/_list.html.erb
@@ -1,3 +1,5 @@
+<% button_text = event.start_date&.future? ? "Are you going?" : "Were you there?" %>
+
 <div id="participants_list">
   <% if participants.any? %>
     <h2 class="mb-6">Known Participants (<%= participants.size %>)</h2>
@@ -7,7 +9,7 @@
         <div class="flex items-center gap-4">
           <div class="text-3xl">👋</div>
           <div class="flex-1">
-            <h3 class="text-base font-semibold text-gray-900">Were you there?</h3>
+            <h3 class="text-base font-semibold text-gray-900"><%= button_text %></h3>
             <p class="text-sm text-gray-600">Mark yourself as a participant!</p>
           </div>
           <div class="flex-shrink-0">
@@ -38,7 +40,7 @@
         <%= render partial: "events/participation_button", locals: {event: event, participation: participation} %>
 
         <div class="bg-purple-50 border border-purple-200 rounded-lg p-4 text-left mt-6">
-          <h3 class="font-semibold text-purple-800 mb-2">Were you there?</h3>
+          <h3 class="font-semibold text-purple-800 mb-2"><%= button_text %></h3>
           <p class="text-sm text-purple-700 mb-3">
             Help build the community memory by marking your participation at this event.
           </p>


### PR DESCRIPTION
Issue #1257 


Future event:

<img width="1680" height="815" alt="Screenshot 2026-01-17 at 01 09 46" src="https://github.com/user-attachments/assets/783786f2-9e2e-4842-9078-5a360b45ca34" />

Past event:

<img width="1667" height="725" alt="Screenshot 2026-01-17 at 00 40 53" src="https://github.com/user-attachments/assets/1d7b2b71-1689-4fed-a0df-7ee546b722df" />


