### PR TITLE
February 2026 Newsletter!

### DIFF
--- a/content/announcements/2026-02-01-february-newsletter.md
+++ b/content/announcements/2026-02-01-february-newsletter.md
@@ -1,0 +1,121 @@
+---
+title: "RubyEvents.org February 2026 Newsletter"
+slug: february-2026-newsletter
+date: 2026-02-01
+author: chaelcodes
+published: true
+excerpt: |-
+  In February, RubyEvents had 12 contributors and 55 PRs merged! This month, we had RubyForGood - Belgium, Belfast RubyFest, and Fukuoka RubyistKaigi 05. We're looking forward to Ruby Community Conference Winter Edition and RBQConf next month!
+tags:
+  - newsletter
+  - february
+  - 2026
+featured_image:
+---
+In February, RubyEvents had 12 contributors and 55 PRs merged! This month, we had RubyForGood - Belgium, Belfast RubyFest, and Fukuoka RubyistKaigi 05. We're looking forward to Ruby Community Conference Winter Edition and RBQConf next month!
+
+## This month's events 
+
+- [Ruby for Good Belgium](https://www.rubyevents.org/events/ruby-for-good-belgium-2026) was in Ghent, Belgium from February 2-4.
+- [Belfast RubyFest](https://www.rubyevents.org/events/belfast-rubyfest-2026) was in Belfast, Ireland on February 11.
+- [Fukuoka RubyistKaigi 05](https://www.rubyevents.org/events/fukuoka-rubyistkaigi-05) was in Fukuoka, Japan on February 28.
+
+> Did you attend a Ruby event this month that isn't on the list? Let us know with an issue or PR!
+
+## Next month's events
+
+- [Ruby Community Conference Winter Edition](https://www.rubyevents.org/events/ruby-community-conference-winter-edition-2026) will be in Kraków, Poland on March 13th. [Tickets](https://luma.com/RubyCommunityConference2026) are PLN 450. _Meet RubyEvents team member, Marco Roth, who'll be speaking about Herb and ReActionView!_
+- [RBQConf](https://www.rubyevents.org/events/rbqconf-2026) will be in Austin, TX on March 26-27. [Tickets](https://www.rubyevents.org/events/rbqconf-2026/tickets) are USD $399. Price increases to $499 on March 4th.
+
+## Open CFPs
+
+- [RubyConf Africa](https://www.rubyevents.org/events/rubyconf-africa-2026/cfp) will be in Nairobi, Kenya from August 21-22. The [CFP](https://www.papercall.io/ruby-conf-africa-2026) closes March 11.
+- [RubyConf](https://www.rubyevents.org/events/rubyconf-2026/cfp) will be in Las Vegas from July 14-16. The [CFP](https://sessionize.com/rubyconf-2026/) closes March 15.
+- [Matsue RubyKaigi 12](https://www.rubyevents.org/events/matsue-rubykaigi-12/cfp) will be in Matsue, Japan on June 6. The [CFP](https://docs.google.com/forms/d/e/1FAIpQLSdINI42_XRbNUpfQfz7y5YVrYi2cFarvzfo3o5QVOkSFfsSsg/viewform) closes March 13.
+- [RBQConf](http://localhost:3000/events/rbqconf-2026/cfp) is looking for lightning talks! The [lightning talk CFP](https://docs.google.com/forms/d/e/1FAIpQLSdVIotL2KY-ZLSCAa6tZfsYZGctnWBKwEfuAtrL4JDqmq6xOg/viewform) closes soon!
+- [tiny ruby #{conf}](https://www.rubyevents.org/events/tiny-ruby-conf-2026/cfp) will be in Helsinki, Finland on October 1. The [CFP](https://cfp.helsinkiruby.fi/) closes June 14.
+
+## Uploaded videos
+
+- [RubyConf TH 2026](https://www.rubyevents.org/events/rubyconfth-2026/talks) added 18 talks!
+- [RubyConf Kenya 2017](https://www.rubyevents.org/events/rubyconf-kenya-2017/talks) added 10 talks!
+- [SF Ruby December Meetup](https://www.rubyevents.org/talks/sf-bay-area-ruby-meetup-december-2025) added 5 talks!
+- [SF Ruby January Meetup](https://www.rubyevents.org/talks/sf-bay-area-ruby-meetup-january-2026) added 5 talks!
+- [RubyConf India 2019](https://www.rubyevents.org/events/rubyconf-india-2019/talks) added 12 talks!
+
+## Contributions
+
+We had 12 contributors this month and 55 merged PRs!
+
+- Rachael Wright-Munn (@ChaelCodes)
+  - [Ruby Community Conference Winter Edition 2026 Updates (#1457)](https://github.com/rubyevents/rubyevents/pull/1457)
+  - [Add pull request template to standardize contributions. (#1455)](https://github.com/rubyevents/rubyevents/pull/1455)
+  - [Favorite User Bug + Favorite Users on Participants (#1446)](https://github.com/rubyevents/rubyevents/pull/1446)
+  - [RBQConf Schedule (#1429)](https://github.com/rubyevents/rubyevents/pull/1429)
+  - [Update Blue Ridge Ruby talk ids and Talks Generator (#1427)](https://github.com/rubyevents/rubyevents/pull/1427)
+  - [Blue Ridge Ruby talks and TalkGenerator (#1425)](https://github.com/rubyevents/rubyevents/pull/1425)
+  - [RubyConf 2026 updates & Sponsor/CFP Generator updates (#1423)](https://github.com/rubyevents/rubyevents/pull/1423)
+  - [Create EventGenerator (#1417)](https://github.com/rubyevents/rubyevents/pull/1417)
+  - [Organization improvements (#1406)](https://github.com/rubyevents/rubyevents/pull/1406)
+  - [Fix locations/:location/users (#1392)](https://github.com/rubyevents/rubyevents/pull/1392)
+  - [Add Favorite to talk page (#1391)](https://github.com/rubyevents/rubyevents/pull/1391)
+  - [Move Fukuoka Assets to new event-series slug (#1390)](https://github.com/rubyevents/rubyevents/pull/1390)
+  - [Tropical on rails 2026 speakers (#1385)](https://github.com/rubyevents/rubyevents/pull/1385)
+  - [Add Favorite Rubyists (#1381)](https://github.com/rubyevents/rubyevents/pull/1381)
+- Adrien Poly (@adrienpoly)
+  - [add file based news/announcements articles (#1362)](https://github.com/rubyevents/rubyevents/pull/1362)
+- 🤖 (@app/copilot-swe-agent)
+  - [Fix CFP link in mobile nav pointing to /events instead of /cfp (#1430)](https://github.com/rubyevents/rubyevents/pull/1430)
+  - [Update tickets_url for Wroclove.rb 2026 (#1394)](https://github.com/rubyevents/rubyevents/pull/1394)
+- Ender Ahmet Yurt (@enderahmetyurt)
+  - [Strip diacritics in Country slug instead of transliterating (#1411)](https://github.com/rubyevents/rubyevents/pull/1411)
+- Hans Schnedlitz (@hschne)
+  - [Fix continent list  (#1428)](https://github.com/rubyevents/rubyevents/pull/1428)
+  - [Add Vienna.rb March 2026 (#1409)](https://github.com/rubyevents/rubyevents/pull/1409)
+- Irina Nazarova (@irinanazarova)
+  - [Add YouTube recordings for SF Ruby Meetup Dec 2025 & Jan 2026 (#1461)](https://github.com/rubyevents/rubyevents/pull/1461)
+- Marco Roth (@marcoroth)
+  - [EuRuKo 2026 dates and venue (#1459)](https://github.com/rubyevents/rubyevents/pull/1459)
+  - [Upgrade Herb to `v0.8.10` and ReActionView to `v0.2.1` (#1414)](https://github.com/rubyevents/rubyevents/pull/1414)
+  - [Add Ruby Hoedown 2007 (#1368)](https://github.com/rubyevents/rubyevents/pull/1368)
+  - [Add Avo Dashboards for Unavailable Videos, Suspicious/Duplicate Users (#1302)](https://github.com/rubyevents/rubyevents/pull/1302)
+  - [Add Ruby Australia Meetups and artwork (#605)](https://github.com/rubyevents/rubyevents/pull/605)
+  - [Implement basic talks filter based on language and kind (#384)](https://github.com/rubyevents/rubyevents/pull/384)
+- Matias Korhonen (@matiaskorhonen)
+  - [Add tiny ruby #{conf} CFP (#1405)](https://github.com/rubyevents/rubyevents/pull/1405)
+- Matt Mayer (@matthewmayer)
+  - [More helpful keynote names for RubyConf India 2019 (#1464)](https://github.com/rubyevents/rubyevents/pull/1464)
+  - [Rubyconf India and DeccanRubyConf assets (#1452)](https://github.com/rubyevents/rubyevents/pull/1452)
+  - [RubyConf India 2019 videos (#1444)](https://github.com/rubyevents/rubyevents/pull/1444)
+  - [Add videos and aliases for RubyConf Kenya 2017 (#1443)](https://github.com/rubyevents/rubyevents/pull/1443)
+  - [fix typo Afria -> Africa (#1442)](https://github.com/rubyevents/rubyevents/pull/1442)
+  - [include aliases when ignoring old events from rubyconferences.org (#1439)](https://github.com/rubyevents/rubyevents/pull/1439)
+  - [Fix awkward line breaking on mobile event metadata (#1435)](https://github.com/rubyevents/rubyevents/pull/1435)
+  - [add 2026 RubyConf TH videos (#1432)](https://github.com/rubyevents/rubyevents/pull/1432)
+  - [Add additional Haggis Ruby info for 2026 (#1422)](https://github.com/rubyevents/rubyevents/pull/1422)
+  - [Case insensitive speaker sort (#1421)](https://github.com/rubyevents/rubyevents/pull/1421)
+  - [Merge some sponsors (#1420)](https://github.com/rubyevents/rubyevents/pull/1420)
+  - [Add RubyConfIndia 2010-2013 events and update website links (#1418)](https://github.com/rubyevents/rubyevents/pull/1418)
+  - [updated assets for RubyConfTH (#1416)](https://github.com/rubyevents/rubyevents/pull/1416)
+  - [Better handling of cancelled events and events with no year in YAML (#1415)](https://github.com/rubyevents/rubyevents/pull/1415)
+  - [RubyConfTH 2019 extra talks (#1413)](https://github.com/rubyevents/rubyevents/pull/1413)
+  - [RubyConfTH: add full schedules for 2019, 2022, 2023; remove 2020 (#1401)](https://github.com/rubyevents/rubyevents/pull/1401)
+  - [fix slug for fastruby (#1400)](https://github.com/rubyevents/rubyevents/pull/1400)
+  - [Case insensitive organizations for sorting (#1396)](https://github.com/rubyevents/rubyevents/pull/1396)
+  - [more detail for rubyconfth: keynote titles, schedule, sponsors, involvements (#1395)](https://github.com/rubyevents/rubyevents/pull/1395)
+  - [Fix website and add Bangkok.rb as organizer for all past rubyconfth events (#1387)](https://github.com/rubyevents/rubyevents/pull/1387)
+- Sudeep Tarlekar (@sudeeptarlekar)
+  - [Count event involvements for organizations (#1449)](https://github.com/rubyevents/rubyevents/pull/1449)
+  - [Order event involvements for organization by date (#1445)](https://github.com/rubyevents/rubyevents/pull/1445)
+- Tom Stuart (@tomstuart)
+  - [Move incorrectly-attributed @tomstuart talks to @rentalcustard (#1440)](https://github.com/rubyevents/rubyevents/pull/1440)
+- Vinícius Alonso (@viniciusalonso)
+  - [Add og informations for missing places in events area (#1448)](https://github.com/rubyevents/rubyevents/pull/1448)
+  - [Order events archive by name and start date (#1447)](https://github.com/rubyevents/rubyevents/pull/1447)
+- Julia López (@yukideluxe)
+  - [Baruco conferences assets (#1412)](https://github.com/rubyevents/rubyevents/pull/1412)
+  - [Fix hidden grid items on tablet viewports (#1410)](https://github.com/rubyevents/rubyevents/pull/1410)
+
+Thank you to everyone for your contributions! ❤️ 
+
+> Looking to join this list in March? Check out our [contributions page](https://www.rubyevents.org/contributions) or the [CONTRIBUTING.md](https://github.com/rubyevents/rubyevents/blob/main/CONTRIBUTING.md) in GitHub.


### PR DESCRIPTION
## Description
<!-- Please describe your changes. -->
Our very first newsletter describing February 2026! (Released on March 3rd. :sweat_smile:)

## Screenshots
<!-- Add screenshots or GIFs if applicable. -->
<img width="1416" height="802" alt="Screenshot 2026-03-03 at 5 46 26 PM" src="https://github.com/user-attachments/assets/cfb461f1-c4b7-4e41-a4a3-588f122c28ed" />

## Testing Steps
<!-- List steps to test your changes. -->
<!-- If this is a content PR, link to the affected pages -->
[/announcements/february-2026-newsletter](https://www.rubyevents.org/announcements/february-2026-newsletter)

## References
<!-- Link to related issues, discussions, other PRs, or references you used to write the PR. -->
- closes #1426

