### PR TITLE
fix: keep selected talk labels active after hover

### DIFF
--- a/app/views/talks/_talk_filter.html.erb
+++ b/app/views/talks/_talk_filter.html.erb
@@ -1,5 +1,5 @@
 <% classes = "bg-white hover:bg-gray-100 cursor-pointer px-4 py-2 text-sm text-gray-500 rounded-full border font-bold select-none" %>
-<% active_classes = "bg-red-500 hover:bg-red-600 text-white border-red-500" %>
+<% active_classes = "!bg-red-500 hover:!bg-red-600 !text-white !border-red-500" %>
 
 <% talks_by_language = talks.group_by(&:language) %>
 <% talks_by_kind = talks.group_by(&:kind) %>


### PR DESCRIPTION
Closes #1577

## Summary
- make selected talk filter pills keep their active red/white styles after hover ends on desktop
- do this by giving the selected-state Tailwind classes precedence over the default pill classes

## Testing
- `bin/rails test test/controllers/events_controller_test.rb`
- manual QA on `/events/rbqconf-2026/talks`: after clicking a talk-kind pill, moving the pointer away kept the pill selected with a red background and white text