### PR TITLE
Fix hidden grid items on tablet viewports

### DIFF
--- a/app/views/countries/state.html.erb
+++ b/app/views/countries/state.html.erb
@@ -48,7 +48,7 @@
             <h2 class="text-primary shrink-0"><%= kind.humanize.pluralize %></h2>
           </div>
 
-          <div class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 md:[&>:nth-child(4)]:hidden lg:grid-cols-4 lg:[&>:nth-child(4)]:block">
+          <div class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
             <%= cache events do %>
               <%= render partial: "events/card", collection: events, as: :event, cached: true %>
             <% end %>

--- a/app/views/events/series/index.html.erb
+++ b/app/views/events/series/index.html.erb
@@ -2,7 +2,7 @@
   <h1 class="title">Event Series</h1>
 
   <section class="flex flex-col w-full gap-4 mt-8">
-    <div class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 md:[&>:nth-child(4)]:hidden lg:grid-cols-4 lg:[&>:nth-child(4)]:block">
+    <div class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
       <%= render partial: "events/series/card", collection: @event_series, as: :series %>
     </div>
 

--- a/app/views/events/series/show.html.erb
+++ b/app/views/events/series/show.html.erb
@@ -65,7 +65,7 @@
         <div class="flex items-center justify-between w-full">
           <h2 class="text-primary shrink-0">Events</h2>
         </div>
-        <div class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 md:[&>:nth-child(4)]:hidden lg:grid-cols-4 lg:[&>:nth-child(4)]:block">
+        <div class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
           <%= cache @events do %>
             <%= render partial: "events/card", collection: @events, as: :event, cached: true %>
           <% end %>

--- a/app/views/profiles/_talks.html.erb
+++ b/app/views/profiles/_talks.html.erb
@@ -2,7 +2,7 @@
   <div role="tablist" class="tabs tabs-boxed bg-base-100 mt-2">
     <input type="radio" name="talk_kinds" role="tab" class="tab px-6 !rounded-lg" aria-label="All" <% if talks.size.positive? %> checked <% end %>>
     <div role="tabpanel" class="tab-content mt-6">
-      <div class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 md:[&>:nth-child(4)]:hidden lg:grid-cols-4 lg:[&>:nth-child(4)]:block">
+      <div class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
         <%= render partial: "talks/card",
               collection: talks,
               as: :talk,
@@ -19,7 +19,7 @@
       <input type="radio" name="talk_kinds" role="tab" class="tab px-6 !rounded-lg" aria-label="<%= talks.first.formatted_kind.pluralize %> (<%= talks.size %>)">
 
       <div role="tabpanel" class="tab-content mt-6">
-        <div class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 md:[&>:nth-child(4)]:hidden lg:grid-cols-4 lg:[&>:nth-child(4)]:block">
+        <div class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
           <%= render partial: "talks/card",
                 collection: talks,
                 as: :talk,

--- a/app/views/recommendations/index.html.erb
+++ b/app/views/recommendations/index.html.erb
@@ -4,7 +4,7 @@
   </h1>
 
   <% if @recommended_talks.present? %>
-    <div class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 md:[&>:nth-child(4)]:hidden lg:grid-cols-4 lg:[&>:nth-child(4)]:block">
+    <div class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
       <%= render partial: "talks/card", collection: @recommended_talks, as: :talk, cached: true,
             locals: {
               back_to: recommendations_path,


### PR DESCRIPTION
Hello! 👋🏻 

I was looking at my profile (😳) on my iPad when I noticed the following...

<img width="870" height="1128" alt="CleanShot 2026-02-12 at 12 57 24@2x" src="https://github.com/user-attachments/assets/f2aa0bf7-64fa-4ede-aa44-8b9cb8c822fa" />

ONE TALK IS MISSING but it turns out that it is just hidden by the css depending on the viewport size 😬 

I can see why in the home page we do not want to show extra items if the viewport does not fit them but, in the pages that show all items, we should never hide them. Am I missing something!?

I asked Claude to lookup the commit and PR descriptions to see if there's a good reason for using those styles in some pages and it feels to me it's just a copy & paste mistake 🤔 

## BEFORE

<img width="1258" height="1744" alt="CleanShot 2026-02-12 at 13 00 42@2x" src="https://github.com/user-attachments/assets/28e9e6ca-637c-42f7-85aa-ab0e8efc520e" />

## AFTER

<img width="1258" height="1744" alt="CleanShot 2026-02-12 at 13 00 16@2x" src="https://github.com/user-attachments/assets/0799c2d6-51c4-498b-8cb7-a1aea55aadc8" />