### PR TITLE
feat(events): add filter by kind to profile events

### DIFF
--- a/app/javascript/controllers/events_filter_controller.js
+++ b/app/javascript/controllers/events_filter_controller.js
@@ -19,6 +19,7 @@ export default class extends Controller {
       const isActive = button.dataset.kind === this.currentValue
       button.classList.toggle('btn-active', isActive)
       button.classList.toggle('btn-primary', isActive)
+      button.classList.toggle('tab-active', isActive)
     })
   }
 

--- a/app/javascript/controllers/events_filter_controller.js
+++ b/app/javascript/controllers/events_filter_controller.js
@@ -17,8 +17,6 @@ export default class extends Controller {
   updateButtons () {
     this.buttonTargets.forEach(button => {
       const isActive = button.dataset.kind === this.currentValue
-      button.classList.toggle('btn-active', isActive)
-      button.classList.toggle('btn-primary', isActive)
       button.classList.toggle('tab-active', isActive)
     })
   }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -32,6 +32,9 @@ application.register("hover-card", HoverCardController)
 import EventListController from "./event_list_controller"
 application.register("event-list", EventListController)
 
+import EventsFilterController from "./events_filter_controller"
+application.register("events-filter", EventsFilterController)
+
 import EventsViewSwitcherController from "./events_view_switcher_controller"
 application.register("events-view-switcher", EventsViewSwitcherController)
 

--- a/app/views/profiles/_events.html.erb
+++ b/app/views/profiles/_events.html.erb
@@ -2,19 +2,34 @@
 
 <% future_events = events.upcoming.sort_by(&:sort_date).reverse %>
 <% past_events = (events.to_a - future_events).sort_by(&:sort_date).reverse %>
+<% event_kinds = events.map(&:kind).uniq.sort %>
 
 <% cache [user, events, Current.user] do %>
-  <div>
+  <div data-controller="events-filter" data-events-filter-current-value="all">
+    <div role="tablist" class="tabs tabs-boxed inline-flex mb-4">
+      <button type="button" class="tab tab-active" data-events-filter-target="button" data-kind="all" data-action="click->events-filter#filter">
+        All
+      </button>
+
+      <% event_kinds.each do |kind| %>
+        <button type="button" class="tab" data-events-filter-target="button" data-kind="<%= kind %>" data-action="click->events-filter#filter">
+          <%= kind.humanize.pluralize %>
+        </button>
+      <% end %>
+    </div>
+
     <div class="space-y-8">
         <% if future_events.any? %>
           <div>
             <h3 class="text-lg font-semibold mb-4">Future Events</h3>
             <div class="mb-6">
-              <div class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+              <div class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4" data-events-filter-target="group">
                 <% future_events.each do |event| %>
-                  <%= cache [event, participations[event.id]] do %>
-                    <%= render partial: "events/card", locals: {event: event, participation: participations[event.id]} %>
-                  <% end %>
+                  <div data-events-filter-target="event" data-kind="<%= event.kind %>">
+                    <%= cache [event, participations[event.id]] do %>
+                      <%= render partial: "events/card", locals: {event: event, participation: participations[event.id]} %>
+                    <% end %>
+                  </div>
                 <% end %>
               </div>
             </div>
@@ -25,11 +40,13 @@
           <div>
             <h3 class="text-lg font-semibold mb-4">Past Events</h3>
             <div class="mb-6">
-              <div class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+              <div class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4" data-events-filter-target="group">
                 <% past_events.each do |event| %>
-                  <%= cache [event, participations[event.id]] do %>
-                    <%= render partial: "events/card", locals: {event: event, participation: participations[event.id]} %>
-                  <% end %>
+                  <div data-events-filter-target="event" data-kind="<%= event.kind %>">
+                    <%= cache [event, participations[event.id]] do %>
+                      <%= render partial: "events/card", locals: {event: event, participation: participations[event.id]} %>
+                    <% end %>
+                  </div>
                 <% end %>
               </div>
             </div>

--- a/app/views/profiles/_events.html.erb
+++ b/app/views/profiles/_events.html.erb
@@ -6,17 +6,7 @@
 
 <% cache [user, events, Current.user] do %>
   <div data-controller="events-filter" data-events-filter-current-value="all">
-    <div role="tablist" class="tabs tabs-boxed inline-flex mb-4">
-      <button type="button" class="tab tab-active" data-events-filter-target="button" data-kind="all" data-action="click->events-filter#filter">
-        All
-      </button>
-
-      <% event_kinds.each do |kind| %>
-        <button type="button" class="tab" data-events-filter-target="button" data-kind="<%= kind %>" data-action="click->events-filter#filter">
-          <%= kind.humanize.pluralize %>
-        </button>
-      <% end %>
-    </div>
+    <%= render "shared/filter_buttons", kinds: event_kinds, current_filter: "all" %>
 
     <div class="space-y-8">
         <% if future_events.any? %>

--- a/app/views/shared/_filter_buttons.html.erb
+++ b/app/views/shared/_filter_buttons.html.erb
@@ -1,30 +1,13 @@
-<%# locals: (current_filter: "all") %>
+<%# locals: (kinds:, current_filter: "all") %>
 
-<div class="flex gap-2 mb-6" data-controller="events-filter" data-events-filter-current-value="<%= current_filter %>">
-  <button
-    type="button"
-    data-events-filter-target="button"
-    data-kind="all"
-    data-action="click->events-filter#filter"
-    class="btn btn-sm <%= "btn-active btn-primary" if current_filter == "all" %>">
+<div role="tablist" class="tabs tabs-boxed inline-flex mb-4">
+  <button type="button" class="tab <%= "tab-active" if current_filter == "all" %>" data-events-filter-target="button" data-kind="all" data-action="click->events-filter#filter">
     All
   </button>
 
-  <button
-    type="button"
-    data-events-filter-target="button"
-    data-kind="conference"
-    data-action="click->events-filter#filter"
-    class="btn btn-sm <%= "btn-active btn-primary" if current_filter == "conference" %>">
-    Conferences
-  </button>
-
-  <button
-    type="button"
-    data-events-filter-target="button"
-    data-kind="meetup"
-    data-action="click->events-filter#filter"
-    class="btn btn-sm <%= "btn-active btn-primary" if current_filter == "meetup" %>">
-    Meetups
-  </button>
+  <% kinds.each do |kind| %>
+    <button type="button" class="tab <%= "tab-active" if current_filter == kind %>" data-events-filter-target="button" data-kind="<%= kind %>" data-action="click->events-filter#filter">
+      <%= kind.humanize.pluralize %>
+    </button>
+  <% end %>
 </div>


### PR DESCRIPTION
## Description
This PR adds a filter by kind to the profile events page.
A few observations here:

- I have refactored the `app/views/shared/_filter_buttons.html.erb` to be used as the tabs with event kinds, because it seemed like they had similar responsibilities. If this refactor is not supposed to happen, I have a previous commit that I can use as well - that won't touch this partial.
- Should I also add an empty state message if `Past Events` or `Due Events` are empty?

Any other feedback, of course,  is more than welcome!

## Screenshots
https://github.com/user-attachments/assets/044536f5-1d7c-4209-8a80-ef8bcec164a3

## Testing Steps
1. Make sure you have a mix of past and future events, of a variety of kinds, in your seed logged user
2. Navigate to https://localhost:3000/profiles/<your_profile>/events
3. Navigate through the kinds in the same way of the video

## References
- closes #1637 
