### PR TITLE
Update WNBrb sponsors

### DIFF
--- a/data/wnb-rb/wnb-rb-meetup/sponsors.yml
+++ b/data/wnb-rb/wnb-rb-meetup/sponsors.yml
@@ -13,9 +13,9 @@
       level: 3
       sponsors:
         - name: "Avo"
-          website: "https://avohq.io/rails-admin"
+          website: "https://avohq.io/"
           slug: "Avo"
           logo_url: "https://www.wnb-rb.dev/packs/static/images/avo-logo-026cd3797aa002c6deed.png"
-        - name: "OmbuLabs"
-          website: "https://www.ombulabs.com/"
-          slug: "OmbuLabs"
+        - name: "FastRuby.io"
+          website: "https://www.fastruby.io/"
+          slug: "fastruby-io"


### PR DESCRIPTION
Instead of OmbuLabs, we are showing our sponsor logo/link as FastRuby.io (a service of OmbuLabs), as per the request of our sponsor. 