### PR TITLE
Revert showing up all button

### DIFF
--- a/app/views/speakers/index.html.erb
+++ b/app/views/speakers/index.html.erb
@@ -11,10 +11,8 @@
         <%= letter.upcase %>
       <% end %>
     <% end %>
-    <% if params[:letter] %>
       <%= link_to speakers_path, class: class_names("flex items-center justify-center w-10 text-gray-500 rounded hover:bg-brand-lighter border", "bg-brand-lighter": params[:letter].blank?) do %>
         all
-      <% end %>
     <% end %>
   </div>
   <div id="speakers" class="hotwire-native:mt-3 grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-x-8 lg:gap-x-12 gap-y-2 min-w-full">


### PR DESCRIPTION
## Description
Hiding `ALL` button when letter param exists was a good idea but we thought that it cannot be not such a good idea :)

## References
- https://github.com/rubyevents/rubyevents/pull/1493
