### PR TITLE
Update tickets URL for Blastoff Rails 2026 event

### DIFF
--- a/data/blastoffrails/blastoffrails-2026/event.yml
+++ b/data/blastoffrails/blastoffrails-2026/event.yml
@@ -13,7 +13,7 @@ banner_background: "#fef0d4"
 featured_background: "#fef0d4"
 featured_color: "#b64023"
 website: "https://blastoffrails.com"
-tickets_url: "https://ti.to/blastoff-rails/2025"
+tickets_url: "https://ti.to/blastoff-rails/2026"
 coordinates:
   latitude: 35.097735421515075
   longitude: -106.6682148179672


### PR DESCRIPTION
## Description
There was an old ticket url that I neglected to update. It is broken now so this fixes it.
