### PR TITLE
Fix video stops when clicking bookmark button

### DIFF
--- a/app/controllers/watch_list_talks_controller.rb
+++ b/app/controllers/watch_list_talks_controller.rb
@@ -5,13 +5,21 @@ class WatchListTalksController < ApplicationController
   def create
     @talk = Talk.find(params[:talk_id])
     @watch_list.talks << @talk
-    redirect_back fallback_location: @watch_list
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_back fallback_location: @watch_list }
+    end
   end
 
   def destroy
     @talk = @watch_list.talks.find(params[:id])
     WatchListTalk.find_by(talk_id: @talk.id, watch_list_id: @watch_list.id).destroy
-    redirect_back fallback_location: @watch_list
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_back fallback_location: @watch_list }
+    end
   end
 
   private

--- a/app/views/talks/_talk.html.erb
+++ b/app/views/talks/_talk.html.erb
@@ -67,29 +67,8 @@
             <% end %>
           <% end %>
 
-          <% if default_watch_list %>
-            <% if user_favorite_talks_ids.include?(talk.id) %>
-              <%= ui_tooltip "Add talk to your watch list" do %>
-                <%= ui_button url: watch_list_talk_path(default_watch_list, talk.id), method: :delete, kind: :pill do %>
-                  <%= fa("bookmark", size: :xs, style: :solid, class: "text-primary") %>
-                  <span class="text-xs">Bookmark</span>
-                <% end %>
-              <% end %>
-            <% else %>
-              <%= ui_tooltip "Add talk to your watch list" do %>
-                <%= ui_button url: watch_list_talks_path(default_watch_list, talk_id: talk.id), method: :post, kind: :pill do %>
-                  <%= fa("bookmark", size: :xs, style: :regular) %>
-                  <span class="text-xs">Bookmark</span>
-                <% end %>
-              <% end %>
-            <% end %>
-          <% else %>
-            <%= ui_tooltip "Add talk to your watch list" do %>
-              <%= ui_button url: new_session_path(redirect_to: request.fullpath), data: {turbo_frame: "modal"}, kind: :pill do %>
-                <%= fa("bookmark", size: :xs, style: :regular) %>
-                <span class="text-xs">Bookmark</span>
-              <% end %>
-            <% end %>
+          <%= turbo_frame_tag dom_id(talk, :bookmark_button) do %>
+            <%= render partial: "watch_list_talks/bookmark_button", locals: {talk: talk, default_watch_list: default_watch_list, is_bookmarked: user_favorite_talks_ids&.include?(talk.id)} %>
           <% end %>
 
           <% if talk.youtube? || talk.parent_talk&.youtube? %>

--- a/app/views/watch_list_talks/_bookmark_button.html.erb
+++ b/app/views/watch_list_talks/_bookmark_button.html.erb
@@ -1,0 +1,26 @@
+<%# locals: (talk:, default_watch_list:, is_bookmarked:) %>
+
+<% if default_watch_list %>
+  <% if is_bookmarked %>
+    <%= ui_tooltip "Remove from your watch list" do %>
+      <%= ui_button url: watch_list_talk_path(default_watch_list, talk.id), method: :delete, kind: :pill do %>
+        <%= fa("bookmark", size: :xs, style: :solid, class: "text-primary") %>
+        <span class="text-xs">Bookmark</span>
+      <% end %>
+    <% end %>
+  <% else %>
+    <%= ui_tooltip "Add talk to your watch list" do %>
+      <%= ui_button url: watch_list_talks_path(default_watch_list, talk_id: talk.id), method: :post, kind: :pill do %>
+        <%= fa("bookmark", size: :xs, style: :regular) %>
+        <span class="text-xs">Bookmark</span>
+      <% end %>
+    <% end %>
+  <% end %>
+<% else %>
+  <%= ui_tooltip "Add talk to your watch list" do %>
+    <%= ui_button url: new_session_path(redirect_to: request.fullpath), data: {turbo_frame: "modal"}, kind: :pill do %>
+      <%= fa("bookmark", size: :xs, style: :regular) %>
+      <span class="text-xs">Bookmark</span>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/watch_list_talks/create.turbo_stream.erb
+++ b/app/views/watch_list_talks/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace dom_id(@talk, :bookmark_button) do %>
+  <%= render partial: "watch_list_talks/bookmark_button", locals: {talk: @talk, default_watch_list: @watch_list, is_bookmarked: true} %>
+<% end %>

--- a/app/views/watch_list_talks/destroy.turbo_stream.erb
+++ b/app/views/watch_list_talks/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace dom_id(@talk, :bookmark_button) do %>
+  <%= render partial: "watch_list_talks/bookmark_button", locals: {talk: @talk, default_watch_list: @watch_list, is_bookmarked: false} %>
+<% end %>


### PR DESCRIPTION
Clicking the bookmark button while a video was playing would stop playback because the controller returned a redirect, triggering Turbo's page morph which disconnected the video player.

This change adds turbo_stream responses to `WatchListTalksController`, similar to how `Talks::WatchedTalksController` already handles it. Now only the bookmark button element is updated, preserving video state.