### PR TITLE
Add missing schemas for YAML files

### DIFF
--- a/app/schemas/featured_city_schema.rb
+++ b/app/schemas/featured_city_schema.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class FeaturedCitySchema < RubyLLM::Schema
+  string :name, description: "Full city name"
+  string :slug, description: "URL-friendly slug for the city"
+  string :state_code, description: "State or province code", required: false
+  string :country_code, description: "ISO 3166-1 alpha-2 country code"
+  number :latitude, description: "Geographic latitude"
+  number :longitude, description: "Geographic longitude"
+  array :aliases, of: :string, description: "Alternative names or abbreviations", required: false
+
+  def to_json_schema
+    result = super
+    result[:schema][:properties][:state_code][:type] = ["string", "null"]
+    result
+  end
+end

--- a/app/schemas/involvement_schema.rb
+++ b/app/schemas/involvement_schema.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class InvolvementSchema < RubyLLM::Schema
+  string :name, description: "Role or involvement type (e.g., 'Organizer', 'Program Committee member')"
+  array :users, of: :string, description: "Person names involved in this role", required: false
+  array :organisations, of: :string, description: "Organization names involved in this role", required: false
+end

--- a/app/schemas/transcript_schema.rb
+++ b/app/schemas/transcript_schema.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class TranscriptSchema < RubyLLM::Schema
+  string :video_id, description: "Video ID on the provider platform"
+  array :cues, description: "Transcript cues" do
+    object do
+      string :start_time, description: "Start timestamp (HH:MM:SS.mmm)"
+      string :end_time, description: "End timestamp (HH:MM:SS.mmm)"
+      string :text, description: "Transcript text for this cue"
+    end
+  end
+end

--- a/lib/tasks/validate.rake
+++ b/lib/tasks/validate.rake
@@ -161,6 +161,24 @@ namespace :validate do
     exit 1 unless success
   end
 
+  desc "Validate featured_cities.yml against FeaturedCitySchema"
+  task featured_cities: :environment do
+    success = validate_array_files("data/featured_cities.yml", FeaturedCitySchema, "featured_cities.yml")
+    exit 1 unless success
+  end
+
+  desc "Validate all involvements.yml files against InvolvementSchema"
+  task involvements: :environment do
+    success = validate_array_files("data/**/involvements.yml", InvolvementSchema, "involvements.yml")
+    exit 1 unless success
+  end
+
+  desc "Validate all transcripts.yml files against TranscriptSchema"
+  task transcripts: :environment do
+    success = validate_array_files("data/**/transcripts.yml", TranscriptSchema, "transcripts.yml")
+    exit 1 unless success
+  end
+
   def validate_unique_speaker_fields
     speakers = YAML.load_file(Rails.root.join("data/speakers.yml"))
     success = true
@@ -518,6 +536,15 @@ namespace :validate do
 
     puts Gum.style("Validating schedule.yml files", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
     results << validate_files("data/**/schedule.yml", ScheduleSchema, "schedule.yml")
+
+    puts Gum.style("Validating featured_cities.yml", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
+    results << validate_array_files("data/featured_cities.yml", FeaturedCitySchema, "featured_cities.yml")
+
+    puts Gum.style("Validating involvements.yml files", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
+    results << validate_array_files("data/**/involvements.yml", InvolvementSchema, "involvements.yml")
+
+    puts Gum.style("Validating transcripts.yml files", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
+    results << validate_array_files("data/**/transcripts.yml", TranscriptSchema, "transcripts.yml")
 
     puts Gum.style("Validating unique speaker slugs and GitHub handles", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
     results << validate_unique_speaker_fields


### PR DESCRIPTION
This pull request introduces new data validation schemas and integrates them into the `rails validation:all` rake task:



* `FeaturedCitySchema` 
* `InvolvementSchema` 
* `TranscriptSchema`

