### PR TITLE
fix slug for fastruby

### DIFF
--- a/data/railsconf/railsconf-2025/sponsors.yml
+++ b/data/railsconf/railsconf-2025/sponsors.yml
@@ -141,7 +141,7 @@
           slug: "gitlab"
           logo_url: "https://railsconf.org/images/uploads/gitlab-logo-100.svg"
 
-        - name: "Fastly"
+        - name: "FastRuby.io"
           website: "https://www.fastruby.io/"
-          slug: "fastly"
+          slug: "fastruby-io"
           logo_url: "https://railsconf.org/images/uploads/fast-ruby-io-rails-maintenance-services.png"


### PR DESCRIPTION
incorrect data caused fastruby logo/website to show up at https://www.rubyevents.org/organizations/fastly - they are two different companies
