### PR TITLE
Sponsor import bug

### DIFF
--- a/app/models/static/event.rb
+++ b/app/models/static/event.rb
@@ -413,9 +413,9 @@ module Static
 
             organisation_ids << organization.id
 
-            sponsor = event.sponsors.find_or_initialize_by(organization:, event:)
-            sponsor.assign_attributes(tier: tier["name"], badge: sponsor["badge"], level: tier["level"])
-            sponsor.save! if sponsor.changed? || sponsor.new_record?
+            sponsor_record = event.sponsors.find_or_initialize_by(organization:, event:)
+            sponsor_record.assign_attributes(tier: tier["name"], badge: sponsor["badge"], level: tier["level"])
+            sponsor_record.save! if sponsor_record.changed? || sponsor_record.new_record?
           end
         end
       end

--- a/test/models/static/event_test.rb
+++ b/test/models/static/event_test.rb
@@ -44,6 +44,17 @@ class Static::EventTest < ActiveSupport::TestCase
     assert event_record.sponsors.exists?
   end
 
+  test "import_sponsors! imports sponsor attributes" do
+    Static::EventSeries.find_by_slug("balkanruby").import_series!
+    event = Static::Event.find_by_slug("balkanruby-2025")
+    event_record = event.import_event!
+    event.import_sponsors!(event_record)
+    assert event_record.sponsors.exists?
+    avo = Organization.find_by(name: "Avo")
+    avo_sponsor = event_record.sponsors.find_by(organization: avo)
+    assert_equal "Party Sponsor", avo_sponsor.badge
+  end
+
   test "import_transcripts!" do
     Static::EventSeries.find_by_slug("helveticruby").import_series!
     event = Static::Event.find_by_slug(SLUG)


### PR DESCRIPTION
## Description
I ran into this issue while working on another branch to add sponsors for Blue Ridge Ruby 2026.  I kept trying to add the `Passport Sponsor` badge for one of the sponsors, and it just wasn't showing up.  Turns out, it was nil in the database.

Since that PR hasn't been opened yet, my test is for an existing sponsor with a badge.  

## Screenshots
With a badge, it should look like this:
<img width="586" height="698" alt="image" src="https://github.com/user-attachments/assets/d937358b-7139-4f90-a9e4-5caf197f7128" />


## Testing Steps
1. Go to an event sponsor page (for example, `http://localhost:3000/events/blue-ridge-ruby-2026/sponsors`)
2. Add a badge attribute to a sponsor in that event's sponsor YAML file (for example, `data/blue-ridge-ruby/blue-ridge-ruby-2026/sponsors.yml`)
3. Reseed your database with that event (you can do this without reseeding the whole database like this `bin/rails db:seed:event_series[blue-ridge-ruby]`) 
4. Refresh the page and ensure that the badge shows up

## References
TODO: link to other PR when it exists

