### PR TITLE
Improve generator template

### DIFF
--- a/lib/generators/talk/templates/talk.yml.tt
+++ b/lib/generators/talk/templates/talk.yml.tt
@@ -2,7 +2,7 @@
 - id: "<%= @talk.id %>"
   title: "<%= @talk.title %>"<%= options[:title] ? "" : " # TODO" %>
   description: |-
-    <%= @talk.description %>
+<%= optimize_indentation(@talk.description, 4) %>
   kind: "<%= @talk.kind %>"
   language: "<%= @talk.language %>"
   date: "<%= @talk.date %>"

--- a/lib/generators/talk/templates/videos.yml.tt
+++ b/lib/generators/talk/templates/videos.yml.tt
@@ -1,4 +1,5 @@
-# docs/ADDING_UNPUBLISHED_TALKS.md
-# docs/ADDING_VIDEOS.md
+# TODO: Add all talks - docs/ADDING_UNPUBLISHED_TALKS.md
+# TODO: Reorder talks for schedule - docs/ADDING_SCHEDULES.md
+# TODO: Add recordings - docs/ADDING_VIDEOS.md
 ---
 


### PR DESCRIPTION
## Description
<!-- Please describe your changes. -->

Properly handle indentation on multi-line descriptions on the first generation.

Add new top-level documentation that steps you through the lifecycle of adding to the videos file.

```yaml
# TODO: Add all talks - docs/ADDING_UNPUBLISHED_TALKS.md
# TODO: Reorder talks for schedule - docs/ADDING_SCHEDULES.md
# TODO: Add recordings - docs/ADDING_VIDEOS.md
```
The first line is added with the file (probably when keynotes are released) and stays until all talks are added.
The second line stays until the schedule is released and the order is updated.
The third line stays until the recordings are released and added.

## Screenshots
<!-- Add screenshots or GIFs if applicable. -->

## Testing Steps
<!-- List steps to test your changes. -->
<!-- If this is a content PR, link to the affected pages -->

```bash
bin/rails g talk --balkanruby-2026 --description "This description is rather long.

It spans multiple paragraphs"
```

## References
<!-- Link to related issues, discussions, other PRs, or references you used to write the PR. -->
- closes #<!-- issue number -->
