### PR TITLE
Hide empty participant group

### DIFF
--- a/app/views/events/participants/_list.html.erb
+++ b/app/views/events/participants/_list.html.erb
@@ -20,14 +20,16 @@
     <% end %>
 
     <% participants.each do |key, participants| %>
-      <h2 class="mb-6"><%= "#{key} (#{participants.size})" %></h2>
-      <div id="<%= dom_id(event, key) %>" class="mb-12 min-w-full grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 h-full">
-        <% participants.each do |participant| %>
-          <div class="border rounded-lg bg-white hover:bg-gray-200 transition-bg duration-300 ease-in-out">
-            <%= render partial: "users/card", locals: {user: participant, favorite_user: favorite_users[participant.id]} %>
-          </div>
-        <% end %>
-      </div>
+      <% unless participants.size.zero? %>
+        <h2 class="mb-6"><%= "#{key} (#{participants.size})" %></h2>
+        <div id="<%= dom_id(event, key) %>" class="mb-12 min-w-full grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 h-full">
+          <% participants.each do |participant| %>
+            <div class="border rounded-lg bg-white hover:bg-gray-200 transition-bg duration-300 ease-in-out">
+              <%= render partial: "users/card", locals: {user: participant, favorite_user: favorite_users[participant.id]} %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
     <% end %>
   <% end %>
 


### PR DESCRIPTION
## Description
Hide empty participant group in events page.

## Screenshots
<img width="1380" height="639" alt="Screenshot 2026-03-26 at 08 55 43" src="https://github.com/user-attachments/assets/40825297-c4c8-4a39-b6f9-3d96bafcf3aa" />


## Testing Steps
* Access an event without favorites and friends.

## References
- closes #1569 
