### PR TITLE
fix: correct talk dates for RubyConf 2022 Mini

### DIFF
--- a/data/rubyconf/rubyconf-2022-mini/videos.yml
+++ b/data/rubyconf/rubyconf-2022-mini/videos.yml
@@ -10,7 +10,7 @@
   speakers:
     - Vladimir Dementyev
   event_name: "RubyConf 2022 Mini"
-  date: "2022-11-15"
+  date: "2022-11-16"
   published_at: "2023-03-01"
   description: |-
     To mock or not mock is an important question, but let's leave it apart and admit that we, Rubyists, use mocks in our tests.
@@ -27,7 +27,7 @@
   speakers:
     - Ernesto Tagwerker
   event_name: "RubyConf 2022 Mini"
-  date: "2022-11-15"
+  date: "2022-11-16"
   published_at: "2023-03-01"
   slides_url: "https://speakerdeck.com/etagwerker/here-be-dragons-the-hidden-gems-of-technical-debt"
   description: |-
@@ -43,7 +43,7 @@
   speakers:
     - Maple Ong
   event_name: "RubyConf 2022 Mini"
-  date: "2022-11-15"
+  date: "2022-11-17"
   published_at: "2023-03-01"
   description: |-
     Did you know Ruby optimizes your code before executing it? If so, ever wonder how that works? The Ruby VM performs various optimizations on bytecode before executing them, one of them called peephole optimizations. Let’s learn about how some peephole optimizations work and how these small changes impact the execution of Ruby’s bytecode. Do these small changes make any impact on the final runtime? Let's find out - experience reading bytecode is not needed!
@@ -56,7 +56,7 @@
   speakers:
     - Hilary Stohs-Krause
   event_name: "RubyConf 2022 Mini"
-  date: "2022-11-16"
+  date: "2022-11-15"
   published_at: "2023-03-01"
   description: |-
     Depending on where you live, money can be a prickly topic in the workplace; however, survey after survey shows it’s also a conversation many employees actively want started. Data also shows that transparency around wages increases trust and job satisfaction and improves gender and racial salary equity.
@@ -72,7 +72,7 @@
     - Chelsea Kaufman
     - Adam Cuppy
   event_name: "RubyConf 2022 Mini"
-  date: "2022-11-15"
+  date: "2022-11-17"
   published_at: "2023-03-01"
   description: |-
     Starting an internship doesn’t have to reduce your team's progress. On the contrary, a quality internship can benefit interns and senior folks. And, it doesn't take much to set up and start. We've done over 100!
@@ -100,7 +100,7 @@
   speakers:
     - Jenny Shih
   event_name: "RubyConf 2022 Mini"
-  date: "2022-11-16"
+  date: "2022-11-17"
   published_at: "2023-03-01"
   description: |-
     Functional programming brings you not just fun, but also profit!
@@ -117,7 +117,7 @@
   speakers:
     - Joël Quenneville
   event_name: "RubyConf 2022 Mini"
-  date: "2022-11-16"
+  date: "2022-11-17"
   published_at: "2023-03-01"
   slides_url: "https://speakerdeck.com/joelq/teaching-ruby-to-count"
   description: |-
@@ -134,7 +134,7 @@
     - Alan Ridlehoover
     - Fito von Zastrow
   event_name: "RubyConf 2022 Mini"
-  date: "2022-11-16"
+  date: "2022-11-17"
   published_at: "2023-03-01"
   description: |-
     Mechanical coffee machines are amazing! You drop in a coin, listen for the clink, make a selection, and the machine springs to life, hissing, clicking, and whirring. Then the complex mechanical ballet ends, splashing that glorious, aromatic liquid into the cup. Ah! C’est magnifique!
@@ -149,7 +149,7 @@
   speakers:
     - Brittany Martin
   event_name: "RubyConf 2022 Mini"
-  date: "2022-11-16"
+  date: "2022-11-17"
   published_at: "2023-03-01"
   description: |-
     A DM. The dreaded message. “They want someone technical on the call.”
@@ -164,7 +164,7 @@
   speakers:
     - John Hawthorn
   event_name: "RubyConf 2022 Mini"
-  date: "2022-11-17"
+  date: "2022-11-15"
   published_at: "2023-03-01"
   description: |-
     Until Ruby 3.2 the `is_a?` method can be a surprising performance bottleneck. It be called directly or through its various synonyms like case statements, rescue statements, protected methods, `Module#===` and more! Recently `is_a?` and its various flavours have been optimized and it's now faster and runs in constant time. Join me in the journey of identifying it as a bottleneck in production, implementing the optimization, squashing bugs, and finally turning it into assembly language in YJIT.
@@ -177,7 +177,7 @@
   speakers:
     - Cameron Gose
   event_name: "RubyConf 2022 Mini"
-  date: "2022-11-15"
+  date: "2022-11-16"
   published_at: "2023-03-01"
   description: |-
     We'll be building a game in Ruby from start to finish using the DragonRuby GameToolkit. Finally we'll publish it so that your new creation can be shared.
@@ -232,7 +232,7 @@
   speakers:
     - Christopher "Aji" Slater
   event_name: "RubyConf 2022 Mini"
-  date: "2022-11-15"
+  date: "2022-11-16"
   published_at: "2023-03-01"
   description: |-
     Automation doesn’t have to be all or nothing. Automating manual processes is a practice that one can employ via simple principles. Broad enough to be applied to a range of workflows, flexible enough to be tailored to an individual’s personal development routines; these principles are not in themselves complex, and can be performed regularly in the day to day of working in a codebase.
@@ -246,7 +246,7 @@
   speakers:
     - Kevin Newton
   event_name: "RubyConf 2022 Mini"
-  date: "2022-11-15"
+  date: "2022-11-16"
   published_at: "2023-03-01"
   description: |-
     Syntax Tree is a new toolkit for interacting with the Ruby parse tree. It can be used to analyze, inspect, debug, and format your Ruby code. In this talk we'll walk through how it works, how to use it in your own applications, and the exciting future possibilities enabled by Syntax Tree.
@@ -323,7 +323,7 @@
   speakers:
     - Barbara Tannenbaum
   event_name: "RubyConf 2022 Mini"
-  date: "2022-11-17"
+  date: "2022-11-15"
   published_at: "2023-03-01"
   description: ""
   video_provider: "youtube"
@@ -349,7 +349,7 @@
   speakers:
     - Stephanie Minn
   event_name: "RubyConf 2022 Mini"
-  date: "2022-11-16"
+  date: "2022-11-15"
   published_at: "2023-03-01"
   description: |-
     Pair programming is intimate. It’s the closest collaboration we do as software developers. When it goes well, it feels great! But when it doesn’t, you might be left feeling frustrated, discouraged, or withdrawn.
@@ -368,7 +368,7 @@
     - Ufuk Kayserilioglu
     - Someone at Shopify
   event_name: "RubyConf 2022 Mini"
-  date: "2022-11-16"
+  date: "2022-11-17"
   published_at: "2023-03-01"
   description: ""
   video_provider: "youtube"
@@ -396,7 +396,7 @@
   speakers:
     - Drew Bragg
   event_name: "RubyConf 2022 Mini"
-  date: "2022-11-16"
+  date: "2022-11-17"
   published_at: "2023-03-01"
   description: |-
     Welcome to the Ruby game show where one lucky contestant tries to guess the output of a small bit of Ruby code. Sound easy? Here's the challenge: the snippets come from some of the weirdest parts of the Ruby language.  The questions aren't easy. Get enough right to be crowned a (some sort of something) Ruby Engineer and win a fabulous, mysterious prize.
@@ -422,7 +422,7 @@
   speakers:
     - Kirk Haines
   event_name: "RubyConf 2022 Mini"
-  date: "2022-11-16"
+  date: "2022-11-15"
   published_at: "2023-03-01"
   description: |-
     Crystal is a Ruby-like compiled language that was originally built using Ruby. Its syntax is remarkably similar to Ruby's, which generally makes it straightforward for a Ruby programmer to start using Crystal. There are some notable, and interesting differences between the languages, however. In this workshop, let's learn some Crystal while we learn a little about the similarities and the differences between the two languages.
@@ -452,7 +452,7 @@
   speakers:
     - Nadia Odunayo
   event_name: "RubyConf 2022 Mini"
-  date: "2022-11-15"
+  date: "2022-11-16"
   published_at: "2023-03-01"
   description: |-
     After a stressful couple of days at work, Deirdre Bug is looking forward to a quiet evening in. But her plans are thwarted when the phone rings. “I know I’m the last person you want to hear from…but...I need your help!” Follow Deirdre as she embarks on an adventure that features a looming Demo Day with serious prize money up for grabs, a trip inside the walls of one of the Ruby community’s most revered institutions, and some broken code that appears to be much more simple than meets the eye.
@@ -465,7 +465,7 @@
   speakers:
     - Jess Hottenstein
   event_name: "RubyConf 2022 Mini"
-  date: "2022-11-16"
+  date: "2022-11-17"
   published_at: "2023-03-01"
   description: |-
     How can we write classes that are easy to understand? How can we write Ruby in a declarative way? How can we use metaprogramming without introducing chaos?
@@ -492,7 +492,7 @@
   speakers:
     - Kevin Menard
   event_name: "RubyConf 2022 Mini"
-  date: "2022-11-15"
+  date: "2022-11-16"
   published_at: "2023-03-01"
   description: |-
     You’ve probably heard of UTF-8 and know about strings, but did you know that Ruby supports more than 100 other encodings? In fact, your application probably uses three encodings without you realizing it. Moreover, encodings apply to more than just strings. In this talk, we’ll take a look at Ruby’s fairly unique approach to encodings and better understand the impact they have on the correctness and performance of our applications. We’ll take a look at the rich encoding APIs Ruby provides and by the end of the talk, you won’t just reach for force_encoding when you see an encoding exception.


### PR DESCRIPTION
## Summary

Fixes incorrect dates on 21 talks for RubyConf 2022 Mini. Talks were assigned to wrong days of the 3-day conference.

## Why this matters

The event page at rubyevents.org/events/rubyconf-2022-mini shows talks on wrong dates. Cross-referenced every talk against the [archived schedule](https://web.archive.org/web/20221128043326/http://www.rubyconfmini.com/schedule) to get the correct day assignments.

## Changes

`data/rubyconf/rubyconf-2022-mini/videos.yml` - corrected `date` field on 21 talks:

- 8 talks on Day 1 (Nov 15): keynote, lightning talks, etc.
- 10 talks on Day 2 (Nov 16): Weaving mocks, Here Be Dragons, Syntax Tree, etc.
- 13 talks on Day 3 (Nov 17): functional programming, TDD, Looking Into Peephole Optimizations, etc.

## Testing

Verified date distribution matches the 3-day schedule structure from the archive.

Fixes #1274

This contribution was developed with AI assistance (Claude Code).