### PR TITLE
Fix awkward line breaking on mobile event metadata

### DIFF
--- a/app/views/events/_header.html.erb
+++ b/app/views/events/_header.html.erb
@@ -23,13 +23,13 @@
             style: "view-transition-name: #{dom_id(event, :logo)}",
             loading: :lazy %>
 
-      <div class="flex-col flex justify-center break-all">
+      <div class="flex-col flex justify-center">
         <h1 class="mb-2 text-black font-bold"><%= title event.name %></h1>
         <h3 class="text-[#636B74]">
           <%= event.to_location.to_html %>
           • <%= event.formatted_dates %>
         </h3>
-        <%= external_link_to event.website.gsub(%r{^https?://}, "").gsub(%r{/$}, ""), event.website %>
+        <%= external_link_to event.website.gsub(%r{^https?://}, "").gsub(%r{/$}, ""), event.website, class: "break-all" %>
       </div>
     </div>
 


### PR DESCRIPTION
fix #1433

this is a more targeted fix for #728 which allows URLs to break, but not regular text like month names or cities
