### PR TITLE
Sort by series name case insensitive on /events/archive

### DIFF
--- a/app/controllers/events/archive_controller.rb
+++ b/app/controllers/events/archive_controller.rb
@@ -2,7 +2,7 @@ class Events::ArchiveController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[index]
 
   def index
-    @events = Event.canonical.includes(:series).order("series.name ASC, events.start_date ASC")
+    @events = Event.canonical.joins(:series).includes(:series).order("LOWER(event_series.name) ASC, events.start_date ASC")
     @events = @events.where("lower(events.name) LIKE ?", "#{params[:letter].downcase}%") if params[:letter].present?
     @events = @events.ft_search(params[:s]) if params[:s].present?
     @events = @events.where(kind: params[:kind]) if params[:kind].present? && params[:kind] != "all"


### PR DESCRIPTION


## Description
Sort event series case-sensitive

## Screenshots
<img width="346" height="357" alt="Screenshot 2026-03-08 at 18 42 49" src="https://github.com/user-attachments/assets/cb0e6a5b-1074-4251-a93e-ac811557f3f6" />


## Testing Steps
Review /events/archive?kind=all

## References

fix #1488
