### PR TITLE
remove bios from speakers.yml where github is available

### DIFF
--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -1257,8 +1257,6 @@
   slug: "arjun-sharma"
 - name: "Arjun Singh"
   github: "arjun810"
-    changes. He's been working with Rails since 2006, and previously founded Gradescope, which is a (Rails-based) AI grading platform used by millions of professors and students
-    worldwide, and was acquired by Turnitin in 2018."
   linkedin: "arjun-singh-629216105"
   slug: "arjun-singh"
 - name: "Arkadiusz Turlewicz"
@@ -3037,8 +3035,6 @@
   slug: "daniel-doubrovkine"
 - name: "Daniel Farina"
   github: "fdr"
-    distributed systems at Citus Data, and contributed to Microsoft Azure. Dan’s career centers on making core infrastructure simple, resilient, and accessible to all
-    developers—with a focus on transparency, real-world performance, and strong open source roots. Based in San Francisco."
   slug: "daniel-farina"
   aliases:
     - name: "Dan Farina"
@@ -3609,8 +3605,6 @@
 - name: "Drew Bragg"
   twitter: "DRBragg"
   github: "drbragg"
-    Senior Developer @ Podia,
-    Podcast Host @ podcast.drbragg.dev,
   website: "https://www.drbragg.dev"
   slug: "drew-bragg"
 - name: "Drew Neil"
@@ -4618,7 +4612,6 @@
   slug: "glenn-vanderburg"
 - name: "Glynnis Ritchie"
   github: "glynnis"
-    With a passion for articulating and solving complex problems, some of Glynnis's favorite design challenges involve data-dense or technical settings like healthcare, education, developer tools, and design systems. When she's not designing, you can find her in her pottery studio.
   slug: "glynnis-ritchie"
 - name: "Go Sueyoshi"
   twitter: "sue445"
@@ -4835,8 +4828,6 @@
   slug: "hampton-catlin"
 - name: "Hana Harencarova"
   github: "hharen"
-    increasingly interested in coding. From working in R and data analysis, she shifted her professional orientation to web development and programming. She fell in love with Ruby
-    and shares her passion by teaching at Ruby Monstas Zürich, Rails Girls and co-organizing Helvetic Ruby. Loves making things happen and a good cup of tea 🍵"
   website: "https://hharen.com"
   slug: "hana-harencarova"
 - name: "Hannah Dwan"
@@ -5511,7 +5502,6 @@
 - name: "Jamis Buck"
   twitter: "jamis"
   github: "jamis"
-    Challenge.”"
   website: "http://weblog.jamisbuck.org"
   slug: "jamis-buck"
 - name: "Jamon Holmgren"
@@ -5699,8 +5689,6 @@
   slug: "javier-trevino"
 - name: "Javier Zon"
   github: "jtomaszon"
-    Javier Zon is a platform engineer, DBA, and founder of ScaleDB.io. At ClickFunnels, he leads the platform team that manages mission-critical infrastructure, from Aurora MySQL to Kubernetes, serving hundreds of thousands of customers every day. He’s passionate about helping teams balance scale, cost, and reliability.
-    Beyond tech, Javier is a Black Belt Taekwondo teacher, dad of two, and believer that engineering communities thrive when we mix technical excellence with human connection.
   slug: "javier-zon"
 - name: "Jay Austin Ewing"
   github: ""
@@ -6298,9 +6286,6 @@
 - name: "John Gallagher"
   twitter: "synapticmishap"
   github: "johngallagher"
-    Based in Belfast, I’m a Principal Engineer for Dynatrace with over a decade of experience building production systems in Ruby and Rails. I'm the author of Software Design Simplified, a practical guide to better code through refactoring, TDD, and evolutionary design.
-    Alongside by day job, I work with teams on complex systems, helping them ship safer, reduce time to recovery, and cut infrastructure costs. I’m passionate about maintainable code, developer workflows, and observability in production.
-    Whether pairing on design problems or running workshops, I help engineers level up their understanding of how to write simpler, more resilient Ruby applications.
   website: "https://joyfulprogramming.com"
   slug: "john-gallagher"
 - name: "John Hawthorn"
@@ -6799,8 +6784,6 @@
 - name: "Junichi Kobayashi"
   twitter: "junk0612"
   github: "junk0612"
-    Rails engineer working at ESM, Inc.
-    A committer of LRama parser generator.
   slug: "junichi-kobayashi"
 - name: "Junji Zhi"
   github: ""
@@ -6860,7 +6843,6 @@
 - name: "Justin Searls"
   twitter: "searls"
   github: "searls"
-    Change, and my newsletter, Searls of Wisdom 💜"
   website: "https://justin.searls.co"
   slug: "justin-searls"
 - name: "Justin Weiss"
@@ -7302,8 +7284,6 @@
 - name: "Kevin Murphy"
   twitter: "kevin_j_m"
   github: "kevin-j-m"
-    improvements. I love coaching team members to improve their technical abilities. Learning together with my coworkers is a joy. I have a track record of delivering solutions to
-    big problems with small teams."
   website: "https://kevinjmurphy.com/"
   slug: "kevin-murphy"
 - name: "Kevin Newton"
@@ -7575,10 +7555,6 @@
   slug: "kyle-banker"
 - name: "Kyle d'Oliveira"
   github: "doliveirakn"
-    Pronouns: He/Him
-    This is my Bio
-    I think it is a good one
-    But I may be wrong
   slug: "kyle-d-oliveira"
 - name: "Kyle Dolezal"
   github: "KyleDolezal"
@@ -8235,7 +8211,6 @@
 - name: "Mario Chávez"
   twitter: "mario_chavez"
   github: "mariochavez"
-    Rails.\r \r https://mariochavez.io\r https://foto.mariochavez.io/"
   website: "https://mariochavez.io"
   slug: "mario-chavez"
   aliases:
@@ -8511,8 +8486,6 @@
 - name: "Matheus Richard"
   twitter: "matheusrich"
   github: "matheusrich"
-    Ruby lover, Crystal enthusiastic, Rust newbie.
-    Currently interested in building interpreters.
   website: "https://matheusrich.com"
   slug: "matheus-richard"
 - name: "Mathieu Eustachy"
@@ -9250,18 +9223,6 @@
   slug: "miles-forrest"
 - name: "Miles Georgi"
   github: "azimux"
-    Miles started programming in 1995 and started programming professionally in 2001.
-    He discovered Ruby in 2007 and in 2008 and released a semi-popular gem called externals
-    that helped manage a mixture of Subversion and Git-managed subprojects.
-    At this time he also contributed some small bug fixes to both Rails and Engines before
-    Engines was part of Rails.
-    In 2014, he encountered his first truly complex domain: a p2p mortgage lending platform.
-    In 2021, he coincidentally encountered a second mighty complex domain:
-    a platform for helping folks apply for electric-vehicle rebates/credits who normally
-    don't apply for such programs.
-    In 2022, Miles was the engineering manager on yet another project with a complex domain,
-    a greenfield project, and from the resulting epiphanies he was inspired to create a
-    software framework that he wished he'd had all along, Foobara!
   website: "https://foobara.org/"
   slug: "miles-georgi"
 - name: "Miles McGuire"
@@ -10581,7 +10542,6 @@
 - name: "Rachael Wright-Munn"
   twitter: "chaelcodes"
   github: "chaelcodes"
-    Dreamer, joining the RubyEvents team, and contributing to Rails, forem, GitLab, Ruby For Good, and many other projects."
   website: "https://www.chael.codes"
   slug: "rachael-wright-munn"
 - name: "Rachel Green"
@@ -10953,7 +10913,6 @@
   slug: "robert-roach"
 - name: "Robert Ross"
   github: "bobbytables"
-    An experienced Rubyist, Robert Ross is the co-founder and CEO of FireHydrant.com. Prior to founding FireHydrant in 2018, Ross worked as a software engineer at Namely, DigitalOcean, and Thunderbolt Labs. When he’s not writing code, he’s writing code. He also enjoys amateur photography, downhill skiing and writing code.
   slug: "robert-ross"
 - name: "Robert Young"
   github: "robertyoung2"
@@ -11186,7 +11145,6 @@
   slug: "ryan-florence"
 - name: "Ryan Hageman"
   github: "ryanhageman"
-    Ryan is a Senior Consultant at Excella who specializes in systems modernization. He's spent 10 years working in codebases ranging from startups to enterprise clients. Most of his work involves building new systems to modernize outdated processes or legacy applications. When he's not coding, Ryan enjoys cooking food from around the world.
   slug: "ryan-hageman"
 - name: "Ryan King"
   github: ""
@@ -12280,10 +12238,6 @@
 - name: "Subin Siby"
   twitter: "SubinSiby"
   github: "subins2000"
-    Curious full stack dev. 10+ years of dev experience. One of the tech leads @bigbinary
-    ........
-    ........
-    206 Partial Content : https://gitlab.com/subins2000
   website: "https://subinsb.com/projects"
   slug: "subin-siby"
 - name: "Sumana Harihareswara"
@@ -12601,7 +12555,6 @@
   slug: "thomas-cannon"
 - name: "Thomas Carr"
   github: "htcarr3"
-    Thomas Carr is a Founding Product Engineer at CorePilot, building an AI-powered ERP solutions for the aviation industry. With over 5 years of experience building Rails applications and integrating AI features, he's passionate about the evolving Ruby AI landscape and sharing practical insights with the community.
   slug: "thomas-carr"
 - name: "Thomas Countz"
   twitter: "thomascountz"
@@ -13294,7 +13247,6 @@
 - name: "Vishwajeetsingh Desurkar"
   twitter: "VishwaDesurkar"
   github: "selectus2"
-    I’ve honed my full-stack skills in Ruby on Rails and Reactjs. Beyond coding, I love connecting with the tech community and my heart beats for Linkin Park! 🎶🎸"
   website: "https://blog.vishwajeetsingh.in"
   slug: "vishwajeetsingh-desurkar"
 - name: "Vitaly Pushkar"


### PR DESCRIPTION
Since bios can be dynamically pulled from Github, this reduces the weight of speakers.yml
