### PR TITLE
fix(events): hide profile events filter if profile has zero events

### DIFF
--- a/app/views/profiles/_events.html.erb
+++ b/app/views/profiles/_events.html.erb
@@ -6,7 +6,9 @@
 
 <% cache [user, events, Current.user] do %>
   <div data-controller="events-filter" data-events-filter-current-value="all">
-    <%= render "shared/filter_buttons", kinds: event_kinds, current_filter: "all" %>
+    <% if events.any? %>
+      <%= render "shared/filter_buttons", kinds: event_kinds, current_filter: "all" %>
+    <% end %>
 
     <div class="space-y-8">
         <% if future_events.any? %>


### PR DESCRIPTION
## Description
Noticed that, on [my PR](https://github.com/rubyevents/rubyevents/pull/1646) that was merged earlier, I forgot to address the case when the user has no participated events. So this is a tiny fix to make sure we only display the filter bar if at least one event is present.

## Screenshots
Before:
<img width="1197" height="711" alt="image" src="https://github.com/user-attachments/assets/d6fbbf5d-e78d-41a4-992c-7c76d10115e0" />

After:
<img width="1424" height="798" alt="image" src="https://github.com/user-attachments/assets/82fb44b3-3633-47a1-bb7e-f31d20fd680b" />


## Testing Steps
1. Delete all the `participated_events` from your seeds logged user
2. Navigate to https://localhost:3000/profiles/<your_profile>/events
3. Check if the filter bar showing `All` is gone

## References
Related to the previously [closed issue](https://github.com/rubyevents/rubyevents/issues/1637)