### PR TITLE
fix: Leave # in Generate Assets rake task

### DIFF
--- a/lib/tasks/event_assets.rake
+++ b/lib/tasks/event_assets.rake
@@ -327,9 +327,9 @@ class EventAssetGenerator
     end
 
     if content.match?(/^featured_color:/)
-      content.gsub!(/^featured_color:.*$/, "featured_color: \"#{text_color.delete("#")}\"")
+      content.gsub!(/^featured_color:.*$/, "featured_color: \"#{text_color}\"")
     else
-      content = content.rstrip + "\nfeatured_color: \"#{text_color.delete("#")}\"\n"
+      content = content.rstrip + "\nfeatured_color: \"#{text_color}\"\n"
     end
     updated = true
 


### PR DESCRIPTION
Fixes #1539

The `EventAssetGenerator` class in `lib/tasks/event_assets.rake` was stripping the `#` prefix from hex color values when writing `featured_color` to event YAML files. The root cause was an explicit `.delete("#")` call on `text_color` in both the update and append branches of the color-writing logic. Removes the `.delete("#")` calls so `text_color` is written as-is, preserving the `#` prefix that other parts of the system expect. Verified by reviewing the before/after output of the `featured_color` field in generated event YAML files.