### PR TITLE
Add additional sponsors to Blue Ridge Ruby 2026

### DIFF
--- a/data/blue-ridge-ruby/blue-ridge-ruby-2026/sponsors.yml
+++ b/data/blue-ridge-ruby/blue-ridge-ruby-2026/sponsors.yml
@@ -66,3 +66,8 @@
           website: "https://launchpadlab.com/"
           slug: "launchpad-lab"
           logo_url: "https://blueridgeruby.com/images/sponsors/launchpad-lab.svg"
+
+        - name: "Practical Computer"
+          website: "https://practical.computer/"
+          slug: "practical-computer"
+          logo_url: "https://blueridgeruby.com/images/sponsors/practical-computer.svg"

--- a/data/blue-ridge-ruby/blue-ridge-ruby-2026/sponsors.yml
+++ b/data/blue-ridge-ruby/blue-ridge-ruby-2026/sponsors.yml
@@ -13,6 +13,11 @@
     - name: "Sapphire"
       level: 2
       sponsors:
+        - name: "simpliphy"
+          website: "https://simpliphy.com/"
+          slug: "simpliphy"
+          logo_url: "https://blueridgeruby.com/images/sponsors/simpliphy.svg"
+
         - name: "Anonymous"
           website: "https://blueridgeruby.com/#sponsors"
           slug: "anonymous"

--- a/data/blue-ridge-ruby/blue-ridge-ruby-2026/sponsors.yml
+++ b/data/blue-ridge-ruby/blue-ridge-ruby-2026/sponsors.yml
@@ -61,3 +61,8 @@
           website: "https://www.bookbub.com/"
           slug: "bookbub"
           logo_url: "https://blueridgeruby.com/images/sponsors/bookbub.svg"
+
+        - name: "LaunchPad Lab"
+          website: "https://launchpadlab.com/"
+          slug: "launchpad-lab"
+          logo_url: "https://blueridgeruby.com/images/sponsors/launchpad-lab.svg"

--- a/data/blue-ridge-ruby/blue-ridge-ruby-2026/sponsors.yml
+++ b/data/blue-ridge-ruby/blue-ridge-ruby-2026/sponsors.yml
@@ -71,3 +71,8 @@
           website: "https://practical.computer/"
           slug: "practical-computer"
           logo_url: "https://blueridgeruby.com/images/sponsors/practical-computer.svg"
+
+        - name: "SOFware"
+          website: "https://sofwarellc.com/"
+          slug: "sofware"
+          logo_url: "https://blueridgeruby.com/images/sponsors/sofware.svg"

--- a/data/blue-ridge-ruby/blue-ridge-ruby-2026/sponsors.yml
+++ b/data/blue-ridge-ruby/blue-ridge-ruby-2026/sponsors.yml
@@ -76,3 +76,8 @@
           website: "https://sofwarellc.com/"
           slug: "sofware"
           logo_url: "https://blueridgeruby.com/images/sponsors/sofware.svg"
+
+        - name: "thoughtbot"
+          website: "https://thoughtbot.com/"
+          slug: "thoughtbot"
+          logo_url: "https://blueridgeruby.com/images/sponsors/thoughtbot.svg"

--- a/data/blue-ridge-ruby/blue-ridge-ruby-2026/sponsors.yml
+++ b/data/blue-ridge-ruby/blue-ridge-ruby-2026/sponsors.yml
@@ -39,3 +39,8 @@
           website: "https://www.scoutapm.com"
           slug: "scout-monitoring"
           logo_url: "https://blueridgeruby.com/images/sponsors/scout_monitoring.svg"
+
+        - name: "HYBRD"
+          website: "https://hybrd.co/"
+          slug: "hybrd"
+          logo_url: "https://blueridgeruby.com/images/sponsors/hybrd.svg"

--- a/data/blue-ridge-ruby/blue-ridge-ruby-2026/sponsors.yml
+++ b/data/blue-ridge-ruby/blue-ridge-ruby-2026/sponsors.yml
@@ -53,3 +53,11 @@
           website: "https://avohq.io/"
           slug: "avo"
           logo_url: "https://blueridgeruby.com/images/sponsors/avo.svg"
+
+    - name: "Travel Sponsors"
+      level: 5
+      sponsors:
+        - name: "BookBub"
+          website: "https://www.bookbub.com/"
+          slug: "bookbub"
+          logo_url: "https://blueridgeruby.com/images/sponsors/bookbub.svg"

--- a/data/blue-ridge-ruby/blue-ridge-ruby-2026/sponsors.yml
+++ b/data/blue-ridge-ruby/blue-ridge-ruby-2026/sponsors.yml
@@ -81,3 +81,8 @@
           website: "https://thoughtbot.com/"
           slug: "thoughtbot"
           logo_url: "https://blueridgeruby.com/images/sponsors/thoughtbot.svg"
+
+        - name: "TRMNL"
+          website: "https://trmnl.com/"
+          slug: "trmnl"
+          logo_url: "https://blueridgeruby.com/images/sponsors/trmnl.svg"

--- a/data/blue-ridge-ruby/blue-ridge-ruby-2026/sponsors.yml
+++ b/data/blue-ridge-ruby/blue-ridge-ruby-2026/sponsors.yml
@@ -1,6 +1,3 @@
-# docs/ADDING_SPONSORS.md
-# Do not remove todo until event is over and all sponsors are added.
-# TODO: Add missing sponsors.
 ---
 - tiers:
     - name: "Ruby"

--- a/data/blue-ridge-ruby/blue-ridge-ruby-2026/sponsors.yml
+++ b/data/blue-ridge-ruby/blue-ridge-ruby-2026/sponsors.yml
@@ -44,3 +44,12 @@
           website: "https://hybrd.co/"
           slug: "hybrd"
           logo_url: "https://blueridgeruby.com/images/sponsors/hybrd.svg"
+
+    - name: "Sponsors"
+      level: 4
+      sponsors:
+        - name: "Avo"
+          badge: "Passport Sponsor"
+          website: "https://avohq.io/"
+          slug: "avo"
+          logo_url: "https://blueridgeruby.com/images/sponsors/avo.svg"


### PR DESCRIPTION
## Description
I have added all the other sponsors currently listed on https://blueridgeruby.com/

## References
This PR is what I originally intended to do, and it caused 3 others:
- https://github.com/rubyevents/rubyevents/pull/1678
- https://github.com/rubyevents/rubyevents/pull/1679
- https://github.com/rubyevents/rubyevents/pull/1682
