### PR TITLE
remove n+1 in cities#index

### DIFF
--- a/app/controllers/cities_controller.rb
+++ b/app/controllers/cities_controller.rb
@@ -5,7 +5,7 @@ class CitiesController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[index show show_by_country show_with_state]
 
   def index
-    @cities = City.all
+    @cities = City.includes(:users, :events).all
   end
 
   def show

--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -233,11 +233,11 @@ class City < ApplicationRecord
   end
 
   def events_count
-    @events_count ||= events.count
+    @events_count ||= events.size
   end
 
   def users_count
-    @users_count ||= users.count
+    @users_count ||= users.size
   end
 
   def feature!


### PR DESCRIPTION
cities#index is one the the slowest page to render according to Appsignal https://appsignal.com/rubyvideo/sites/648c9414d2a5e4567617aaf0/performance/incidents/652

<img width="1792" height="764" alt="CleanShot 2026-01-20 at 08 15 36@2x" src="https://github.com/user-attachments/assets/2d1aae0f-77d2-4f65-9d91-9140f89ead07" />

This PR remove the N+1 it should speed up the rendering in production 

## Before (in dev with less users)

<img width="1938" height="580" alt="CleanShot 2026-01-20 at 08 13 11@2x" src="https://github.com/user-attachments/assets/a561c54f-5e38-4641-8008-c7a1cb0e93fa" />


## After (in dev with less users)

<img width="1944" height="508" alt="CleanShot 2026-01-20 at 08 11 30@2x" src="https://github.com/user-attachments/assets/4592815f-7e12-41e6-bdd5-6dd153d2910d" />
