### PR TITLE
Include ... | RubyEvents.org in <title> and set missing titles

### DIFF
--- a/app/views/announcements/index.html.erb
+++ b/app/views/announcements/index.html.erb
@@ -8,7 +8,7 @@
 
 <div class="container py-8">
   <div class="flex items-center justify-between mb-8">
-    <h1 class="title text-primary">Announcements</h1>
+    <h1 class="title text-primary"><%= title "Announcements" %></h1>
     <%= link_to feed_announcements_path(format: :rss, tag: @current_tag.presence), class: "btn btn-ghost btn-sm gap-2", title: "RSS Feed", target: "_blank" do %>
       <%= fa("rss", size: :sm) %>
     <% end %>

--- a/app/views/browse/index.html.erb
+++ b/app/views/browse/index.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_refreshes_with method: :morph, scroll: :preserve %>
 
 <div class="container flex flex-col gap-8 my-8 hotwire-native:my-0 hotwire-native:mb-8">
-  <h1 class="title text-primary hotwire-native:hidden">Browse</h1>
+  <h1 class="title text-primary hotwire-native:hidden"><%= title "Browse" %></h1>
 
   <% if @featured_events.any? %>
     <%= render "browse/featured_events", events: @featured_events %>

--- a/app/views/contributions/index.html.erb
+++ b/app/views/contributions/index.html.erb
@@ -1,3 +1,4 @@
+<% title "Contribute" %>
 
 <div class="container py-8">
   <h1 class="title">

--- a/app/views/gems/index.html.erb
+++ b/app/views/gems/index.html.erb
@@ -2,7 +2,7 @@
   <div class="flex items-center gap-2 title text-primary">
     <h1 class="flex items-center gap-2">
       <%= fa("gem", size: :md, class: "fill-primary") %>
-      Ruby Gems
+      <%= title "Ruby Gems" %>
     </h1>
   </div>
 

--- a/app/views/gems/show.html.erb
+++ b/app/views/gems/show.html.erb
@@ -10,7 +10,7 @@
     <div class="flex flex-wrap items-center gap-3 title text-primary">
       <h1 class="flex items-center gap-2">
         <%= fa("gem", size: :md, class: "fill-primary") %>
-        <code class="font-mono"><%= @gem.gem_name %></code>
+        <code class="font-mono"><%= title @gem.gem_name %></code>
       </h1>
 
       <% if @gem.version.present? %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= display_meta_tags site: "" %>
+    <%= display_meta_tags site: "RubyEvents.org", reverse: true %>
 
     <%= vite_client_tag %>
     <%= combobox_style_tag %>

--- a/app/views/leaderboard/index.html.erb
+++ b/app/views/leaderboard/index.html.erb
@@ -1,5 +1,5 @@
 <div class="container mx-auto px-4 py-8">
-  <h1 class="text-3xl font-bold mb-6">Speaker Leaderboard</h1>
+  <h1 class="text-3xl font-bold mb-6"><%= title "Speaker Leaderboard" %></h1>
 
   <div class="mb-6">
     <%= link_to "All Time", leaderboard_path(filter: "all_time"), class: "btn btn-sm #{(@filter == "all_time") ? "btn-primary" : "btn-outline"} mr-2" %>

--- a/app/views/page/home.html.erb
+++ b/app/views/page/home.html.erb
@@ -1,4 +1,5 @@
 <% title hotwire_native_app? ? "RubyEvents" : "RubyEvents.org - On a mission to index all Ruby events" %>
+<% set_meta_tags site: nil # remove the "... | RubyEvents.org" from the title as that's already included above %>
 <% content_for :body_class, "home-page" %>
 
 <% if @featured_events.any? %>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -1,6 +1,6 @@
 <div class="container py-8">
   <div class="max-w-2xl mx-auto">
-    <h1 class="text-3xl font-bold mb-8">Settings</h1>
+    <h1 class="text-3xl font-bold mb-8"><%= title "Settings" %></h1>
 
     <%= form_with(model: Current.user, url: settings_path, method: :patch) do |form| %>
       <div class="space-y-8">

--- a/app/views/stamps/index.html.erb
+++ b/app/views/stamps/index.html.erb
@@ -8,7 +8,7 @@
 
 <div class="container mx-auto px-4 py-8">
   <div class="max-w-7xl mx-auto">
-    <h1 class="text-4xl font-bold mb-8">Ruby Passport Stamps</h1>
+    <h1 class="text-4xl font-bold mb-8"><%= title "Ruby Passport Stamps" %></h1>
 
     <% if @stamps.empty? %>
       <div class="alert alert-info">

--- a/app/views/todos/index.html.erb
+++ b/app/views/todos/index.html.erb
@@ -1,5 +1,5 @@
 <div class="container py-8">
-  <h1 class="text-2xl font-bold mb-2">Data TODOs</h1>
+  <h1 class="text-2xl font-bold mb-2"><%= title "Data TODOs" %></h1>
   <p class="text-base-content/70 mb-4">
     These are items in our data files that need attention. Want to help? Check out our
     <%= link_to "contribution guide", contributions_path, class: "link link-primary" %>.

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container py-8">
   <div class="flex items-center justify-between">
     <div class="flex items-center gap-2 title text-primary">
-      <h1>Topics</h1>
+      <h1><%= title "Topics" %></h1>
     </div>
 
     <%= link_to gems_path, class: "btn btn-sm btn-outline btn-primary" do %>


### PR DESCRIPTION
## Description
This adds `... | RubyEvents.org` to all `<title>`s and sets it for a couple a pages that didn't have it set. There might be more missing, i'll do a another check later, but this is at least already a nice improvement.
