### PR TITLE
Sort past events in profiles by most recent

### DIFF
--- a/app/views/profiles/_events.html.erb
+++ b/app/views/profiles/_events.html.erb
@@ -1,7 +1,7 @@
 <%# Event Participations v1 %>
 
 <% future_events = events.upcoming.sort_by(&:sort_date).reverse %>
-<% past_events = (events.to_a - future_events.sort_by(&:sort_date).reverse).sort_by(&:sort_date).reverse %>
+<% past_events = (events.to_a - future_events).sort_by(&:sort_date).reverse %>
 
 <% cache [user, events, Current.user] do %>
   <div>


### PR DESCRIPTION
## Description
Sort past events in profiles by most recent

## Screenshots
<img width="1415" height="669" alt="Screenshot 2026-03-29 at 19 43 45" src="https://github.com/user-attachments/assets/0cfef26c-3b0e-43c7-b573-6980f7e9fabd" />


## Testing Steps
* Access http://localhost:3000/profiles/tenderlove/events

## References

- closes #1589 
