### PR TITLE
Add wnb rb meetup sponsors

### DIFF
--- a/data/wnb-rb/wnb-rb-meetup/sponsors.yml
+++ b/data/wnb-rb/wnb-rb-meetup/sponsors.yml
@@ -7,7 +7,7 @@
         - name: "Gusto"
           website: "https://gusto.com/"
           slug: "gusto"
-          logo_url: "https://rubyonrails.org/assets/images/logo-gusto.svg"
+          logo_url: "https://www.wnb-rb.dev/packs/static/images/Gusto-logo-fbfed097feb08a784df3.png"
     - name: "Opal"
       description: "Annual sponsorships of $1000 per year"
       level: 3
@@ -15,8 +15,7 @@
         - name: "Avo"
           website: "https://avohq.io/rails-admin"
           slug: "Avo"
-          logo_url: "https://2024.euruko.org/assets/images/sponsors/avo-logo.png"
+          logo_url: "https://www.wnb-rb.dev/packs/static/images/avo-logo-026cd3797aa002c6deed.png"
         - name: "OmbuLabs"
           website: "https://www.ombulabs.com/"
           slug: "OmbuLabs"
-          logo_url: "https://2017.southeastruby.com/images/sponsors/ombulabs.png"


### PR DESCRIPTION
Adding annual sponsors of WNB.rb.

Note: We're working on getting OmbuLabs up on the WNB.rb website, but as an organizer of WNB.rb I can confirm they are an active sponsor.