### PR TITLE
Add CFP for Toronto Ruby Meetup

### DIFF
--- a/data/toronto-ruby/toronto-ruby-meetup/cfp.yml
+++ b/data/toronto-ruby/toronto-ruby-meetup/cfp.yml
@@ -1,0 +1,2 @@
+---
+- link: "https://github.com/toronto-ruby/talks"


### PR DESCRIPTION
## Description
This PR adds a Call for Proposals (CFP) for the Toronto Ruby meetup.

## Testing Steps
1. Run the seed command to create the CFP:
`bin/rails db:seed:event_series[toronto-ruby]
`

2. Visit the CFP page:  
http://localhost:3000/cfp  
- Confirm that the Toronto Ruby CFP appears in the list

3. Click on **"Submit your Talk Proposal"** for the Toronto Ruby meetup:  
http://localhost:3000/events/toronto-ruby-meetup/cfp  
- Verify that it redirects to:  
  https://github.com/toronto-ruby/talks  

## References
#1317 

