### PR TITLE
Allow passing args for paths to enforce strings on when linting yaml

### DIFF
--- a/yaml/enforce_strings.mjs
+++ b/yaml/enforce_strings.mjs
@@ -1,10 +1,37 @@
 import fs from 'fs'
 import { Formatter } from './formatter.mjs'
 
-const files = fs.readdirSync('./data', { recursive: true }).filter(file => file.endsWith('.yml'))
+const files = []
+const paths = []
+if (process.argv.length > 2) {
+  process.argv.slice(2).forEach((path) => {
+    paths.push(path)
+  })
+} else {
+  paths.push('./data')
+}
 
-files.forEach(file => {
+paths.forEach((path) => {
+  if (path.endsWith('/')) {
+    path = path.slice(0, -1)
+  }
+  if (fs.existsSync(path)) {
+    if (fs.lstatSync(path).isDirectory()) {
+      fs.readdirSync(path, { recursive: true })
+        .filter((file) => file.endsWith('.yml'))
+        .forEach((file) => files.push(`${path}/${file}`))
+    } else if (path.endsWith('.yml')) {
+      files.push(path)
+    } else {
+      console.log(`Ignoring ${path} as it's not yaml`)
+    }
+  } else {
+    console.log(`Ignoring ${path} as it doesn't exist`)
+  }
+})
+
+files.forEach((file) => {
   console.log(`Enforcing Strings: ${file}`)
-  const formatter = new Formatter(`./data/${file}`)
+  const formatter = new Formatter(file)
   formatter.format()
 })


### PR DESCRIPTION
## Description

The `yaml/enforce_strings.mjs` script lints everything in `./data` by default, however, this is slow if we've only updated one event, or even just one yaml file for that event. This commit updates the script to treat all the arguments in `process.argv.slice(2)` (e.g. not `node` and `yaml/enforce_strings.mjs`) as paths to format.

## References

Brought up while asking about yaml listing for lrug.org data in https://github.com/rubyevents/rubyevents/pull/889#discussion_r3041833061

This discussion suggested making `bin/lint` or `yarn format:yml` take args, but looking at the contents, I don't think it makes sense: `bin/lint` lints _everything_ not just yaml files, and `format:yml` also runs prettier so it's not obvious where the args should go.  Giving the underlying `yaml/enforce_strings.mjs` script the ability to take args gives us what we need for individual usage.
