### PR TITLE
Add upcoming events link in meetups page

### DIFF
--- a/app/views/events/meetups/index.html.erb
+++ b/app/views/events/meetups/index.html.erb
@@ -14,6 +14,9 @@
           List
         </button>
       </div>
+      <div class="flex gap-4 whitespace-nowrap">
+        <%= link_to "Upcoming Events", events_path, class: "link" %>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
## Description
The link was missing in my last PR #1511 

## Screenshots
<img width="1386" height="605" alt="Screenshot 2026-03-11 at 15 36 24" src="https://github.com/user-attachments/assets/268bec53-7c71-490b-b9a3-5e388f0b00b3" />


## Testing Steps
<!-- List steps to test your changes. -->
<!-- If this is a content PR, link to the affected pages -->

## References
https://github.com/rubyevents/rubyevents/pull/1511#issuecomment-4040688070