### PR TITLE
Case insensitive organizations for sorting

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -4,7 +4,7 @@ class OrganizationsController < ApplicationController
 
   # GET /organizations
   def index
-    @organizations = Organization.includes(:events).order(:name)
+    @organizations = Organization.includes(:events).order("LOWER(name)")
     @organizations = @organizations.where("lower(name) LIKE ?", "#{params[:letter].downcase}%") if params[:letter].present?
     @featured_organizations = Organization.joins(:sponsors).group("organizations.id").order("COUNT(sponsors.id) DESC").limit(25).includes(:events)
   end


### PR DESCRIPTION
- **sort organizations case-insensitive**

<img width="1360" height="360" alt="Screenshot 2026-02-03 at 12 56 13" src="https://github.com/user-attachments/assets/61fdcf72-a201-44ba-a83b-86f3296584d8" />

Prevents lower-case orgs being sorted at the bottom on https://www.rubyevents.org/organizations