### PR TITLE
Order event involvements for organization by date

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -17,7 +17,9 @@ class OrganizationsController < ApplicationController
 
     @countries_with_events = @events.grouped_by_country
 
-    involvements = @organization.event_involvements.includes(:event).order(:position)
+    involvements = @organization.event_involvements.joins(:event).order(
+      Arel.sql("COALESCE(events.start_date, events.created_at) ASC")
+    )
     @involvements_by_role = involvements.group_by(&:role)
     @involved_events = @organization.involved_events.includes(:series).distinct.order(start_date: :desc)
 


### PR DESCRIPTION
Currently on organization show page, involvements are ordered by position, and when position for event involvements is not correct events are ordered in arbitrary order.
This commit fixes the ordering by either start_date from events column, or created_at, when start_date is empty.

fixes: #1437