### PR TITLE
Grepfruit will display sponsor TODOs

### DIFF
--- a/data/blue-ridge-ruby/blue-ridge-ruby-2026/sponsors.yml
+++ b/data/blue-ridge-ruby/blue-ridge-ruby-2026/sponsors.yml
@@ -1,4 +1,6 @@
 # docs/ADDING_SPONSORS.md
+# Do not remove todo until event is over and all sponsors are added.
+# TODO: Add missing sponsors.
 ---
 - tiers:
     - name: "Ruby"

--- a/lib/generators/sponsors/templates/sponsors.yml.tt
+++ b/lib/generators/sponsors/templates/sponsors.yml.tt
@@ -1,4 +1,6 @@
 # docs/ADDING_SPONSORS.md
+# Do not remove todo until event is over and all sponsors are added.
+# TODO: Add missing sponsors.
 ---
 - tiers:
 <%- level = 0 -%>


### PR DESCRIPTION
## Description
<!-- Please describe your changes. -->

We're currently updating events with sponsors that are yet to happen, which means sponsors may be added in the future. Unfortunately, events with sponsors files don't display under Contributing for Missing Sponsors.

Grepfruit looks for todos and displays them at the event and event series level. This allows us to surface files that may still be missing sponsors, even if the sponsor file is already generated.

## Screenshots
<!-- Add screenshots or GIFs if applicable. -->
<img width="1279" height="196" alt="Screenshot 2026-04-01 at 12 46 32 PM" src="https://github.com/user-attachments/assets/cbece3f6-45c3-4ea2-ae61-452f9827ae77" />


## Testing Steps
<!-- List steps to test your changes. -->
<!-- If this is a content PR, link to the affected pages -->

1. Generate a new sponsors file using `bin/rails g sponsors`
2. Observe that there is now a TODO that must be manually reviewed.

## References
<!-- Link to related issues, discussions, other PRs, or references you used to write the PR. -->
- closes #<!-- issue number -->
