### PR TITLE
Show playlists for events with no videos page

### DIFF
--- a/app/models/event/static_metadata.rb
+++ b/app/models/event/static_metadata.rb
@@ -110,6 +110,10 @@ class Event::StaticMetadata < ActiveRecord::AssociatedObject
     static_repository&.status == "cancelled"
   end
 
+  def playlist
+    static_repository&.playlist
+  end
+
   private
 
   def static_repository

--- a/app/views/contributions/_events_without_videos.html.erb
+++ b/app/views/contributions/_events_without_videos.html.erb
@@ -12,7 +12,12 @@
           <b class="mt-4 mb-2">Events without videos:</b>
 
           <% events.each do |event| %>
-            <span><%= link_to event.name, event, class: "hover:underline" %></span>
+            <span>
+              <%= link_to event.name, event, class: "hover:underline" %>
+              <% if event.static_metadata.playlist.present? %>
+                (<%= link_to "playlist", event.static_metadata.playlist, target: "_blank", rel: "noopener" %>)
+              <% end %>
+            </span>
           <% end %>
         </div>
       <% end %>


### PR DESCRIPTION
On /contributions page, in the "Events with no videos" tab, if an event has a playlist in the YML, link to it. This allows prioritising events for which videos are available but not extracted yet.
