### PR TITLE
Case insensitive speaker sort

### DIFF
--- a/app/controllers/speakers_controller.rb
+++ b/app/controllers/speakers_controller.rb
@@ -4,7 +4,7 @@ class SpeakersController < ApplicationController
 
   # GET /speakers
   def index
-    @speakers = User.speakers.order(:name)
+    @speakers = User.speakers.order("LOWER(users.name)")
     @speakers = @speakers.where("lower(users.name) LIKE ?", "#{params[:letter].downcase}%") if params[:letter].present?
     @speakers = @speakers.ft_search(params[:s]).with_snippets.ranked if params[:s].present?
     @pagy, @speakers = pagy(@speakers, gearbox_extra: true, gearbox_limit: [200, 300, 600], page: params[:page])


### PR DESCRIPTION
Similar to 6660e35977048ebb2c657a3acd7cc726c1e37871 this makes speaker sort case insensitive so the lowercase names (mostly pseudonyms/usernames) don't get pushed to the end

<img width="1325" height="301" alt="image" src="https://github.com/user-attachments/assets/90660063-c1bd-475a-a61e-ff78b9e0f757" />

