### PR TITLE
feat: add anchor links to component library headings

### DIFF
--- a/app/views/page/components/_avatars.html.erb
+++ b/app/views/page/components/_avatars.html.erb
@@ -1,4 +1,7 @@
-<h2 class="text-2xl font-bold mb-4">Avatar</h2>
+<h2 id="avatar" class="text-2xl font-bold mb-4 group">
+  <a href="#avatar" class="opacity-0 group-hover:opacity-100 no-underline mr-1 text-gray-400" aria-label="Link to Avatar">#</a>
+  Avatar
+</h2>
 
 <% avatarable = User.speakers.first %>
 <div class="flex gap-16 w-full">

--- a/app/views/page/components/_buttons.html.erb
+++ b/app/views/page/components/_buttons.html.erb
@@ -1,4 +1,7 @@
-<h2 class="text-2xl font-bold mb-4">Button</h2>
+<h2 id="button" class="text-2xl font-bold mb-4 group">
+  <a href="#button" class="opacity-0 group-hover:opacity-100 no-underline mr-1 text-gray-400" aria-label="Link to Button">#</a>
+  Button
+</h2>
 <div class="flex gap-16 w-full">
   <div class="flex items-center justify-start gap-4 mb-8 flex-wrap">
     <% [:primary, :secondary, :neutral, :rounded, :ghost, :link].each do |kind| %>

--- a/app/views/page/components/_dropdowns.html.erb
+++ b/app/views/page/components/_dropdowns.html.erb
@@ -1,4 +1,7 @@
-<h2 class="text-2xl font-bold">Dropdown</h2>
+<h2 id="dropdown" class="text-2xl font-bold group">
+  <a href="#dropdown" class="opacity-0 group-hover:opacity-100 no-underline mr-1 text-gray-400" aria-label="Link to Dropdown">#</a>
+  Dropdown
+</h2>
 <div class="flex items-center justify-start gap-8 py-8">
   <%= ui_dropdown id: "dropdown" do |c| %>
     Dropdown

--- a/app/views/page/components/_links.html.erb
+++ b/app/views/page/components/_links.html.erb
@@ -1,4 +1,7 @@
-<h2 class="text-2xl font-bold">Links</h2>
+<h2 id="links" class="text-2xl font-bold group">
+  <a href="#links" class="opacity-0 group-hover:opacity-100 no-underline mr-1 text-gray-400" aria-label="Link to Links">#</a>
+  Links
+</h2>
 <div class="flex items-center justify-start gap-8 py-8">
   <%= external_link_to "www.ruby-lang.org", "https://www.ruby-lang.org/" %>
 

--- a/app/views/page/components/_modals.html.erb
+++ b/app/views/page/components/_modals.html.erb
@@ -1,4 +1,7 @@
-<h2 class="text-2xl font-bold">Modal</h2>
+<h2 id="modal" class="text-2xl font-bold group">
+  <a href="#modal" class="opacity-0 group-hover:opacity-100 no-underline mr-1 text-gray-400" aria-label="Link to Modal">#</a>
+  Modal
+</h2>
 <div class="flex items-center justify-start gap-8 py-8">
   <%= ui_button "Top position", "#", kind: :pill, data: {toggle: "modal", target: "modal-top"} %>
   <%= ui_modal position: :top, id: "modal-top" do %>

--- a/app/views/page/components/_stamps.html.erb
+++ b/app/views/page/components/_stamps.html.erb
@@ -1,4 +1,7 @@
-<h2 class="text-2xl font-bold mb-4">Stamp</h2>
+<h2 id="stamp" class="text-2xl font-bold mb-4 group">
+  <a href="#stamp" class="opacity-0 group-hover:opacity-100 no-underline mr-1 text-gray-400" aria-label="Link to Stamp">#</a>
+  Stamp
+</h2>
 
 <% country_stamp = Stamp.country_stamps.sample %>
 

--- a/app/views/page/components/_tabs.html.erb
+++ b/app/views/page/components/_tabs.html.erb
@@ -1,4 +1,7 @@
-<h2 class="text-2xl font-bold">Tabs</h2>
+<h2 id="tabs" class="text-2xl font-bold group">
+  <a href="#tabs" class="opacity-0 group-hover:opacity-100 no-underline mr-1 text-gray-400" aria-label="Link to Tabs">#</a>
+  Tabs
+</h2>
 <div class="flex flex-col items-start justify-start gap-8 py-8">
   <div>Todo (this is a WIP of the tab component, just the Daisy UI markup and a Stimulus controller)</div>
 

--- a/app/views/page/components/_tooltips.html.erb
+++ b/app/views/page/components/_tooltips.html.erb
@@ -1,4 +1,7 @@
-<h2 class="text-2xl font-bold">Tooltips</h2>
+<h2 id="tooltips" class="text-2xl font-bold group">
+  <a href="#tooltips" class="opacity-0 group-hover:opacity-100 no-underline mr-1 text-gray-400" aria-label="Link to Tooltips">#</a>
+  Tooltips
+</h2>
 <div class="flex flex-col items-start justify-start gap-8 py-8">
 
   <%= ui_tooltip "basic text in the tooltip" do %>


### PR DESCRIPTION
## Description

Adds hover-revealed anchor links to each heading in the Component Library page per #1636. Each `<h2>` in `app/views/page/components/*.html.erb` now has:

1. An `id` matching the component's slug (`avatar`, `button`, `dropdown`, `links`, `modal`, `stamp`, `tabs`, `tooltips`) so `/components#modal` scrolls directly to the Modal section.
2. A `#` anchor inline that appears on hover (Tailwind `group` + `group-hover:opacity-100`), giving a one-click way to grab the direct URL to that component.

No heading text changed; spacing preserved by keeping the existing `mb-4` where it was already set (avatars, buttons, stamps).

## Screenshots

No screenshot attached — the change is purely the anchor marker appearing on hover. Verification steps below reproduce the behavior locally.

## Testing Steps

1. `bin/dev` and open `/components`.
2. Page content should look identical to before.
3. Hover over any heading (e.g., "Modal") — a faint gray `#` appears before the heading text.
4. Click the `#` — the URL updates to `/components#modal` and the page stays scrolled to that heading.
5. Copy the URL, paste into a new tab — the page loads and jumps straight to Modal.
6. Repeat for the other seven headings (avatar, button, dropdown, links, stamp, tabs, tooltips).

## References

- closes #1636

---

Implementation note: these are static view partials; no controller, route, or model logic was touched, so the existing test suite covers this change unchanged. The `group` / `group-hover:opacity-100` pattern matches the Tailwind usage already present elsewhere in the app.

This contribution was developed with AI assistance (Codex).
