### PR TITLE
Disallow users to change their name

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -118,7 +118,6 @@ class ProfilesController < ApplicationController
 
   def user_params
     params.require(:user).permit(
-      :name,
       :github_handle,
       :twitter,
       :bsky,

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -7,7 +7,7 @@
 
     <div>
       <%= form.label :name %>
-      <%= form.text_field :name, class: "input input-bordered w-full" %>
+      <%= form.text_field :name, disabled: true, class: "input input-bordered w-full" %>
     </div>
 
     <div>

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -79,15 +79,23 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
     sign_in_as @user
 
     assert_no_changes -> { @user.suggestions.pending.count } do
-      patch profile_url(@user), params: {user: {bio: "new bio", name: "new-name", twitter: "new-twitter", website: "new-website"}}
+      patch profile_url(@user), params: {user: {bio: "new bio", twitter: "new-twitter", website: "new-website"}}
     end
 
     assert_redirected_to profile_url(@user)
     assert_equal "new bio", @user.reload.bio
-    assert_equal @user.name, "new-name"
     assert_equal @user.twitter, "new-twitter"
     assert_equal @user.website, "https://new-website"
     assert_equal @user.id, @user.suggestions.last.suggested_by_id
+  end
+
+  test "owner cannot update their name" do
+    sign_in_as @user
+    original_name = @user.name
+
+    patch profile_url(@user), params: {user: {name: "new-name"}}
+
+    assert_equal original_name, @user.reload.name
   end
 
   test "should redirect when user not found" do


### PR DESCRIPTION
## Description

Currently we use the `name` of the `users` table to match against the names references in the `videos.yml` and the `involvements.yml` files.

If we allow people to edit their name we cannot match the name with the users anymore on subsequent re-seeds. In order to prevent that we should disallow people to update their name through the UI. Changes to the name (or their aliases) should be made in the `speakers.yml` file directly.


## Screenshots

<img width="2690" height="1960" alt="CleanShot 2026-04-15 at 04 08 29@2x" src="https://github.com/user-attachments/assets/8453596a-383d-4e88-9670-0e65d3c2b374" />



## Testing Steps

* Visit Profile
* Click "Edit Profile"
* Check that the `name` field is disabled and cannot be updated

## References

 \-