### PR TITLE
Better handling of cancelled events and events with no year in YAML

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -5,6 +5,7 @@
 @import "components/button.css";
 @import "components/diff.css";
 @import "components/dropdown.css";
+@import "components/event.css";
 @import "components/form.css";
 @import "components/hotwire-combobox.css";
 @import "components/markdown.css";

--- a/app/assets/stylesheets/components/event.css
+++ b/app/assets/stylesheets/components/event.css
@@ -1,0 +1,6 @@
+@layer components {
+  .event-card.cancelled,
+  .card.cancelled {
+    opacity: 0.5;
+  }
+}

--- a/app/models/event/static_metadata.rb
+++ b/app/models/event/static_metadata.rb
@@ -106,6 +106,10 @@ class Event::StaticMetadata < ActiveRecord::AssociatedObject
     !!static_repository.try(:hybrid) || false
   end
 
+  def cancelled?
+    static_repository&.status == "cancelled"
+  end
+
   private
 
   def static_repository

--- a/app/models/event_series.rb
+++ b/app/models/event_series.rb
@@ -98,8 +98,11 @@ class EventSeries < ApplicationRecord
   end
 
   def description
-    start_year = events.minimum(:date)&.year
-    end_year = events.maximum(:date)&.year
+    non_cancelled = events.reject { |e| e.static_metadata.cancelled? }
+
+    event_years = non_cancelled.filter_map { |e| (e.date || e.start_date || e.end_date)&.year }
+    start_year = event_years.min
+    end_year = event_years.max
 
     time_range = if start_year && start_year == end_year
       %( in #{start_year})
@@ -109,11 +112,11 @@ class EventSeries < ApplicationRecord
       ""
     end
 
-    event_type = pluralize(events.size, meetup? ? "event-series" : "event")
+    event_type = pluralize(non_cancelled.size, meetup? ? "event-series" : "event")
     frequency_text = (kind == "organisation") ? "" : " is a #{frequency} #{kind} and "
 
     <<~DESCRIPTION
-      #{name} #{frequency_text}hosted #{event_type}#{time_range}. We have currently indexed #{pluralize(events.sum { |event| event.talks_count }, "#{name} talk")}.
+      #{name} #{frequency_text}hosted #{event_type}#{time_range}. We have currently indexed #{pluralize(non_cancelled.sum(&:talks_count), "#{name} talk")}.
     DESCRIPTION
   end
 

--- a/app/views/events/_card.html.erb
+++ b/app/views/events/_card.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (event:, participation: nil) %>
 
 <%= link_to event_path(event), class: "flex w-full", data: {turbo_frame: "_top"} do %>
-  <div class="card card-compact bg-white border w-full">
+  <div class="card card-compact bg-white border w-full <%= "cancelled" if event.static_metadata.cancelled? %>">
     <%= image_tag image_path(event.card_image_path), class: "w-full object-cover rounded-t-xl border-b", alt: event.name, width: 300, height: 175 %>
     <div class="card-body flex flex-col items-center justify-center min-h-[130px]">
       <div class="text-xl font-semibold text-center line-clamp-1"><%= event.name %></div>


### PR DESCRIPTION
* Cancelled events are now shown with opacity:0.5 so they look different on the event series page
* Cancelled events are not included in the EVENT_COUNT or TALK_COUNT in the series summary "FOOCONF is a yearly conference and hosted EVENT_COUNT events between START and END. We have currently indexed TALK_COUNT FOOCONF talks."
* The START and END dates are fixed so that conferences that have a start_date but no date are included in the series summary