### PR TITLE
Add troubleshooting section for Git error

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,15 @@ All file changes will be present locally when you close the container.
 
 - Clone RubyEvents with https, it tends to behave better, and new `gh auth login` commands won't generate new ssh keys.
 - If you cannot fetch or push, use `gh auth login` to auth with GitHub.
+- If you cannot push and get this error:
+
+  ```
+  /opt/homebrew/bin/gh auth git-credential erase: 1: /opt/homebrew/bin/gh: not found
+  remote: Invalid username or token. Password authentication is not supported for Git operations.
+  ```
+
+  use `gh auth setup-git`.
+
 - After the container is set up, run `bin/dev` in the terminal to start the development server. The application will be forwarded to [localhost:3000](localhost:3000).
 - To run system tests, use `HEADLESS=true bin/rails test`. The HEADLESS=true environment variable ensures Chrome runs in headless mode, which is required in the container environment.
 


### PR DESCRIPTION
## Description
I ran into this error while setting up the app for the first time.  I had successfully cloned down the branch, and my `gh auth login` was successful, but when pushing I got:

```
root@cd9121867033:/rails# git push origin brr-2026-adding-sponsors
/opt/homebrew/bin/gh auth git-credential get: 1: /opt/homebrew/bin/gh: not found
/opt/homebrew/bin/gh auth git-credential erase: 1: /opt/homebrew/bin/gh: not found
remote: Invalid username or token. Password authentication is not supported for Git operations.
fatal: Authentication failed for 'https://github.com/katiebuilds/rubyevents.git/'
```

After running `gh auth setup-git`, I could successfully push up to my branch.
