### PR TITLE
Sort conferences on CFPs at the top

### DIFF
--- a/app/controllers/cfp_controller.rb
+++ b/app/controllers/cfp_controller.rb
@@ -9,6 +9,6 @@ class CFPController < ApplicationController
       cfps = cfps.joins(:event).where(events: {kind: params[:kind]})
     end
 
-    @events = cfps.map(&:event)
+    @events = cfps.map(&:event).group_by(&:kind).values.flatten
   end
 end


### PR DESCRIPTION
## Description
Currently all the CFPs at the moment are ordered based on closing date and they are displayed on the CFP index page. This commit shows conferences at the top on CFP list page ordered by closing date and then meetup after the conference.

## Screenshots
<img width="1283" height="742" alt="Screenshot 2026-03-12 at 20 42 00" src="https://github.com/user-attachments/assets/1f79658e-85c8-4465-81bd-eb2af112a9d2" />


## References
Fixes: #1523
