### PR TITLE
First contribution - Fix: ActionView::StrictLocalsError when loading contributions via Turbo

### DIFF
--- a/app/views/contributions/_events_without_dates.html.erb
+++ b/app/views/contributions/_events_without_dates.html.erb
@@ -1,12 +1,12 @@
-<%# locals: (events_without_dates:) %>
+<%# locals: () %>
 
 <%= turbo_frame_tag "events_without_dates" do %>
-  <h2 class="mb-4">Events without conference dates (<%= events_without_dates.flat_map(&:last).count %>)</h2>
+  <h2 class="mb-4">Events without conference dates (<%= @events_without_dates.flat_map(&:last).count %>)</h2>
 
   <article class="prose mb-6">This section lists events that are missing conference dates. Adding conference dates allows us to show when this event took place, so we could show them in a calendar or similar.</article>
 
   <div id="events-without-dates" class="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3 gap-4 min-w-full mb-6">
-    <% events_without_dates.each do |file_path, events| %>
+    <% @events_without_dates.each do |file_path, events| %>
       <%= link_to "https://github.com/rubyevents/rubyevents/edit/main/#{file_path}", id: "event-#{file_path}", class: "hover:bg-gray-100 p-4 rounded-lg border bg-white", target: :_blank do %>
         <div class="flex flex-col">
           <h3 class="line-clamp-1"><pre>Data File: <%= file_path %></pre></h3>

--- a/app/views/contributions/_events_without_location.html.erb
+++ b/app/views/contributions/_events_without_location.html.erb
@@ -1,12 +1,12 @@
-<%# locals: (events_without_location:) %>
+<%# locals: () %>
 
 <%= turbo_frame_tag "events_without_location" do %>
-  <h2 class="mb-4">Events without locations (<%= events_without_location.flat_map(&:last).count %>)</h2>
+  <h2 class="mb-4">Events without locations (<%= @events_without_location.flat_map(&:last).count %>)</h2>
 
   <article class="prose mb-6">This section lists events that are missing location information. By adding a location, we can show in which city/country this event took place.</article>
 
   <div id="events-without-locations" class="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3 gap-4 min-w-full mb-6">
-    <% events_without_location.each do |file_path, events| %>
+    <% @events_without_location.each do |file_path, events| %>
       <%= link_to "https://github.com/rubyevents/rubyevents/edit/main/#{file_path}", id: "event-#{file_path}", class: "hover:bg-gray-100 p-4 rounded-lg border bg-white", target: :_blank do %>
         <div class="flex flex-col">
           <h3 class="line-clamp-1"><pre>Data File: <%= file_path %></pre></h3>

--- a/app/views/contributions/_events_without_videos.html.erb
+++ b/app/views/contributions/_events_without_videos.html.erb
@@ -1,12 +1,12 @@
-<%# locals: (events_without_videos:) %>
+<%# locals: () %>
 
 <%= turbo_frame_tag "events_without_videos" do %>
-  <h2 class="mb-4">Events without videos (<%= events_without_videos.flat_map(&:last).count %>)</h2>
+  <h2 class="mb-4">Events without videos (<%= @events_without_videos.flat_map(&:last).count %>)</h2>
 
   <article class="prose mb-6">This section highlights events that do not have associated videos available. Explore these events to see if the talks weren't recorded or just not yet added the site.</article>
 
   <div id="events-without-locations" class="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3 gap-4 min-w-full mb-6">
-    <% events_without_videos.each do |series, events| %>
+    <% @events_without_videos.each do |series, events| %>
       <%= content_tag :div, id: dom_id(series, "without-videos"), class: "p-4 rounded-lg border bg-white", target: :_blank do %>
         <div class="flex flex-col">
           <h3 class="line-clamp-1"><p>Event Series: <%= link_to series.name, series_path(series), class: "hover:underline" %></p></h3>

--- a/app/views/contributions/_missing_videos_cue.html.erb
+++ b/app/views/contributions/_missing_videos_cue.html.erb
@@ -1,14 +1,14 @@
-<%# locals: (missing_videos_cue:, missing_videos_cue_count:) %>
+<%# locals: () %>
 
 <%= turbo_frame_tag "missing_videos_cue" do %>
-  <h2 class="mb-4">Missing Video Cues (<%= missing_videos_cue_count %>)</h2>
+  <h2 class="mb-4">Missing Video Cues (<%= @missing_videos_cue_count %>)</h2>
 
   <article class="prose mb-6">
     This section highlights talks that have child talks but are missing video cues. You can help by adding video cues to these talks so we can let users play the the talk from the exact time it starts.
   </article>
 
   <div id="talks-dates-out-of-bounds" class="grid sm:grid-cols-1 lg:grid-cols-2 xl:grid-cols-2 gap-4 min-w-full mb-6">
-    <% missing_videos_cue.each do |event, talks| %>
+    <% @missing_videos_cue.each do |event, talks| %>
       <%= content_tag :div, id: dom_id(event), class: "p-4 rounded-lg border bg-white", target: :_blank do %>
         <article class="prose">
           <h3 class="line-clamp-1">Event: <%= event.name %></h3>

--- a/app/views/contributions/_speakers_without_github.html.erb
+++ b/app/views/contributions/_speakers_without_github.html.erb
@@ -1,12 +1,12 @@
-<%# locals: (speakers_without_github:) %>
+<%# locals: () %>
 
 <%= turbo_frame_tag "speakers_without_github" do %>
-  <h2 class="mb-4">Speakers without GitHub handles (<%= speakers_without_github.count %>)</h2>
+  <h2 class="mb-4">Speakers without GitHub handles (<%= @speakers_without_github.count %>)</h2>
 
   <article class="prose mb-6">These speakers are currently missing a GitHub handle. By adding a GitHub handle to their profile, we can enhance their speaker profiles with an avatar and automatically retrieve additional information.</article>
 
   <div id="speakers" class="grid sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 min-w-full mb-6">
-    <% speakers_without_github.each do |speaker| %>
+    <% @speakers_without_github.each do |speaker| %>
       <%= content_tag :div, id: dom_id(speaker), class: "flex justify-between p-4 rounded-lg border bg-white" do %>
         <span><%= link_to speaker.name, edit_profile_path(speaker), class: "underline link", data: {turbo_frame: "modal"} %></span>
         <span>

--- a/app/views/contributions/_talks_dates_out_of_bounds.html.erb
+++ b/app/views/contributions/_talks_dates_out_of_bounds.html.erb
@@ -1,19 +1,19 @@
-<%# locals: (out_of_bound_talks:, dates_by_event_name:) %>
+<%# locals: () %>
 
 <%= turbo_frame_tag "talks_dates_out_of_bounds" do %>
-  <h2 class="mb-4">Review Talk Dates (<%= out_of_bound_talks.flat_map(&:last).count %>)</h2>
+  <h2 class="mb-4">Review Talk Dates (<%= @out_of_bound_talks.flat_map(&:last).count %>)</h2>
 
   <article class="prose mb-6">This section shows talks with dates that don't quite match the event dates. Sometimes we only have the year for certain events, so we use that as a reference.</article>
 
   <div id="talks-dates-out-of-bounds" class="grid sm:grid-cols-1 lg:grid-cols-2 xl:grid-cols-2 gap-4 min-w-full mb-6">
-    <% out_of_bound_talks.select { |_event, talks| talks.any? }.each do |event, talks| %>
+    <% @out_of_bound_talks.select { |_event, talks| talks.any? }.each do |event, talks| %>
       <%= content_tag :div, id: dom_id(event), class: "p-4 rounded-lg border bg-white", target: :_blank do %>
         <article class="prose">
           <h3 class="line-clamp-1">Event: <%= event.name %></h3>
 
           <b class="mt-4 mb-2">Talk date is outside event dates:</b>
 
-          <p class="mb-2">Event Dates: <%= dates_by_event_name[event.name].inspect %></p>
+          <p class="mb-2">Event Dates: <%= @dates_by_event_name[event.name].inspect %></p>
 
           <ul>
             <% talks.each do |talk| %>

--- a/app/views/contributions/_talks_without_slides.html.erb
+++ b/app/views/contributions/_talks_without_slides.html.erb
@@ -1,12 +1,12 @@
-<%# locals: (talks_without_slides:) %>
+<%# locals: () %>
 
 <%= turbo_frame_tag "talks_without_slides" do %>
-  <h2 class="mb-4">Talks without slides (<%= talks_without_slides.count %>)</h2>
+  <h2 class="mb-4">Talks without slides (<%= @talks_without_slides.count %>)</h2>
 
   <article class="prose mb-6">These talks currently do not have slides attached. However, we know that the speaker has an account on Speakerdeck where they usually upload their slides. Feel free to explore if these talks have associated slidedecks on Speakerdeck.com.</article>
 
   <div id="speakers" class="grid sm:grid-cols-1 lg:grid-cols-2 xl:grid-cols-2 gap-4 min-w-full mb-6">
-    <% talks_without_slides.each do |talk| %>
+    <% @talks_without_slides.each do |talk| %>
       <%= link_to edit_talk_path(talk), id: dom_id(talk), class: "hover:bg-gray-100 p-4 rounded-lg border bg-white" do %>
         <div class="flex flex-col">
           <span class="font-bold"><%= talk.title %></span>

--- a/app/views/contributions/show.html.erb
+++ b/app/views/contributions/show.html.erb
@@ -1,16 +1,16 @@
 <% case @step %>
 <% when :speakers_without_github %>
-  <%= render "contributions/speakers_without_github", locals: {speakers_without_github: @speakers_without_github} %>
+  <%= render "contributions/speakers_without_github" %>
 <% when :talks_without_slides %>
-  <%= render "contributions/talks_without_slides", locals: {talks_without_slides: @talks_without_slides} %>
+  <%= render "contributions/talks_without_slides" %>
 <% when :events_without_videos %>
-  <%= render "contributions/events_without_videos", locals: {events_without_videos: @events_without_videos} %>
+  <%= render "contributions/events_without_videos" %>
 <% when :events_without_location %>
-  <%= render "contributions/events_without_location", locals: {events_without_location: @events_without_location} %>
+  <%= render "contributions/events_without_location" %>
 <% when :events_without_dates %>
-  <%= render "contributions/events_without_dates", locals: {events_without_dates: @events_without_dates} %>
+  <%= render "contributions/events_without_dates" %>
 <% when :talks_dates_out_of_bounds %>
-  <%= render "contributions/talks_dates_out_of_bounds", locals: {out_of_bound_talks: @out_of_bound_talks, dates_by_event_name: @dates_by_event_name} %>
+  <%= render "contributions/talks_dates_out_of_bounds" %>
 <% when :missing_videos_cue %>
-  <%= render "contributions/missing_videos_cue", locals: {missing_videos_cue: @missing_videos_cue, missing_videos_cue_count: @missing_videos_cue_count} %>
+  <%= render "contributions/missing_videos_cue" %>
 <% end %>


### PR DESCRIPTION
Hi @ChaelCodes , 

It was great meeting you at Rails Girls São Paulo! You mentioned that I could take a look at the contributions section of your website, so I've put together this PR with the fixes for the rendering issue. 

Let me know if you’d like me to change anything. Hope you're doing well!

Best,
Carla Valdivia

## Description
`contributions/views/show.html.erb `- replaced strict locals with instance variables in contributions partials to ensure proper rendering when Turbo frames load them dynamically.   

  When Turbo frame requests rendered partials with strict locals declarations, Rails raised                             
  `ActionView::StrictLocalsError `because the local variables weren't being passed correctly through Turbo's rendering    
  pipeline.  

## Screenshots
Before changes: 
<img width="799" height="471" alt="Screenshot 2026-04-26 at 22 09 46" src="https://github.com/user-attachments/assets/fb378ae0-2a5d-4a84-9d67-edef002c108a" />


After changes:
<img width="1266" height="621" alt="Screenshot 2026-04-26 at 21 54 24" src="https://github.com/user-attachments/assets/0e1d288c-84ec-434e-a910-797c9cf81af5" />


## Testing Steps
Visit `/contributions` and click any menu option (speakers without github handles, talks without slides)