### PR TITLE
Meetups without talks/videos are displayed

### DIFF
--- a/app/controllers/events/meetups_controller.rb
+++ b/app/controllers/events/meetups_controller.rb
@@ -4,7 +4,7 @@ class Events::MeetupsController < ApplicationController
   # GET /events/meetups
   def index
     @meetups = Event.where(kind: :meetup)
-      .joins(:talks)
+      .left_joins(:talks)
       .distinct
       .includes(:series)
       .group("events.id")


### PR DESCRIPTION
## Description
<!-- Please describe your changes. -->

This pull request updates the way meetups are queried in the `Events::MeetupsController` to ensure all meetups are included, even those without associated talks.

Query update for meetups:

* Changed the query in the `index` action to use `left_joins(:talks)` instead of `joins(:talks)`, so meetups without talks will also be returned in the results.

## Screenshots
<!-- Add screenshots or GIFs if applicable. -->

## Testing Steps
<!-- List steps to test your changes. -->
<!-- If this is a content PR, link to the affected pages -->
* /events/meetups displays events without talks like Austin.rb

## References
<!-- Link to related issues, discussions, other PRs, or references you used to write the PR. -->
- closes #<!-- issue number -->
