### PR TITLE
Isolate Generator specs

### DIFF
--- a/test/lib/generators/cfp_generator_test.rb
+++ b/test/lib/generators/cfp_generator_test.rb
@@ -6,8 +6,7 @@ require "yaml"
 
 class CFPGeneratorTest < Rails::Generators::TestCase
   tests CfpGenerator
-  destination Rails.root.join("tmp/generators")
-  setup :prepare_destination
+  destination Rails.root.join("tmp/generators/cfp")
 
   test "generator runs without errors" do
     assert_nothing_raised do
@@ -24,6 +23,8 @@ class CFPGeneratorTest < Rails::Generators::TestCase
 
     cfp_file_path = File.join(destination_root, "data/rubyconf/2022/cfp.yml")
     validate_cfp_file(cfp_file_path)
+
+    File.delete cfp_file_path
   end
 
   test "update cfp.yml if called twice" do
@@ -37,6 +38,8 @@ class CFPGeneratorTest < Rails::Generators::TestCase
 
     cfp_file_path = File.join(destination_root, "data/rubyconf/2023/cfp.yml")
     validate_cfp_file(cfp_file_path)
+
+    File.delete cfp_file_path
   end
 
   test "append to cfp.yml if called with a different name" do
@@ -50,6 +53,8 @@ class CFPGeneratorTest < Rails::Generators::TestCase
 
     cfp_file_path = File.join(destination_root, "data/rubyconf/2024/cfp.yml")
     validate_cfp_file(cfp_file_path)
+
+    File.delete cfp_file_path
   end
 
   def validate_cfp_file(path)

--- a/test/lib/generators/event_generator_test.rb
+++ b/test/lib/generators/event_generator_test.rb
@@ -6,12 +6,9 @@ require "yaml"
 
 class EventGeneratorTest < Rails::Generators::TestCase
   tests EventGenerator
-  destination Rails.root.join("tmp/generators")
-  setup :prepare_destination
+  destination Rails.root.join("tmp/generators/event")
 
   test "creates event.yml in correct directory" do
-    skip "flaky test" if ENV["CI"]
-
     assert_nothing_raised do
       run_generator ["--event-series", "rubyconf", "--event", "2024", "--name", "RubyConf 2024"]
     end
@@ -19,6 +16,8 @@ class EventGeneratorTest < Rails::Generators::TestCase
     assert_file "data/rubyconf/2024/event.yml" do |content|
       assert_match(/\S/, content) # Verify file has content
     end
+
+    File.delete(File.join(destination_root, "data/rubyconf/2024/event.yml"))
   end
 
   test "creates venue.yml" do
@@ -27,24 +26,35 @@ class EventGeneratorTest < Rails::Generators::TestCase
       assert_match(/RubyConf 2025 Venue/, content)
       assert_match(/123 Main St/, content)
     end
+
+    File.delete(File.join(destination_root, "data/rubyconf/2025/event.yml"))
+    File.delete(File.join(destination_root, "data/rubyconf/2025/venue.yml"))
   end
 
   test "event.yml passes schema validation" do
     run_generator ["--event-series", "rubyconf", "--event", "2026", "--name", "RubyConf 2026"]
 
-    validate_event_schema File.join(destination_root, "data/rubyconf/2026/event.yml")
+    event_file_path = File.join(destination_root, "data/rubyconf/2026/event.yml")
+    validate_event_schema event_file_path
+
+    File.delete event_file_path
   end
 
   test "event with all flags passes schema validation" do
     run_generator ["--event-series", "rubyconf", "--event", "2027", "--name", "RubyConf 2027", "--kind", "retreat", "--hybrid", "--last-edition"]
 
-    validate_event_schema File.join(destination_root, "data/rubyconf/2027/event.yml")
+    event_file_path = File.join(destination_root, "data/rubyconf/2027/event.yml")
+    validate_event_schema event_file_path
+    File.delete event_file_path
   end
 
   test "event with all flags off passes schema validation" do
     run_generator ["--event-series", "rubyconf", "--event", "2028", "--name", "RubyConf 2028", "--no-hybrid", "--no-last-edition"]
 
-    validate_event_schema File.join(destination_root, "data/rubyconf/2028/event.yml")
+    event_file_path = File.join(destination_root, "data/rubyconf/2028/event.yml")
+    validate_event_schema event_file_path
+
+    File.delete event_file_path
   end
 
   def validate_event_schema(file_path)

--- a/test/lib/generators/schedule_generator_test.rb
+++ b/test/lib/generators/schedule_generator_test.rb
@@ -3,8 +3,7 @@ require "generators/schedule/schedule_generator"
 
 class ScheduleGeneratorTest < Rails::Generators::TestCase
   tests ScheduleGenerator
-  destination Rails.root.join("tmp/generators")
-  setup :prepare_destination
+  destination Rails.root.join("tmp/generators/schedule")
 
   test "creates schedule.yml in correct directory" do
     assert_nothing_raised do
@@ -15,7 +14,10 @@ class ScheduleGeneratorTest < Rails::Generators::TestCase
       assert_match(/\S/, content) # Verify file has content
     end
 
-    validate_schedule_schema File.join(destination_root, "data/rbqconf/rbqconf-2026/schedule.yml")
+    schedule_file_path = File.join(destination_root, "data/rbqconf/rbqconf-2026/schedule.yml")
+    validate_schedule_schema schedule_file_path
+
+    File.delete schedule_file_path
   end
 
   def validate_schedule_schema(file_path)

--- a/test/lib/generators/sponsors_generator_test.rb
+++ b/test/lib/generators/sponsors_generator_test.rb
@@ -6,7 +6,7 @@ require "yaml"
 
 class SponsorsGeneratorTest < Rails::Generators::TestCase
   tests SponsorsGenerator
-  destination Rails.root.join("tmp/generators")
+  destination Rails.root.join("tmp/generators/sponsors")
   setup :prepare_destination
 
   test "generator populates sponsors.yml with arguments" do
@@ -20,6 +20,8 @@ class SponsorsGeneratorTest < Rails::Generators::TestCase
       assert_match(/typesense/, content, "typesense sponsor missing")
       assert_match(/appsignal/, content, "AppSignal sponsor missing")
     end
+
+    File.delete File.join(destination_root, "data/tropicalrb/tropical-on-rails-2026/sponsors.yml")
   end
 
   test "sponsors.yml passes schema validation" do
@@ -38,5 +40,7 @@ class SponsorsGeneratorTest < Rails::Generators::TestCase
     end
 
     assert_empty errors, "Sponsors YAML does not conform to schema: #{errors.join(", ")}"
+
+    File.delete sponsor_file_path
   end
 end

--- a/test/lib/generators/talk_generator_test.rb
+++ b/test/lib/generators/talk_generator_test.rb
@@ -5,14 +5,15 @@ require "json_schemer"
 
 class TalkGeneratorTest < Rails::Generators::TestCase
   tests TalkGenerator
-  destination Rails.root.join("tmp/generators")
-  setup :prepare_destination
+  destination Rails.root.join("tmp/generators/talk")
 
   test "generator runs without errors" do
     assert_nothing_raised do
       # This must be a real event - tests Static::Event lookup
       run_generator ["--event", "rubyconf-2024"]
     end
+
+    File.delete(File.join(destination_root, "data/rubyconf/rubyconf-2024/videos.yml"))
   end
 
   test "creates videos.yml with valid yaml" do
@@ -24,6 +25,8 @@ class TalkGeneratorTest < Rails::Generators::TestCase
 
     videos_file_path = File.join(destination_root, "data/rubyconf/2025/videos.yml")
     validate_talk_file(videos_file_path)
+
+    File.delete(videos_file_path)
   end
 
   test "update videos.yml if called twice" do
@@ -37,6 +40,8 @@ class TalkGeneratorTest < Rails::Generators::TestCase
 
     videos_file_path = File.join(destination_root, "data/rubyconf/2026/videos.yml")
     validate_talk_file(videos_file_path)
+
+    File.delete(videos_file_path)
   end
 
   test "append to videos.yml if called with a different details" do
@@ -57,13 +62,18 @@ class TalkGeneratorTest < Rails::Generators::TestCase
 
     videos_file_path = File.join(destination_root, "data/rubyconf/2027/videos.yml")
     validate_talk_file(videos_file_path)
+
+    File.delete(videos_file_path)
   end
 
   test "finds event series from static event if not provided" do
     run_generator ["--event", "tropical-on-rails-2026", "--title", "Keynote: Marco Roth", "--speaker", "Marco Roth"]
+
     assert_file "data/tropicalrb/tropical-on-rails-2026/videos.yml" do |content|
       assert_match(/\S/, content)
     end
+
+    File.delete(File.join(destination_root, "data/tropicalrb/tropical-on-rails-2026/videos.yml"))
   end
 
   def validate_talk_file(path)

--- a/test/lib/generators/venue_generator_test.rb
+++ b/test/lib/generators/venue_generator_test.rb
@@ -6,8 +6,7 @@ require "yaml"
 
 class VenueGeneratorTest < Rails::Generators::TestCase
   tests VenueGenerator
-  destination Rails.root.join("tmp/generators")
-  setup :prepare_destination
+  destination Rails.root.join("tmp/generators/venue")
 
   test "creates venue.yml in correct directory" do
     assert_nothing_raised do
@@ -17,23 +16,35 @@ class VenueGeneratorTest < Rails::Generators::TestCase
     assert_file "data/rubyconf/rubyconf-2001/venue.yml" do |content|
       assert_match(/\S/, content) # Verify file has content
     end
+
+    File.delete File.join(destination_root, "data/rubyconf/rubyconf-2001/venue.yml")
   end
 
   test "venue.yml passes schema validation" do
     run_generator ["--event-series", "rubyconf", "--event", "2002"]
 
-    validate_venue_schema File.join(destination_root, "data/rubyconf/2002/venue.yml")
+    venue_file_path = File.join(destination_root, "data/rubyconf/2002/venue.yml")
+    validate_venue_schema venue_file_path
+
+    File.delete venue_file_path
   end
 
   test "venue with all flags passes schema validation" do
     run_generator ["--event-series", "rubyconf", "--event", "2003", "--hotel", "--nearby", "--locations", "--rooms", "--spaces", "--accessibility"]
-    validate_venue_schema File.join(destination_root, "data/rubyconf/2003/venue.yml")
+
+    venue_file_path = File.join(destination_root, "data/rubyconf/2003/venue.yml")
+    validate_venue_schema venue_file_path
+
+    File.delete venue_file_path
   end
 
   test "venue with all flags off passes schema validation" do
     run_generator ["--event-series", "rubyconf", "--event", "2004", "--no-hotel", "--no-nearby", "--no-locations", "--no-rooms", "--no-spaces", "--no-accessibility"]
 
-    validate_venue_schema File.join(destination_root, "data/rubyconf/2004/venue.yml")
+    venue_file_path = File.join(destination_root, "data/rubyconf/2004/venue.yml")
+    validate_venue_schema venue_file_path
+
+    File.delete venue_file_path
   end
 
   def validate_venue_schema(file_path)


### PR DESCRIPTION
## Description

<!-- Please describe your changes. -->

`setup :prepare_destination` deletes everything in the destination root folder.
This means that test cleanup from prior runs was deleting files before they were done being tested and resulting in flaky tests. Instead, in this PR, each test manually cleans up the generated file.

In addition, I isolated each test's root directory to prevent file collisions across tests, which was not enough to avoid flaky test results.

## Screenshots

<!-- Add screenshots or GIFs if applicable. -->

N/A

## Testing Steps

<!-- List steps to test your changes. -->
<!-- If this is a content PR, link to the affected pages -->

Run `bin/rails test test/lib/generators test/models` 7 times and see no flakies.

## References

<!-- Link to related issues, discussions, other PRs, or references you used to write the PR. -->

- closes #<!-- issue number -->
- https://github.com/rails/rails/blob/13c9effcae3a00e4c2d46e8d069340220cc8bc03/railties/lib/rails/generators/testing/behavior.rb#L100
- https://garrettdimon.com/journal/posts/creating-custom-rails-generators#the-tests
- https://docs.ruby-lang.org/en/4.0/File.html#method-c-delete
