### PR TITLE
Improve memory and performance of Event Seeds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -262,6 +262,9 @@ group :development do
   # Guard for watching file changes and auto-importing [https://github.com/guard/guard]
   gem "guard"
 
+  # Benchmark is no longer included in the standard lib - used for benchmarking
+  gem "benchmark"
+
   gem "ruby-lsp-rails", require: false
   gem "standardrb", "~> 1.0", require: false
   gem "erb_lint", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,6 +192,7 @@ GEM
     base64 (0.2.0)
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
+    benchmark (0.5.0)
     better_html (2.2.0)
       actionview (>= 7.0)
       activesupport (>= 7.0)
@@ -796,6 +797,7 @@ DEPENDENCIES
   avo
   avo-pro!
   bcrypt (~> 3.1.7)
+  benchmark
   bootsnap
   bundler-audit
   byebug

--- a/app/models/concerns/url_normalizable.rb
+++ b/app/models/concerns/url_normalizable.rb
@@ -14,7 +14,7 @@ module UrlNormalizable
       # Strip query params and fragment identifiers
       uri.query = nil
       uri.fragment = nil
-      uri.to_s
+      uri.to_s.chomp("/")
     rescue URI::InvalidURIError
       value
     end

--- a/app/models/static/event.rb
+++ b/app/models/static/event.rb
@@ -353,24 +353,11 @@ module Static
       return unless imported?
       return unless event.videos_file.exist?
 
-      event.videos_file.entries.each do |talk_data|
-        talk = ::Talk.find_or_initialize_by(static_id: talk_data["id"])
-        talk.update_from_yml_metadata!(event: event)
-        Search::Backend.index(talk) if index
-
-        child_talks = talk_data["talks"]
-
-        next unless child_talks
-
-        Array.wrap(child_talks).each do |child_talk_data|
-          child_talk = ::Talk.find_or_initialize_by(static_id: child_talk_data["id"])
-          child_talk.parent_talk = talk
-          child_talk.update_from_yml_metadata!(event: event)
-          Search::Backend.index(child_talk) if index
-        end
-      rescue ActiveRecord::RecordInvalid => e
-        puts "Couldn't save: #{talk_data["title"]} (#{talk_data["id"]}), error: #{e.message}"
+      Static::Video.where_event_slug(slug).each do |video|
+        video.import!(event: event, index: index)
       end
+    rescue ActiveRecord::RecordInvalid => e
+      puts "Couldn't save: #{talk_data["title"]} (#{talk_data["id"]}), error: #{e.message}"
     end
 
     def import_sponsors!(event)

--- a/app/models/static/event.rb
+++ b/app/models/static/event.rb
@@ -521,7 +521,8 @@ module Static
         end
 
         transcript_record = talk.talk_transcript || ::Talk::Transcript.new(talk: talk)
-        transcript_record.update!(raw_transcript: transcript)
+        transcript_record.update_attributes(raw_transcript: transcript)
+        transcript_record.save! if transcript_record.changed? || transcript_record.new_record?
       end
     end
 

--- a/app/models/static/event.rb
+++ b/app/models/static/event.rb
@@ -365,6 +365,8 @@ module Static
       end
     rescue ActiveRecord::RecordInvalid => e
       puts "Couldn't save: #{talk_data["title"]} (#{talk_data["id"]}), error: #{e.message}"
+      error_location = ActiveSupport::BacktraceCleaner.new.clean_locations(e.backtrace_locations).first
+      puts "::error file=#{error_location&.path},line=#{error_location&.lineno}::#{e.record.class} (#{e.record&.to_param}) - #{e.detailed_message}"
     end
 
     def import_sponsors!(event)

--- a/app/models/static/event.rb
+++ b/app/models/static/event.rb
@@ -292,9 +292,9 @@ module Static
     end
 
     def import_event!
-      event = ::Event.find_or_create_by(slug: slug)
+      event = ::Event.find_or_initialize_by(slug: slug)
 
-      event.update!(
+      event.assign_attributes(
         name: title,
         date: attributes["date"] || published_at,
         date_precision: date_precision || "day",
@@ -309,16 +309,18 @@ module Static
       )
 
       if event.venue.exist?
-        event.update!(
+        event.assign_attributes(
           latitude: event.venue.latitude,
           longitude: event.venue.longitude
         )
       else
-        event.update!(
+        event.assign_attributes(
           latitude: coordinates.is_a?(Hash) ? coordinates.dig("latitude") : nil,
           longitude: coordinates.is_a?(Hash) ? coordinates.dig("longitude") : nil
         )
       end
+
+      event.save! if event.changed? || event.new_record?
 
       event.sync_aliases_from_list(aliases) if aliases.present?
 

--- a/app/models/static/event.rb
+++ b/app/models/static/event.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Static
   class Event < FrozenRecord::Base
     include ActionView::Helpers::DateHelper

--- a/app/models/static/event.rb
+++ b/app/models/static/event.rb
@@ -339,13 +339,16 @@ module Static
       cfps = YAML.load_file(cfp_file_path)
 
       cfps.each do |cfp_data|
-        event.cfps.find_or_create_by(
+        cfp = event.cfps.find_or_initialize_by(
           link: cfp_data["link"],
           open_date: cfp_data["open_date"]
-        ).update(
+        )
+        cfp.assign_attributes(
           name: cfp_data["name"],
           close_date: cfp_data["close_date"]
         )
+
+        cfp.save! if cfp.changed? || cfp.new_record?
       end
     end
 

--- a/app/models/static/event.rb
+++ b/app/models/static/event.rb
@@ -373,7 +373,7 @@ module Static
       event.sponsors_file.file.each do |sponsors|
         sponsors["tiers"].each do |tier|
           tier["sponsors"].each do |sponsor|
-            s = nil
+            organization = nil
             domain = nil
 
             if sponsor["website"].present?
@@ -383,35 +383,41 @@ module Static
                 parsed = PublicSuffix.parse(host)
                 domain = parsed.domain
 
-                s = ::Organization.find_by(domain: domain) if domain.present?
+                organization = ::Organization.find_by(domain: domain) if domain.present?
               rescue PublicSuffix::Error, URI::InvalidURIError
                 # If parsing fails, continue with other matching methods
               end
             end
 
-            s ||= ::Organization.find_by_name_or_alias(sponsor["name"]) || ::Organization.find_by_slug_or_alias(sponsor["slug"]&.downcase)
-            s ||= ::Organization.find_or_initialize_by(name: sponsor["name"])
+            organization ||= ::Organization.find_by_name_or_alias(sponsor["name"]) || ::Organization.find_by_slug_or_alias(sponsor["slug"]&.downcase)
+            organization ||= ::Organization.find_or_initialize_by(name: sponsor["name"])
 
-            s.update(
+            organization.update(
               website: sponsor["website"],
               description: sponsor["description"],
               domain: domain
             )
 
-            s.add_logo_url(sponsor["logo_url"]) if sponsor["logo_url"].present?
-            s.logo_url = sponsor["logo_url"] if sponsor["logo_url"].present? && s.logo_url.blank?
+            organization.add_logo_url(sponsor["logo_url"]) if sponsor["logo_url"].present?
+            organization.logo_url = sponsor["logo_url"] if sponsor["logo_url"].present? && organization.logo_url.blank?
 
-            s = ::Organization.find_by_slug_or_alias(s.slug) || ::Organization.find_by_name_or_alias(s.name) unless s.persisted?
+            organization = ::Organization.find_by_slug_or_alias(organization.slug) || ::Organization.find_by_name_or_alias(organization.name) unless organization.persisted?
 
-            s.save!
+            organization.save! if organization.changed? || organization.new_record?
 
-            organisation_ids << s.id
+            organisation_ids << organization.id
 
-            event.sponsors.find_or_create_by!(organization: s, event: event).update!(tier: tier["name"], badge: sponsor["badge"], level: tier["level"])
+            sponsor = event.sponsors.find_or_initialize_by(organization:, event:)
+            sponsor.assign_attributes(tier: tier["name"], badge: sponsor["badge"], level: tier["level"])
+            sponsor.save! if sponsor.changed? || sponsor.new_record?
           end
         end
       end
       event.sponsors.where.not(organization_id: organisation_ids).destroy_all
+    rescue ActiveRecord::RecordInvalid => e
+      error_location = ActiveSupport::BacktraceCleaner.new.clean_locations(e.backtrace_locations).first
+      puts "::error file=#{error_location&.path},line=#{error_location&.lineno}::#{e.record.class} (#{e.record&.to_param}) - #{e.detailed_message}"
+      raise e
     end
 
     def import_involvements!(event)

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -641,7 +641,7 @@ class Talk < ApplicationRecord
 
     self.slug = new_slug
 
-    save!
+    save! if changed? || new_record?
   end
 
   def static_metadata

--- a/lib/tasks/seed.rake
+++ b/lib/tasks/seed.rake
@@ -38,7 +38,7 @@ namespace :db do
       before, after = 0, 0
       benchmark = Benchmark.measure do
         before = GC.stat[:total_allocated_objects]
-        Search::Backend.without_indexing do 
+        Search::Backend.without_indexing do
           Static::Event.import_all!
         end
         after = GC.stat[:total_allocated_objects]

--- a/lib/tasks/seed.rake
+++ b/lib/tasks/seed.rake
@@ -35,20 +35,16 @@ namespace :db do
 
     desc "Seed all events without series - will error on new event series"
     task events: :environment do
-      before, after = 0, 0
-      benchmark = Benchmark.measure do
-        before = GC.stat[:total_allocated_objects]
-        Search::Backend.without_indexing do
-          Static::Event.import_all!
-        end
-        after = GC.stat[:total_allocated_objects]
+      Search::Backend.without_indexing do
+        Static::Event.import_all!
       end
-      puts "Allocated objects: #{after - before}, Real: #{benchmark.real}, total: #{benchmark.total}"
     end
 
     desc "Seed all speakers"
     task speakers: :environment do
-      Static::Speaker.import_all!
+      Search::Backend.without_indexing do
+        Static::Speaker.import_all!
+      end
     end
   end
 end

--- a/lib/tasks/seed.rake
+++ b/lib/tasks/seed.rake
@@ -35,7 +35,15 @@ namespace :db do
 
     desc "Seed all events without series - will error on new event series"
     task events: :environment do
-      Static::Event.import_all!
+      before, after = 0, 0
+      benchmark = Benchmark.measure do
+        before = GC.stat[:total_allocated_objects]
+        Search::Backend.without_indexing do 
+          Static::Event.import_all!
+        end
+        after = GC.stat[:total_allocated_objects]
+      end
+      puts "Allocated objects: #{after - before}, Real: #{benchmark.real}, total: #{benchmark.total}"
     end
 
     desc "Seed all speakers"

--- a/test/models/organization_test.rb
+++ b/test/models/organization_test.rb
@@ -61,7 +61,7 @@ class OrganizationTest < ActiveSupport::TestCase
 
   test "should prepend https and strip params if missing scheme" do
     organization = Organization.create!(name: "Coerce Corp", website: "example.com/?utm_campaign=abc#top")
-    assert_equal "https://example.com/", organization.website
+    assert_equal "https://example.com", organization.website
   end
 
   test "should default to unknown kind" do

--- a/test/models/static/event_test.rb
+++ b/test/models/static/event_test.rb
@@ -1,6 +1,58 @@
 require "test_helper"
 
 class Static::EventTest < ActiveSupport::TestCase
+  SLUG = "helveticruby-2025"
+
+  test "import!" do
+    Static::EventSeries.find_by_slug("helveticruby").import_series!
+    event = Static::Event.find_by_slug(SLUG)
+    ENV["SEED_SMOKE_TEST"] = "true"
+    result = event.import!
+    assert_equal "Helvetic Ruby 2025", result.name
+  ensure
+    ENV.delete("SEED_SMOKE_TEST")
+  end
+
+  test "import_event!" do
+    Static::EventSeries.find_by_slug("helveticruby").import_series!
+    event = Static::Event.find_by_slug(SLUG)
+    result = event.import_event!
+    assert_equal "Helvetic Ruby 2025", result.name
+  end
+
+  test "import_cfps!" do
+    Static::EventSeries.find_by_slug("helveticruby").import_series!
+    event = Static::Event.find_by_slug(SLUG)
+    event_record = event.import_event!
+    event.import_cfps!(event_record)
+    assert event_record.cfps.exists?
+  end
+
+  test "import_videos!" do
+    Static::EventSeries.find_by_slug("helveticruby").import_series!
+    event = Static::Event.find_by_slug(SLUG)
+    event_record = event.import_event!
+    event.import_videos!(event_record)
+    assert event_record.talks.exists?
+  end
+
+  test "import_sponsors!" do
+    Static::EventSeries.find_by_slug("helveticruby").import_series!
+    event = Static::Event.find_by_slug(SLUG)
+    event_record = event.import_event!
+    event.import_sponsors!(event_record)
+    assert event_record.sponsors.exists?
+  end
+
+  test "import_transcripts!" do
+    Static::EventSeries.find_by_slug("helveticruby").import_series!
+    event = Static::Event.find_by_slug(SLUG)
+    event_record = event.import_event!
+    event.import_videos!(event_record)
+    event.import_transcripts!(event_record)
+    assert ::Talk::Transcript.exists?
+  end
+
   test "import_involvements!" do
     event = Static::Event.find_by_slug("xoruby-portland-2025")
     event.import_event!


### PR DESCRIPTION
## Description
<!-- Please describe your changes. -->

Importing events takes ages and lots of memory. We run into issues seeding data because of this. This PR aims to reduce object allocations and time by only updating the record when there are changes. In production (and development) we're normally only updating one or two events, and rarely a larger PR might include 10. While this won't affect the initial seed data, it will help with later runs.

Each commit represents the benchmark after running `bin/rails db:seed:event_series[rubyconf]` which was slow and large enough to notice, but not as tedious as the full events seed.

## Screenshots
<!-- Add screenshots or GIFs if applicable. -->

## Testing Steps
<!-- List steps to test your changes. -->
<!-- If this is a content PR, link to the affected pages -->

```bash
bin/rails db:seed:events
```

Before:
> Allocated objects: 82901672, Real: 167.88938579300884, total: 176.907387

After:
> Allocated objects: 64046016, Real: 110.00759493600344, total: 116.541339

## References
<!-- Link to related issues, discussions, other PRs, or references you used to write the PR. -->
- closes #1608
