### PR TITLE
Fix bug in meetups date today method

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -232,11 +232,9 @@ class Event < ApplicationRecord
   end
 
   def today?
-    if meetup?
-      (date.beginning_of_day..date.end_of_day)
-    else
-      (start_date..end_date)
-    end.cover?(Date.today)
+    return talks.where(date: Date.today).exists? if meetup?
+
+    (start_date..end_date).cover?(Date.today)
   rescue => _e
     false
   end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -246,24 +246,26 @@ class EventTest < ActiveSupport::TestCase
 
   test "today? conference is not today" do
     event = Event.new(start_date: 3.days.ago, end_date: 2.days.ago, kind: :conference)
-
     assert !event.today?
   end
 
   test "today? conference is today" do
     event = Event.new(start_date: 1.day.ago, end_date: 2.days.from_now, kind: :conference)
-
     assert event.today?
   end
 
   test "today? meetup is not today" do
-    event = Event.new(date: 2.days.ago, kind: :meetup)
+    event = events(:wnb_rb_meetup)
+    talk = talks(:non_english_talk_one)
+    talk.update!(date: 3.days.ago, event: event)
 
     assert !event.today?
   end
 
   test "today? meetup is today" do
-    event = Event.new(date: Date.today, kind: :meetup)
+    event = events(:wnb_rb_meetup)
+    talk = talks(:non_english_talk_one)
+    talk.update!(date: Date.today, event: event)
 
     assert event.today?
   end


### PR DESCRIPTION
## Description
The method `Event#today?` is handling wrong the meetup date. Because meetups uses `date` field instead of `start_date` and `end_date`.

## Screenshots

<img width="1376" height="635" alt="Screenshot 2026-03-17 at 23 59 30" src="https://github.com/user-attachments/assets/d373f5c9-14a3-4f91-8a3f-379cd00d8a33" />

## Testing Steps
* Access http://localhost:3000/events/meetups
* Change's date of some meetup in rails console to the future
* Browsing the meetup and check the text

## References
https://github.com/rubyevents/rubyevents/pull/1526#issuecomment-4068409896
