### PR TITLE
Add entry for sponsors out of order to issues

### DIFF
--- a/docs/ADDING_SPONSORS.md
+++ b/docs/ADDING_SPONSORS.md
@@ -9,11 +9,13 @@ Sponsor data is stored in YAML files within the conference/event directories. Ea
 ## File Structure
 
 Sponsors are stored in YAML files at:
+
 ```
 data/{series-name}/{event-name}/sponsors.yml
 ```
 
 For example:
+
 - [`data/rubykaigi/rubykaigi-2025/sponsors.yml`](https://github.com/rubyevents/rubyevents/blob/main/data/rubykaigi/rubykaigi-2025/sponsors.yml)
 - [`data/railsconf/railsconf-2025/sponsors.yml`](https://github.com/rubyevents/rubyevents/blob/main/data/railsconf/railsconf-2025/sponsors.yml)
 
@@ -87,6 +89,7 @@ bin/rails g sponsors --event-series tropicalrb --event tropical-on-rails-2026
 ### 3. Gather Sponsor Information
 
 For each sponsor, collect:
+
 - Official company name
 - Company website URL
 - Logo image URL (preferably high-resolution)
@@ -140,6 +143,7 @@ bin/dev
 - **Invalid YAML syntax**: Check indentation (use spaces, not tabs)
 - **Missing required fields**: Ensure all required properties are present
 - **Old sponsor logos**: All sponsor logos listed in any sponsors file are associated with a sponsor, and the first logo stored is displayed
+- **Sponsors out of order**: Enter sponsors in the correct order in the file, which may not be how they are displayed
 
 ## Submission Process
 
@@ -154,6 +158,7 @@ bin/dev
 ## Need Help?
 
 If you have questions about contributing sponsors:
+
 - Open an issue on GitHub
 - Check existing sponsors files for examples
 - Reference this documentation


### PR DESCRIPTION
## Description
- The order that sponsors appear on the event website could be significant because a sponsor appearing first may have donated more.
- Currently, sponsors do not necessarily appear in the order they are in the YAML file, but this may be added in the future.
- As long as they are in the desired order in the YAML file, it is fine/expected that they do not appear in that order on the sponsor page.
- There are some whitespace changes here, possibly from Prettier?

