### PR TITLE
Replace git clone and bundle with curl in lrug script

### DIFF
--- a/bin/update_lrug_meetups
+++ b/bin/update_lrug_meetups
@@ -7,6 +7,7 @@ if command -v mise &> /dev/null; then
 fi
 
 curl https://lrug.org/rubyevents-video-playlist.yml > data/lrug/lrug-meetup/videos.yml
-yarn format:yml
+node yaml/enforce_strings.mjs data/lrug/lrug-meetup/videos.yml
+prettier -c data/lrug/lrug-meetup/videos.yml -w
 git add data/lrug/lrug-meetup/videos.yml
 git commit -m "Update LRUG Meetups"

--- a/bin/update_lrug_meetups
+++ b/bin/update_lrug_meetups
@@ -2,22 +2,11 @@
 
 set -e  # Exit on error
 
-if [ -d "lrug.org" ]; then
-  cd lrug.org
-  git pull
-else
-  git clone https://github.com/lrug/lrug.org
-  cd lrug.org
-fi
-
 if command -v mise &> /dev/null; then
   eval "$(mise activate bash)"
 fi
 
-bundle install
-bundle exec middleman build
-cp public/rubyevents-video-playlist.yml ../data/lrug/lrug-meetup/videos.yml
-cd ..
+curl https://lrug.org/rubyevents-video-playlist.yml > data/lrug/lrug-meetup/videos.yml
 yarn format:yml
 git add data/lrug/lrug-meetup/videos.yml
 git commit -m "Update LRUG Meetups"


### PR DESCRIPTION
## Description

The `bin/update_lrug_meetups` script clones the `lrug/lrug.org` repo, does a `bundle install`, and builds the whole site to get their version of the `rubyevents-video-playlist.yml` to drop into
`data/lrug/lrug-meetup/videos.yml`. However, this file is available on https://lrug.org so we can drastically speed this process up if we just pull it down from there instead.

I was reminded of this script in https://github.com/rubyevents/rubyevents/pull/889#discussion_r3047316678 but realised I wouldn't use it as-is because I already have [`lrug/lrug.org`](https://github.com/lrug/lrug.org) checked out.  By switching it to `curl` instead of `git clone && bundle install && bundle exec middleman build` I'm much more likely to use it, and if we do just make this run periodically on CI or whatever, this'll make it faster.

Appreciate, I may be overreaching here as this script isn't really _for me_, so no worries if this doesn't make the cut.