### PR TITLE
Create merge users service

### DIFF
--- a/app/avo/actions/assign_canonical_user.rb
+++ b/app/avo/actions/assign_canonical_user.rb
@@ -4,7 +4,14 @@ class Avo::Actions::AssignCanonicalUser < Avo::BaseAction
   def fields
     field :user_id, as: :select, name: "Canonical user",
       help: "The name of the speaker to be set as canonical",
-      options: -> { User.order(:name).pluck(:name, :id) }
+      options: -> {
+        User.order(:name).map do |u|
+          label = u.name.to_s
+          label += " (@#{u.github_handle})" if u.github_handle.present?
+          label += " – #{u.talks_count} talk(s)"
+          [label, u.id]
+        end
+      }
   end
 
   def handle(query:, fields:, current_user:, resource:, **args)

--- a/app/avo/resources/user.rb
+++ b/app/avo/resources/user.rb
@@ -75,5 +75,6 @@ class Avo::Resources::User < Avo::BaseResource
     action Avo::Actions::UserFetchGitHub
     action Avo::Actions::GeocodeRecord
     action Avo::Actions::ClearUser
+    action Avo::Actions::AssignCanonicalUser
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -410,40 +410,7 @@ class User < ApplicationRecord
   end
 
   def assign_canonical_user!(canonical_user:)
-    ActiveRecord::Base.transaction do
-      if name.present? && slug.present?
-        canonical_user.aliases.find_or_create_by!(name: name, slug: slug)
-      end
-
-      user_talks.each do |user_talk|
-        duplicated = user_talk.dup
-        duplicated.user = canonical_user
-        duplicated.save
-      end
-
-      event_participations.each do |participation|
-        duplicated = participation.dup
-        duplicated.user = canonical_user
-        duplicated.save
-      end
-
-      event_involvements.each do |involvement|
-        duplicated = involvement.dup
-        duplicated.involvementable = canonical_user
-        duplicated.save
-      end
-
-      user_talks.destroy_all
-      event_participations.destroy_all
-      event_involvements.destroy_all
-
-      update_columns(
-        canonical_id: canonical_user.id,
-        github_handle: nil,
-        slug: "",
-        marked_for_deletion: true
-      )
-    end
+    MergeUsersService.new(user_to_keep: canonical_user, user_to_merge: self).call
   end
 
   def set_slug

--- a/app/services/merge_users_service.rb
+++ b/app/services/merge_users_service.rb
@@ -1,0 +1,122 @@
+class MergeUsersService
+  PROFILE_FIELDS = %i[bio github_handle twitter bsky linkedin mastodon website speakerdeck pronouns pronouns_type location].freeze
+
+  attr_reader :user_to_keep, :user_to_merge
+
+  def initialize(user_to_keep:, user_to_merge:)
+    @user_to_keep = user_to_keep
+    @user_to_merge = user_to_merge
+  end
+
+  def call
+    @merged_profile = PROFILE_FIELDS.to_h { |f| [f, user_to_merge.send(f)] }
+
+    ActiveRecord::Base.transaction do
+      create_alias
+      transfer_talks
+      transfer_event_participations
+      transfer_event_involvements
+      transfer_watched_talks
+      transfer_bookmarks
+      transfer_favorite_users
+      transfer_favorited_by
+      clear_unique_fields_from_merged_user
+      merge_profile_fields
+      mark_merged_user_for_deletion
+    end
+  end
+
+  private
+
+  def create_alias
+    return if user_to_merge.name.blank? || user_to_merge.slug.blank?
+    user_to_keep.aliases.find_or_create_by!(name: user_to_merge.name, slug: user_to_merge.slug)
+  end
+
+  def transfer_talks
+    user_to_merge.user_talks.each do |user_talk|
+      dup = user_talk.dup
+      dup.user = user_to_keep
+      dup.save
+    end
+    user_to_merge.user_talks.destroy_all
+  end
+
+  def transfer_event_participations
+    user_to_merge.event_participations.each do |participation|
+      dup = participation.dup
+      dup.user = user_to_keep
+      dup.save
+    end
+    user_to_merge.event_participations.destroy_all
+  end
+
+  def transfer_event_involvements
+    user_to_merge.event_involvements.each do |involvement|
+      dup = involvement.dup
+      dup.involvementable = user_to_keep
+      dup.save
+    end
+    user_to_merge.event_involvements.destroy_all
+  end
+
+  def transfer_watched_talks
+    user_to_merge.watched_talks.each do |watched_talk|
+      next if user_to_keep.watched_talks.exists?(talk_id: watched_talk.talk_id)
+      dup = watched_talk.dup
+      dup.user = user_to_keep
+      dup.save
+    end
+    user_to_merge.watched_talks.destroy_all
+  end
+
+  def transfer_bookmarks
+    return unless user_to_merge.watch_lists.any?
+
+    canonical_watch_list = user_to_keep.default_watch_list
+    user_to_merge.watch_lists.each do |watch_list|
+      watch_list.watch_list_talks.each do |wlt|
+        canonical_watch_list.watch_list_talks.find_or_create_by(talk_id: wlt.talk_id)
+      end
+    end
+    user_to_merge.watch_lists.destroy_all
+  end
+
+  def transfer_favorite_users
+    user_to_merge.favorite_users.each do |fav|
+      next if fav.favorite_user_id == user_to_keep.id
+      user_to_keep.favorite_users.find_or_create_by(favorite_user_id: fav.favorite_user_id)
+    end
+    user_to_merge.favorite_users.destroy_all
+  end
+
+  def transfer_favorited_by
+    user_to_merge.favorited_by.each do |fav|
+      next if fav.user_id == user_to_keep.id
+      user_to_keep.favorited_by.find_or_create_by(user_id: fav.user_id)
+    end
+    user_to_merge.favorited_by.destroy_all
+  end
+
+  def clear_unique_fields_from_merged_user
+    user_to_merge.update_column(:github_handle, nil)
+  end
+
+  def merge_profile_fields
+    updates = {}
+    PROFILE_FIELDS.each do |field|
+      next if user_to_keep.send(field).present?
+      value = @merged_profile[field]
+      updates[field] = value if value.present?
+    end
+    user_to_keep.update_columns(updates) if updates.any?
+  end
+
+  def mark_merged_user_for_deletion
+    user_to_merge.update_columns(
+      canonical_id: user_to_keep.id,
+      slug: "",
+      marked_for_deletion: true
+    )
+  end
+end

--- a/app/services/merge_users_service.rb
+++ b/app/services/merge_users_service.rb
@@ -10,6 +10,7 @@ class MergeUsersService
 
   def call
     @merged_profile = PROFILE_FIELDS.to_h { |f| [f, user_to_merge.send(f)] }
+    succeeded = false
 
     ActiveRecord::Base.transaction do
       create_alias
@@ -22,8 +23,10 @@ class MergeUsersService
       transfer_favorited_by
       clear_unique_fields_from_merged_user
       merge_profile_fields
-      mark_merged_user_for_deletion
+      succeeded = true
     end
+
+    mark_merged_user_for_deletion if succeeded
   end
 
   private
@@ -113,10 +116,6 @@ class MergeUsersService
   end
 
   def mark_merged_user_for_deletion
-    user_to_merge.update_columns(
-      canonical_id: user_to_keep.id,
-      slug: "",
-      marked_for_deletion: true
-    )
+    user_to_merge.delete
   end
 end

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -22,11 +22,9 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
     original_slug = @user_with_talk.slug
 
     @user_with_talk.assign_canonical_speaker!(canonical_speaker: @user)
-    @user_with_talk.reload
+    @user.reload
 
-    assert_equal @user, @user_with_talk.canonical
     assert @user.talks.ids.include?(talk.id)
-    assert @user_with_talk.talks.empty?
 
     get profile_url(original_slug)
     assert_redirected_to profile_url(@user)
@@ -128,7 +126,6 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
     duplicate_user = User.create!(name: "Duplicate User", github_handle: "duplicate-controller")
 
     duplicate_user.assign_canonical_user!(canonical_user: canonical_user)
-    duplicate_user.reload
 
     alias_record = Alias.find_by(slug: "duplicate-controller")
     assert_not_nil alias_record

--- a/test/controllers/speakers_controller_test.rb
+++ b/test/controllers/speakers_controller_test.rb
@@ -30,9 +30,6 @@ class SpeakersControllerTest < ActionDispatch::IntegrationTest
     speaker = users(:one)
     canonical = users(:marco)
     speaker.assign_canonical_speaker!(canonical_speaker: canonical)
-    speaker.reload
-    assert_equal speaker.canonical, canonical
-    assert_equal speaker.canonical_slug, canonical.slug
 
     get speakers_url(canonical: false, with_talks: false), as: :json
     assert_response :success

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -69,17 +69,14 @@ class UserTest < ActiveSupport::TestCase
     assert_equal user1.id, found_user.id
   end
 
-  test "assign_canonical_user! marks user for deletion" do
+  test "assign_canonical_user! deletes user" do
     user = User.create!(name: "Duplicate User", github_handle: "duplicate-test")
     canonical_user = User.create!(name: "Canonical User", github_handle: "canonical-test")
-
-    assert_equal false, user.marked_for_deletion
+    user_id = user.id
 
     user.assign_canonical_user!(canonical_user: canonical_user)
-    user.reload
 
-    assert_equal true, user.marked_for_deletion
-    assert_equal canonical_user, user.canonical
+    assert_not User.exists?(user_id)
   end
 
   test "assign_canonical_user! creates an alias on the canonical user" do
@@ -149,12 +146,9 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 0, canonical_user.talks.count
 
     user.assign_canonical_user!(canonical_user: canonical_user)
-    user.reload
     canonical_user.reload
 
-    assert_equal 0, user.talks.count
     assert_equal 2, canonical_user.talks.count
-
     assert_includes canonical_user.talks, talk1
     assert_includes canonical_user.talks, talk2
   end
@@ -171,10 +165,8 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 0, canonical_user.event_participations.count
 
     user.assign_canonical_user!(canonical_user: canonical_user)
-    user.reload
     canonical_user.reload
 
-    assert_equal 0, user.event_participations.count
     assert_equal 1, canonical_user.event_participations.count
     assert_equal event, canonical_user.participated_events.first
   end
@@ -212,10 +204,8 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 0, canonical_user.event_involvements.count
 
     user.assign_canonical_user!(canonical_user: canonical_user)
-    user.reload
     canonical_user.reload
 
-    assert_equal 0, user.event_involvements.count
     assert_equal 1, canonical_user.event_involvements.count
     assert_equal event, canonical_user.involved_events.first
   end
@@ -243,15 +233,14 @@ class UserTest < ActiveSupport::TestCase
     assert_equal event.id, new_involvement.event_id
   end
 
-  test "assign_canonical_speaker! calls assign_canonical_user!" do
+  test "assign_canonical_speaker! deletes user and creates alias" do
     user = User.create!(name: "Old Method User", github_handle: "old-method")
     canonical_user = User.create!(name: "Canonical", github_handle: "canonical-old")
+    user_id = user.id
 
     user.assign_canonical_speaker!(canonical_speaker: canonical_user)
-    user.reload
 
-    assert_equal true, user.marked_for_deletion
-    assert_equal canonical_user, user.canonical
+    assert_not User.exists?(user_id)
     assert_not_nil canonical_user.aliases.find_by(name: "Old Method User")
   end
 
@@ -263,12 +252,11 @@ class UserTest < ActiveSupport::TestCase
     assert_nil found_user
   end
 
-  test "find_by_name_or_alias finds alias even if original user is marked for deletion" do
+  test "find_by_name_or_alias finds alias even if original user is deleted" do
     canonical_user = User.create!(name: "Canonical User", github_handle: "canonical-marked-test")
     marked_user = User.create!(name: "Duplicate User", github_handle: "duplicate-marked-test")
 
     marked_user.assign_canonical_user!(canonical_user: canonical_user)
-    marked_user.reload
 
     alias_record = Alias.find_by(aliasable_type: "User", name: "Duplicate User")
     assert_not_nil alias_record
@@ -287,13 +275,12 @@ class UserTest < ActiveSupport::TestCase
     assert_nil found_user
   end
 
-  test "find_by_slug_or_alias finds alias even if original user is marked for deletion" do
+  test "find_by_slug_or_alias finds alias even if original user is deleted" do
     canonical_user = User.create!(name: "Canonical Slug User", github_handle: "canonical-slug-marked")
     marked_user = User.create!(name: "Duplicate Slug User", github_handle: "duplicate-slug-marked")
     original_slug = marked_user.slug
 
     marked_user.assign_canonical_user!(canonical_user: canonical_user)
-    marked_user.reload
 
     alias_record = Alias.find_by(aliasable_type: "User", slug: original_slug)
     assert_not_nil alias_record

--- a/test/services/merge_users_service_test.rb
+++ b/test/services/merge_users_service_test.rb
@@ -1,0 +1,165 @@
+require "test_helper"
+
+class MergeUsersServiceTest < ActiveSupport::TestCase
+  setup do
+    @user_to_keep = User.create!(name: "Canonical User", github_handle: "canonical-merge-test")
+    @user_to_merge = User.create!(name: "Duplicate User", github_handle: "duplicate-merge-test")
+  end
+
+  def merge
+    MergeUsersService.new(user_to_keep: @user_to_keep, user_to_merge: @user_to_merge).call
+  end
+
+  test "marks merged user for deletion" do
+    merge
+    assert @user_to_merge.reload.marked_for_deletion
+  end
+
+  test "sets canonical_id on merged user" do
+    merge
+    assert_equal @user_to_keep.id, @user_to_merge.reload.canonical_id
+  end
+
+  test "creates an alias for the merged user's name on user_to_keep" do
+    merge
+    assert @user_to_keep.aliases.exists?(name: "Duplicate User")
+  end
+
+  test "transfers talks to user_to_keep" do
+    talk1 = talks(:one)
+    talk2 = talks(:two)
+    UserTalk.create!(user: @user_to_merge, talk: talk1)
+    UserTalk.create!(user: @user_to_merge, talk: talk2)
+
+    merge
+    @user_to_keep.reload
+    @user_to_merge.reload
+
+    assert_includes @user_to_keep.talks, talk1
+    assert_includes @user_to_keep.talks, talk2
+    assert_equal 0, @user_to_merge.talks.count
+  end
+
+  test "does not duplicate talks already on user_to_keep" do
+    talk = talks(:one)
+    UserTalk.create!(user: @user_to_keep, talk: talk)
+    UserTalk.create!(user: @user_to_merge, talk: talk)
+
+    merge
+    @user_to_keep.reload
+
+    assert_equal 1, @user_to_keep.user_talks.where(talk: talk).count
+  end
+
+  test "transfers event participations to user_to_keep" do
+    series = EventSeries.create!(name: "Test Series", slug: "test-series-mus")
+    event = Event.create!(name: "Test Event", slug: "test-event-mus", series: series, date: Date.today)
+    EventParticipation.create!(user: @user_to_merge, event: event, attended_as: :speaker)
+
+    merge
+    @user_to_keep.reload
+
+    assert_equal 1, @user_to_keep.event_participations.where(event: event).count
+    assert_equal 0, @user_to_merge.reload.event_participations.count
+  end
+
+  test "transfers watched talks to user_to_keep" do
+    talk = talks(:one)
+    WatchedTalk.create!(user: @user_to_merge, talk: talk, watched: true, watched_at: Time.current)
+
+    merge
+    @user_to_keep.reload
+
+    assert @user_to_keep.watched_talks.exists?(talk: talk)
+    assert_equal 0, @user_to_merge.reload.watched_talks.count
+  end
+
+  test "does not duplicate watched talks already on user_to_keep" do
+    talk = talks(:one)
+    WatchedTalk.create!(user: @user_to_keep, talk: talk, watched: true, watched_at: Time.current)
+    WatchedTalk.create!(user: @user_to_merge, talk: talk, watched: true, watched_at: Time.current)
+
+    merge
+    @user_to_keep.reload
+
+    assert_equal 1, @user_to_keep.watched_talks.where(talk: talk).count
+  end
+
+  test "transfers bookmarks to user_to_keep's watch list" do
+    talk = talks(:one)
+    watch_list = WatchList.create!(user: @user_to_merge, name: "My List")
+    WatchListTalk.create!(watch_list: watch_list, talk: talk)
+
+    merge
+    @user_to_keep.reload
+
+    assert @user_to_keep.watch_lists.joins(:watch_list_talks).where(watch_list_talks: {talk: talk}).exists?
+    assert_equal 0, @user_to_merge.reload.watch_lists.count
+  end
+
+  test "transfers favorite_users to user_to_keep" do
+    other_user = User.create!(name: "Other User", github_handle: "other-merge-test")
+    FavoriteUser.create!(user: @user_to_merge, favorite_user: other_user)
+
+    merge
+    @user_to_keep.reload
+
+    assert @user_to_keep.favorite_users.exists?(favorite_user: other_user)
+    assert_equal 0, @user_to_merge.reload.favorite_users.count
+  end
+
+  test "does not create self-referential favorite after merge" do
+    FavoriteUser.create!(user: @user_to_merge, favorite_user: @user_to_keep)
+
+    merge
+    @user_to_keep.reload
+
+    assert_not @user_to_keep.favorite_users.exists?(favorite_user: @user_to_keep)
+  end
+
+  test "transfers favorited_by to user_to_keep" do
+    other_user = User.create!(name: "Fan User", github_handle: "fan-merge-test")
+    FavoriteUser.create!(user: other_user, favorite_user: @user_to_merge)
+
+    merge
+    @user_to_keep.reload
+
+    assert @user_to_keep.favorited_by.exists?(user: other_user)
+    assert_equal 0, @user_to_merge.reload.favorited_by.count
+  end
+
+  test "copies blank profile fields from merged user to user_to_keep" do
+    @user_to_merge.update_columns(bio: "Expert Ruby developer", twitter: "duplicate_handle")
+
+    merge
+    @user_to_keep.reload
+
+    assert_equal "Expert Ruby developer", @user_to_keep.bio
+    assert_equal "duplicate_handle", @user_to_keep.twitter
+  end
+
+  test "does not overwrite existing profile fields on user_to_keep" do
+    @user_to_keep.update_columns(bio: "Original bio")
+    @user_to_merge.update_columns(bio: "Duplicate bio")
+
+    merge
+    @user_to_keep.reload
+
+    assert_equal "Original bio", @user_to_keep.bio
+  end
+
+  test "clears github_handle on merged user" do
+    merge
+    assert_nil @user_to_merge.reload.github_handle
+  end
+
+  test "copies github_handle from merged user if user_to_keep has none" do
+    @user_to_keep.update_columns(github_handle: nil, slug: "canonical-merge-test")
+    @user_to_merge.update_columns(github_handle: "duplicate-merge-test")
+
+    merge
+    @user_to_keep.reload
+
+    assert_equal "duplicate-merge-test", @user_to_keep.github_handle
+  end
+end

--- a/test/services/merge_users_service_test.rb
+++ b/test/services/merge_users_service_test.rb
@@ -10,14 +10,10 @@ class MergeUsersServiceTest < ActiveSupport::TestCase
     MergeUsersService.new(user_to_keep: @user_to_keep, user_to_merge: @user_to_merge).call
   end
 
-  test "marks merged user for deletion" do
+  test "destroys merged user" do
+    id = @user_to_merge.id
     merge
-    assert @user_to_merge.reload.marked_for_deletion
-  end
-
-  test "sets canonical_id on merged user" do
-    merge
-    assert_equal @user_to_keep.id, @user_to_merge.reload.canonical_id
+    assert_not User.exists?(id)
   end
 
   test "creates an alias for the merged user's name on user_to_keep" do
@@ -33,11 +29,9 @@ class MergeUsersServiceTest < ActiveSupport::TestCase
 
     merge
     @user_to_keep.reload
-    @user_to_merge.reload
 
     assert_includes @user_to_keep.talks, talk1
     assert_includes @user_to_keep.talks, talk2
-    assert_equal 0, @user_to_merge.talks.count
   end
 
   test "does not duplicate talks already on user_to_keep" do
@@ -60,7 +54,6 @@ class MergeUsersServiceTest < ActiveSupport::TestCase
     @user_to_keep.reload
 
     assert_equal 1, @user_to_keep.event_participations.where(event: event).count
-    assert_equal 0, @user_to_merge.reload.event_participations.count
   end
 
   test "transfers watched talks to user_to_keep" do
@@ -71,7 +64,6 @@ class MergeUsersServiceTest < ActiveSupport::TestCase
     @user_to_keep.reload
 
     assert @user_to_keep.watched_talks.exists?(talk: talk)
-    assert_equal 0, @user_to_merge.reload.watched_talks.count
   end
 
   test "does not duplicate watched talks already on user_to_keep" do
@@ -94,7 +86,6 @@ class MergeUsersServiceTest < ActiveSupport::TestCase
     @user_to_keep.reload
 
     assert @user_to_keep.watch_lists.joins(:watch_list_talks).where(watch_list_talks: {talk: talk}).exists?
-    assert_equal 0, @user_to_merge.reload.watch_lists.count
   end
 
   test "transfers favorite_users to user_to_keep" do
@@ -105,7 +96,6 @@ class MergeUsersServiceTest < ActiveSupport::TestCase
     @user_to_keep.reload
 
     assert @user_to_keep.favorite_users.exists?(favorite_user: other_user)
-    assert_equal 0, @user_to_merge.reload.favorite_users.count
   end
 
   test "does not create self-referential favorite after merge" do
@@ -125,7 +115,6 @@ class MergeUsersServiceTest < ActiveSupport::TestCase
     @user_to_keep.reload
 
     assert @user_to_keep.favorited_by.exists?(user: other_user)
-    assert_equal 0, @user_to_merge.reload.favorited_by.count
   end
 
   test "copies blank profile fields from merged user to user_to_keep" do
@@ -146,11 +135,6 @@ class MergeUsersServiceTest < ActiveSupport::TestCase
     @user_to_keep.reload
 
     assert_equal "Original bio", @user_to_keep.bio
-  end
-
-  test "clears github_handle on merged user" do
-    merge
-    assert_nil @user_to_merge.reload.github_handle
   end
 
   test "copies github_handle from merged user if user_to_keep has none" do


### PR DESCRIPTION
## Description

 - Transfers talks, event participations, event involvements
  - Transfers watched talks (with duplicate guard)
  - Transfers bookmarks (watch lists → user_to_keep's default watch list)
  - Transfers favorite_users and favorited_by (skipping self-referential cases)
  - Merges blank profile fields from the merged user
  - Marks the merged user for deletion with canonical_id set

## Screensh

<img width="1867" height="918" alt="Screenshot 2026-04-19 at 22 17 22" src="https://github.com/user-attachments/assets/67c95e82-da76-4ae3-abe4-9a7f1a1da952" />
ots

<img width="1875" height="844" alt="Screenshot 2026-04-19 at 22 20 58" src="https://github.com/user-attachments/assets/bd40f67c-8601-4569-b505-26d397c9b448" />


## Testing Steps
- Find duplicate users
- Access the admin panel
- Select the duplicate user
- Click on the "Assign Canonical User" action and choose the user to keep

## References
- closes #1610
