### PR TITLE
Add Favorite Rubyists

### DIFF
--- a/app/controllers/favorite_users_controller.rb
+++ b/app/controllers/favorite_users_controller.rb
@@ -3,8 +3,9 @@ class FavoriteUsersController < ApplicationController
 
   # GET /favorite_users or /favorite_users.json
   def index
-    @favorite_users = FavoriteUser.where(user: Current.user).includes(:favorite_user).order(favorite_user: {name: :asc})
-    @recommendations = FavoriteUser.recommendations_for(Current.user) if @favorite_users.empty?
+    @ruby_friends = FavoriteUser.where(user: Current.user).includes(:favorite_user, :mutual_favorite_user).where.associated(:mutual_favorite_user).order(favorite_user: {name: :asc})
+    @favorite_rubyists = FavoriteUser.where(user: Current.user).includes(:favorite_user, :mutual_favorite_user).where.missing(:mutual_favorite_user).order(favorite_user: {name: :asc})
+    @recommendations = FavoriteUser.recommendations_for(Current.user) if @favorite_rubyists.empty? && @ruby_friends.empty?
   end
 
   # POST /favorite_users or /favorite_users.json

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -135,8 +135,7 @@ class ProfilesController < ApplicationController
   end
 
   def set_favorite_user
-    return unless Current.user
-    @favorite_user = FavoriteUser.find_by(user: Current.user, favorite_user: @user)
+    @favorite_user = Current.user ? @user.favorited_by.find_or_initialize_by(user: Current.user) : nil
   end
 
   def set_mutual_events

--- a/app/models/favorite_user.rb
+++ b/app/models/favorite_user.rb
@@ -24,12 +24,24 @@ class FavoriteUser < ApplicationRecord
   belongs_to :favorite_user, class_name: "User"
 
   validates :user, comparison: {other_than: :favorite_user}
+  validates :favorite_user_id, uniqueness: {scope: :user_id}
 
+  has_one :mutual_favorite_user, class_name: "FavoriteUser", primary_key: [:user_id, :favorite_user_id], foreign_key: [:favorite_user_id, :user_id]
+
+  # Suggest favorite users based on talks the user has watched
+  # No check for existing favorite users
   def self.recommendations_for(user)
-    user
-      .watched_talks
-      .includes(talk: :speakers)
+    recommended_user_ids = user
+      .watched_talks.joins(talk: :speakers)
+      .where.not(users: {id: user.id})
+      .distinct
       .limit(6)
-      .flat_map { |wt| wt.talk.speakers }
+      .pluck("users.id")
+
+    recommended_users = User.where(id: recommended_user_ids)
+    recommended_users
+      .map do |recommended_user|
+        FavoriteUser.new(user: user, favorite_user: recommended_user)
+      end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -120,6 +120,10 @@ class User < ApplicationRecord
   has_many :event_involvements, as: :involvementable, dependent: :destroy
   has_many :involved_events, through: :event_involvements, source: :event
 
+  # Favorite user associations
+  has_many :favorite_users, dependent: :destroy, inverse_of: :user
+  has_many :favorited_by, class_name: "FavoriteUser", foreign_key: "favorite_user_id", inverse_of: :favorite_user
+
   belongs_to :canonical, class_name: "User", optional: true
   belongs_to :city_record, class_name: "City", optional: true, inverse_of: false,
     foreign_key: [:city, :country_code, :state_code], primary_key: [:name, :country_code, :state_code]

--- a/app/views/favorite_users/_favorite_user.html.erb
+++ b/app/views/favorite_users/_favorite_user.html.erb
@@ -1,10 +1,25 @@
-<div id="<%= dom_id favorite_user %>">
-  <div class="border rounded-lg flex justify-between items-center bg-white hover:bg-gray-200 transition-bg duration-300 ease-in-out">
-    <%= render partial: "users/card", locals: {user: favorite_user.favorite_user} %>
-    <%= ui_tooltip "Remove from your list of Favorite Rubyists" do %>
-      <%= button_to favorite_user_path(favorite_user), method: :delete do %>
-        <%= fa("star", size: :sm, style: :solid, class: "fill-yellow-400 mx-5") %>
+<%# locals: (favorite_user:) %>
+
+<% if Current.user %>
+  <div id="<%= dom_id favorite_user %>">
+    <% if favorite_user.persisted? && favorite_user.mutual_favorite_user&.persisted? %>
+      <%= ui_tooltip "Remove from your list of Ruby Friends" do %>
+          <%= button_to favorite_user_path(favorite_user), method: :delete, form_class: "mt-1" do %>
+            <%= fa("star", size: :sm, style: :solid, class: "fill-red-600") %>
+          <% end %>
+      <% end %>
+    <% elsif favorite_user.persisted? %>
+      <%= ui_tooltip "Remove from your list of Favorite Rubyists" do %>
+          <%= button_to favorite_user_path(favorite_user), method: :delete, form_class: "mt-1" do %>
+            <%= fa("star", size: :sm, style: :solid, class: "fill-yellow-400") %>
+          <% end %>
+      <% end %>
+    <% elsif favorite_user.valid? %>
+      <%= ui_tooltip "Add to your list of Favorite Rubyists" do %>
+          <%= button_to favorite_users_path, method: :post, params: {favorite_user: {favorite_user_id: favorite_user.favorite_user_id}}, form_class: "mt-1" do %>
+            <%= fa("star", size: :sm, style: :regular, class: "hover:fill-yellow-400") %>
+          <% end %>
       <% end %>
     <% end %>
   </div>
-</div>
+<% end %>

--- a/app/views/favorite_users/_list.html.erb
+++ b/app/views/favorite_users/_list.html.erb
@@ -1,0 +1,9 @@
+<%# locals:(favorite_users:) %>
+
+<div class="min-w-full grid sm:grid-cols-2 lg:grid-cols-3 gap-4 mt-2">
+  <% favorite_users.each do |favorite_user| %>
+    <div class="border rounded-lg flex justify-between items-center bg-white hover:bg-gray-200 transition-bg duration-300 ease-in-out">
+      <%= render partial: "users/card", locals: {user: favorite_user.favorite_user, favorite_user: favorite_user} %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/favorite_users/_no_favorites.html.erb
+++ b/app/views/favorite_users/_no_favorites.html.erb
@@ -9,15 +9,10 @@
 </div>
 
 <div id="favorite_users" class="min-w-full grid sm:grid-cols-2 lg:grid-cols-3 gap-4 mt-2">
-<% recommendations.each do |recommended_user| %>
-  <div id="<%= dom_id recommended_user %>">
+<% recommendations.each do |favorite_user| %>
+  <div id="<%= dom_id favorite_user %>">
     <div class="border rounded-lg flex justify-between items-center bg-white hover:bg-gray-200 transition-bg duration-300 ease-in-out">
-      <%= render partial: "users/card", locals: {user: recommended_user} %>
-      <%= ui_tooltip "Add to your Favorite Rubyists" do %>
-        <%= button_to favorite_users_path(favorite_user: {favorite_user_id: recommended_user.id}), method: :post do %>
-          <%= fa("star", size: :sm, style: :regular, class: "fill-yellow-400 mx-5") %>
-        <% end %>
-      <% end %>
+      <%= render partial: "users/card", locals: {user: favorite_user.favorite_user, favorite_user: favorite_user} %>
     </div>
   </div>
 <% end %>

--- a/app/views/favorite_users/index.html.erb
+++ b/app/views/favorite_users/index.html.erb
@@ -1,13 +1,24 @@
-<div class="container">
-  <h2>
-    <%= fa("star", size: :sm, style: :solid, class: "fill-yellow-400 inline") %>
-    Favorite Rubyists
-  </h2>
-  <% if @favorite_users.empty? %>
+<div class="container flex flex-col gap-6">
+  <% if @favorite_rubyists.empty? && @ruby_friends.empty? %>
     <%= render partial: "favorite_users/no_favorites", locals: {recommendations: @recommendations} %>
   <% else %>
-    <div id="favorite_users" class="min-w-full grid sm:grid-cols-2 lg:grid-cols-3 gap-4 mt-2">
-      <%= render @favorite_users %>
-    </div>
+    <% if @ruby_friends.any? %>
+      <div id="ruby-friends">
+        <h2 class="mb-4">
+          <%= fa("star", size: :sm, style: :solid, class: "fill-red-600 inline") %>
+          Ruby Friends
+        </h2>
+        <%= render partial: "favorite_users/list", locals: {favorite_users: @ruby_friends} %>
+      </div>
+    <% end %>
+    <% if @favorite_rubyists.any? %>
+      <div id="favorite-rubyists">
+        <h2>
+          <%= fa("star", size: :sm, style: :solid, class: "fill-yellow-400 inline") %>
+          Favorite Rubyists
+        </h2>
+        <%= render partial: "favorite_users/list", locals: {favorite_users: @favorite_rubyists} %>
+      </div>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/profiles/_header_content.html.erb
+++ b/app/views/profiles/_header_content.html.erb
@@ -39,20 +39,7 @@
             <% end %>
           <% end %>
         <% end %>
-
-        <% if Current.user && favorite_user.present? %>
-          <%= button_to favorite_user_path(favorite_user), method: :delete do %>
-            <%= ui_tooltip "Remove from your list of Favorite Rubyists" do %>
-              <%= fa("star", size: :sm, style: :solid, class: "fill-yellow-400") %>
-            <% end %>
-          <% end %>
-        <% elsif Current.user && Current.user != user %>
-          <%= ui_tooltip "Add to your list of Favorite Rubyists" do %>
-            <%= button_to favorite_users_path(favorite_user: {favorite_user_id: user.id}), method: :post do %>
-              <%= fa("star", size: :sm, style: :regular) %>
-            <% end %>
-          <% end %>
-        <% end %>
+        <%= render "favorite_users/favorite_user", favorite_user: favorite_user %>
       </h1>
 
       <% if user.wrapped_public? %>

--- a/app/views/users/_card.html.erb
+++ b/app/views/users/_card.html.erb
@@ -1,31 +1,37 @@
-<%= link_to profile_path(user), class: "flex flex-col gap-4 hover:bg-gray-200 transition-bg duration-300 ease-in-out p-2 px-4 rounded-lg", data: {turbo_frame: "_top"} do %>
-  <div class="flex items-center gap-4">
-    <%= ui_avatar(user) %>
+<%# locals: (user:, favorite_user: nil) %>
 
-    <div>
-      <div class="font-bold text-base line-clamp-1 flex items-center gap-1.5">
-        <span class="line-clamp-1"><%= user.name %></span>
+<div class="flex items-center px-2">
+  <% if favorite_user.present? %>
+    <%= render partial: "favorite_users/favorite_user", locals: {favorite_user: favorite_user} %>
+  <% end %>
+  <%= link_to profile_path(user), class: "flex flex-col gap-4 hover:bg-gray-200 transition-bg duration-300 ease-in-out p-2 px-4 rounded-lg", data: {turbo_frame: "_top"} do %>
+    <div class="flex items-center gap-4">
+      <%= ui_avatar(user) %>
+      <div>
+        <div class="font-bold text-base line-clamp-1 flex items-center gap-1.5">
+          <span class="line-clamp-1"><%= user.name %></span>
 
-        <% if user.verified? %>
-          <%= fa("badge-check", class: "fill-blue-500", size: :xs) %>
-        <% end %>
+          <% if user.verified? %>
+            <%= fa("badge-check", class: "fill-blue-500", size: :xs) %>
+          <% end %>
 
-        <% if user.ruby_passport_claimed? %>
-          <%= fa("passport", class: "fill-orange-800", size: :xs) %>
-        <% end %>
-      </div>
+          <% if user.ruby_passport_claimed? %>
+            <%= fa("passport", class: "fill-orange-800", size: :xs) %>
+          <% end %>
+        </div>
 
-      <div class="text-xs text-gray-500 line-clamp-1">
-        <% if defined?(content) %>
-          <%= content %>
-        <% elsif user.github_handle.present? %>
-          <%= "@#{user.github_handle}" %>
-        <% elsif user.bsky.present? %>
-          <%= "@#{user.bsky}" %>
-        <% else %>
-          <%= "@#{user.slug}" %>
-        <% end %>
+        <div class="text-xs text-gray-500 line-clamp-1">
+          <% if defined?(content) %>
+            <%= content %>
+          <% elsif user.github_handle.present? %>
+            <%= "@#{user.github_handle}" %>
+          <% elsif user.bsky.present? %>
+            <%= "@#{user.bsky}" %>
+          <% else %>
+            <%= "@#{user.slug}" %>
+          <% end %>
+        </div>
       </div>
     </div>
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/test/controllers/speakers_controller_test.rb
+++ b/test/controllers/speakers_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class SpeakersControllerTest < ActionDispatch::IntegrationTest
   setup do
-    @speaker = users(:one)
+    @speaker = users(:zero_talks)
     @speaker_with_talk = users(:marco)
   end
 

--- a/test/fixtures/talks.yml
+++ b/test/fixtures/talks.yml
@@ -98,6 +98,15 @@ three:
   video_provider: youtube
   static_id: talk-title-3
 
+lightning_talk:
+  title: Lightning Talks
+  description: All of the lightning talks
+  slug: lightning-talks
+  kind: "lightning_talk"
+  video_provider: youtube
+  date: "2024-08-15"
+  static_id: lightning-talk-title
+
 brightonruby_2024_one:
   title: Getting to Two Million Users as a One Woman Dev Team
   description: talk descritpion 2

--- a/test/fixtures/user_talks.yml
+++ b/test/fixtures/user_talks.yml
@@ -38,3 +38,27 @@ marco_talk_one:
 marco_talk_two:
   user: marco
   talk: three
+
+yaroslav_lightning_talk:
+  user: yaroslav
+  talk: lightning_talk
+
+marco_lightning_talk:
+  user: marco
+  talk: lightning_talk
+
+chael_lightning_talk:
+  user: chael
+  talk: lightning_talk
+
+one_lightning_talk:
+  user: one
+  talk: lightning_talk
+
+two_lightning_talk:
+  user: two
+  talk: lightning_talk
+
+lazaro_nixon_lightning_talk:
+  user: lazaro_nixon
+  talk: lightning_talk

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -51,6 +51,15 @@
 #
 # rubocop:enable Layout/LineLength
 
+zero_talks:
+  email: zero_talks_user@rubyevents.org
+  name: Zero Talks
+  twitter: zero_talks
+  github_handle: zero_talks
+  bio: "Zero Talks"
+  slug: zero_talks
+  password_digest: <%= BCrypt::Password.create("Secret1*3*5*") %>
+
 one:
   email: one@rubyevents.org
   name: One
@@ -71,6 +80,14 @@ two:
   slug: two
   password_digest: <%= BCrypt::Password.create("Secret1*3*5*") %>
 
+chael:
+  email: chaelcodes@rubyevents.org
+  password_digest: <%= BCrypt::Password.create("Secret1*3*5*") %>
+  name: Rachael Wright-Munn
+  github_handle: chaelcodes
+  slug: rachael-wright-munn
+  talks_count: 5
+
 marco:
   email: marcoroth@rubyevents.org
   password_digest: <%= BCrypt::Password.create("Secret1*3*5*") %>
@@ -80,7 +97,7 @@ marco:
   bio: "Marco"
   website: https://marcoroth.dev
   slug: marcoroth
-  talks_count: 2
+  talks_count: 42
 
 yaroslav:
   email: yaroslav@rubyevents.org

--- a/test/models/favorite_user_test.rb
+++ b/test/models/favorite_user_test.rb
@@ -1,7 +1,38 @@
 require "test_helper"
 
 class FavoriteUserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "mutual_favorite_user association" do
+    chael = users(:chael)
+    marco = users(:marco)
+
+    favorite1 = FavoriteUser.create!(user: chael, favorite_user: marco)
+    favorite2 = FavoriteUser.create!(user: marco, favorite_user: chael)
+    favorite3 = FavoriteUser.create!(user: chael, favorite_user: users(:yaroslav))
+
+    assert_equal favorite2, favorite1.mutual_favorite_user
+    assert_equal favorite1, favorite2.mutual_favorite_user
+    assert_nil favorite3.mutual_favorite_user
+  end
+
+  test "build mutual_favorite_user" do
+    chael = users(:chael)
+    marco = users(:marco)
+
+    favorite1 = FavoriteUser.create!(user: chael, favorite_user: marco)
+    favorite2 = favorite1.build_mutual_favorite_user(user: marco, favorite_user: chael)
+
+    assert_equal marco, favorite2.user
+    assert_equal chael, favorite2.favorite_user
+  end
+
+  test "recommendations_for user with limited watched talks" do
+    talk = talks(:lightning_talk)
+    user = users(:chael)
+    WatchedTalk.create!(user: user, talk: talk, progress_seconds: 100)
+    recommendations = FavoriteUser.recommendations_for(user)
+
+    assert recommendations.all? { |fu| fu.user == user }
+    assert_equal 5, recommendations.count
+    assert recommendations.map(&:favorite_user).all? { |speaker| speaker.talks.any? { |talk| user.watched_talks.exists?(talk_id: talk.id) } }
+  end
 end

--- a/test/models/talk_test.rb
+++ b/test/models/talk_test.rb
@@ -398,11 +398,11 @@ class TalkTest < ActiveSupport::TestCase
   test "discarded user_talks" do
     talk = talks(:one)
     user_talk = talk.user_talks.first
-    assert_equal 1, user_talk.user.talks_count
+    assert_equal 2, user_talk.user.talks_count
     user_talk.discard
     assert_equal 1, talk.user_talks.count
     assert_equal 0, talk.kept_user_talks.count
-    assert_equal 0, user_talk.user.talks_count
+    assert_equal 1, user_talk.user.talks_count
   end
 
   test "should return original title" do


### PR DESCRIPTION
# Description

closes [#1259](https://github.com/rubyevents/rubyevents/issues/1259)

If two users have favorited each other, they are considered "Ruby Friends."

This pull request introduces significant improvements to the Favorite Users feature, adding support for "Ruby Friends" (mutual favorites), updating the UI to distinguish between mutual and one-way favorites, and refactoring the recommendation and display logic. It also enhances test coverage and updates fixtures for more robust testing.

**Favorite Users and Ruby Friends functionality:**

- Added `mutual_favorite_user` association to the `FavoriteUser` model, enabling identification of mutual favorite relationships ("Ruby Friends").
- Updated the `User` model to include `favorite_users` and `favorited_by` associations for easier querying of favorite relationships.

**Controller and logic updates:**

- Refactored `FavoriteUsersController#index` to separate mutual favorites (`@ruby_friends`) from one-way favorites (`@favorite_rubyists`).
- Changed `ProfilesController#set_favorite_user` to use the new `favorited_by` association for more efficient lookup.
- Changed the `FavoriteUser.recommendations_for` method to return `FavoriteUser` instances built from watched talks' speakers.

**UI and view enhancements:**

- Updated favorite user UI components to distinguish between "Ruby Friends" and "Favorite Rubyists," providing appropriate actions and tooltips for each state. [[1]](diffhunk://#diff-cbd3fd5275159f4744f4ce3e34f8628d40f29f38e3a613ee353954ef2fc1ca7fL42-R42) [[2]](diffhunk://#diff-349a3cc0913b745a24cc6820245e230f1479296615922c3f8ddf17d3c7772001L2-L9)
- Refactored views to use new partials for listing and displaying favorite users, and updated the main index page to show separate sections for Ruby Friends and Favorite Rubyists. [[1]](diffhunk://#diff-6f1b49adc8959d57d4869fe96d579d75ec5527b40453179aeee698fd79e8b8d3L1-R23) [[2]](diffhunk://#diff-838b4cead934b6af5ebac3a79cc8cb91aaa0f706a85189cfaa794321912eca77R1-R9) [[3]](diffhunk://#diff-19027f9999f4ce859356d6852cad62ee226a7941be29afa11da1d1a2cde40e0eL12-R15) [[4]](diffhunk://#diff-4524aa438e739a556be5304404c26811a3b0ddf874870356b3e5b7a25c1318ffR1-R18) [[5]](diffhunk://#diff-4524aa438e739a556be5304404c26811a3b0ddf874870356b3e5b7a25c1318ffR37)
- Added Favorite User form to the user card. Only displays if a favorite user is passed.

**Testing and fixtures:**

- Added comprehensive tests for mutual favorite associations and recommendations in `FavoriteUserTest`.
- Expanded test fixtures for users, talks, and user-talk relationships to support new test scenarios. [[1]](diffhunk://#diff-e9f27c74028e8910fb166b75aea94c4092440bd55335de5cae7c1439d4e9b0aeR74-R81) [[2]](diffhunk://#diff-e9f27c74028e8910fb166b75aea94c4092440bd55335de5cae7c1439d4e9b0aeL83-R91) [[3]](diffhunk://#diff-78c066cb17f9e7a7148da2f9c416081330c6a26b519636404c6bc8a569e5df96R101-R109) [[4]](diffhunk://#diff-239baab5d658172fda5d38d3f9a6315f1b5a4806af9d59923d6ef1346ab55d7cR41-R64)

**Screenshots**

Screenshot of Index page
Screenshot of red star on user card