### PR TITLE
Add sanitize_url helper to properly fix xss in back_path

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -43,4 +43,12 @@ module ApplicationHelper
   def canonical_url
     content_for?(:canonical_url) ? content_for(:canonical_url) : "https://www.rubyevents.org#{request.path}"
   end
+
+  def sanitize_url(url, fallback: "")
+    if Rails::HTML::Sanitizer.allowed_uri?(url)
+      url
+    else
+      fallback
+    end
+  end
 end

--- a/app/views/talks/show.html.erb
+++ b/app/views/talks/show.html.erb
@@ -7,7 +7,7 @@
   <div class="w-full flex">
     <div class="flex-grow min-w-0 overflow-hidden">
       <div class="flex items-center justify-between w-full hotwire-native:hidden">
-        <%= link_to sanitize(back_path) do %>
+        <%= link_to sanitize_url(back_path, fallback: talks_path) do %>
           <div class="flex items-center gap-2 title text-base text-primary mb-4">
             <%= fa("arrow-left-long", class: "transition-arrow fill-primary", size: :xs) %>
             <div><%= back_to_title %></div>

--- a/app/views/topics/show.html.erb
+++ b/app/views/topics/show.html.erb
@@ -1,7 +1,7 @@
 <div class="container flex flex-col w-full gap-4 my-8">
   <% back_path = params[:back_to].presence || topics_path %>
   <% back_to_title = params[:back_to_title].presence || "Topics" %>
-  <%= link_to sanitize(back_path), class: "hotwire-native:hidden" do %>
+  <%= link_to sanitize_url(back_path, fallback: topics_path), class: "hotwire-native:hidden" do %>
     <div class="flex items-center gap-2 title text-primary">
       <%= fa("arrow-left-long", class: "transition-arrow fill-primary", size: :xs) %>
       <div><%= back_to_title %></div>


### PR DESCRIPTION
## Description
<!-- Please describe your changes. -->
The previous fix was not correct because `sanitize` only removes unsafe protocols from the `href` attribute of an `a` not from a string (returned by the URL helper).

I added a `sanitize_url` helper that can be called with a string and it returns a fallback in case the string has an unsafe protocol. 

This might get upstream to Rails so in the future the helper could potentially be removed.

Co-author: @gregmolnar 

## Screenshots
<!-- Add screenshots or GIFs if applicable. -->

## Testing Steps
<!-- List steps to test your changes. -->
<!-- If this is a content PR, link to the affected pages -->

https://www.rubyevents.org/talks/the-state-of-security-in-rails-8?back_to=javascript:alert(1)&back_to_title=Greg+Molnar

Clicking the button will not trigger an alert window anymore.

## References
<!-- Link to related issues, discussions, other PRs, or references you used to write the PR. -->
- related: https://github.com/rubyevents/rubyevents/pull/954