### PR TITLE
Update RuCoCo 2026 Winter Edition videos

### DIFF
--- a/data/ruby-community-conference/ruby-community-conference-winter-edition-2026/videos.yml
+++ b/data/ruby-community-conference/ruby-community-conference-winter-edition-2026/videos.yml
@@ -96,47 +96,55 @@
 
 - id: "obie-fernandez-ruby-community-conference-winter-edition-2026"
   title: "Ruby & AI conversation"
+  raw_title: "Ruby & AI conversation - Obie Fernandez [EN]"
   description: |-
     A conversation about the intersection of Ruby and AI technologies, exploring opportunities and challenges.
   speakers:
     - Obie Fernandez
   date: "2026-03-13"
   announced_at: "2025-12-10"
-  video_provider: "scheduled"
-  video_id: "obie-fernandez-ruby-community-conference-winter-edition-2026"
+  published_at: "2026-04-16"
+  video_provider: "youtube"
+  video_id: "BoXGn5-onb0"
 
 - id: "marco-roth-ruby-community-conference-winter-edition-2026"
   title: "Herb to ReActionView: A New Foundation for the View Layer"
+  raw_title: "Herb and ReActionView - Marco Roth [EN]"
   description: |-
     This talk is an overview of how Herb came to be, what Herb can do for you today, and what the future with ReActionView might look like and how Herb could enable it.
   speakers:
     - Marco Roth
   date: "2026-03-13"
   announced_at: "2025-12-30"
-  video_provider: "scheduled"
-  video_id: "marco-roth-ruby-community-conference-winter-edition-2026"
+  published_at: "2026-04-16"
+  video_provider: "youtube"
+  video_id: "NXYriXsz6Uo"
 
 - id: "carmine-paolino-talk-ruby-community-conference-winter-edition-2026"
   title: "Ruby Is the Best Language for Building AI Web Apps"
+  raw_title: "Ruby Is the Best Language for Building AI Web Apps - Carmine Paolino [EN]"
   description: |-
     Everyone says you need Python to build serious AI apps. That used to be true for training models, but most teams today are building products on top of APIs. This talk shows, with real code and production experience, why Ruby can be a better default for that work: less ceremony, cleaner agent abstractions, and faster iteration. The thesis is simple: when complexity drops, product quality goes up.
   kind: "talk"
   language: "en"
   date: "2026-03-13"
+  published_at: "2026-04-16"
   speakers:
     - Carmine Paolino
-  video_provider: "scheduled"
-  video_id: "carmine-paolino-talk-ruby-community-conference-winter-edition-2026"
+  video_provider: "youtube"
+  video_id: "ucAwF9ZPZo4"
 
 - id: "chris-hasinski-lightning_talk-ruby-community-conference-winter-edition-2026"
   title: "Doom"
+  raw_title: "Doom - Chris Hasiński [EN]"
   kind: "lightning_talk"
   description: ""
   date: "2026-03-13"
+  published_at: "2026-04-16"
   speakers:
     - Chris Hasiński
-  video_provider: "scheduled"
-  video_id: "chris-hasinski-lightning_talk-ruby-community-conference-winter-edition-2026"
+  video_provider: "youtube"
+  video_id: "tBNPfMqxUHQ"
 
 - id: "sergey-sergyenko-lightning_talk-ruby-community-conference-winter-edition-2026"
   title: "The 00 Robot Arm: Low-Cost Open-Source Infrastructure for Embodied AI Inference"
@@ -150,20 +158,24 @@
 
 - id: "pawel-strzalkowski-lightning_talk-ruby-community-conference-winter-edition-2026"
   title: "Make a game with Ruby and Model Context Protocol"
+  raw_title: "Make a game with Ruby and Model Context Protocol - Paweł Strzałkowski [EN]"
   description: ""
   kind: "lightning_talk"
   date: "2026-03-13"
+  published_at: "2026-04-16"
   speakers:
     - Paweł Strzałkowski
-  video_provider: "scheduled"
-  video_id: "pawel-strzalkowski-lightning_talk-ruby-community-conference-winter-edition-2026"
+  video_provider: "youtube"
+  video_id: "ecRCx-8Vjgk"
 
 - id: "nick-sutterer-lightning_talk-ruby-community-conference-winter-edition-2026"
   title: "The Story"
+  raw_title: "The Story - Nick Sutterer [EN]"
   description: ""
   kind: "lightning_talk"
   date: "2026-03-13"
+  published_at: "2026-04-16"
   speakers:
     - Nick Sutterer
-  video_provider: "scheduled"
-  video_id: "nick-sutterer-lightning_talk-ruby-community-conference-winter-edition-2026"
+  video_provider: "youtube"
+  video_id: "OmY7fVfL878"


### PR DESCRIPTION
## Description
<!-- Please describe your changes. -->
Add 6 released videos for RUCOCO ❄️ 2026.

## Screenshots
<!-- Add screenshots or GIFs if applicable. -->

<img width="1302" height="691" alt="Screenshot 2026-04-16 at 1 36 25 PM" src="https://github.com/user-attachments/assets/8d05a328-0e20-487d-8cc9-ed720caae6e3" />


## Testing Steps
<!-- List steps to test your changes. -->
<!-- If this is a content PR, link to the affected pages -->
- https://www.rubyevents.org/events/ruby-community-conference-winter-edition-2026

## References
<!-- Link to related issues, discussions, other PRs, or references you used to write the PR. -->
- closes #<!-- issue number -->
