### PR TITLE
Fix "Content missing" on /contributions sub-tabs

### DIFF
--- a/app/views/contributions/show.html.erb
+++ b/app/views/contributions/show.html.erb
@@ -1,16 +1,16 @@
 <% case @step %>
 <% when :speakers_without_github %>
-  <%= render "contributions/speakers_without_github", locals: {speakers_without_github: @speakers_without_github} %>
+  <%= render "contributions/speakers_without_github", speakers_without_github: @speakers_without_github %>
 <% when :talks_without_slides %>
-  <%= render "contributions/talks_without_slides", locals: {talks_without_slides: @talks_without_slides} %>
+  <%= render "contributions/talks_without_slides", talks_without_slides: @talks_without_slides %>
 <% when :events_without_videos %>
-  <%= render "contributions/events_without_videos", locals: {events_without_videos: @events_without_videos} %>
+  <%= render "contributions/events_without_videos", events_without_videos: @events_without_videos %>
 <% when :events_without_location %>
-  <%= render "contributions/events_without_location", locals: {events_without_location: @events_without_location} %>
+  <%= render "contributions/events_without_location", events_without_location: @events_without_location %>
 <% when :events_without_dates %>
-  <%= render "contributions/events_without_dates", locals: {events_without_dates: @events_without_dates} %>
+  <%= render "contributions/events_without_dates", events_without_dates: @events_without_dates %>
 <% when :talks_dates_out_of_bounds %>
-  <%= render "contributions/talks_dates_out_of_bounds", locals: {out_of_bound_talks: @out_of_bound_talks, dates_by_event_name: @dates_by_event_name} %>
+  <%= render "contributions/talks_dates_out_of_bounds", out_of_bound_talks: @out_of_bound_talks, dates_by_event_name: @dates_by_event_name %>
 <% when :missing_videos_cue %>
-  <%= render "contributions/missing_videos_cue", locals: {missing_videos_cue: @missing_videos_cue, missing_videos_cue_count: @missing_videos_cue_count} %>
+  <%= render "contributions/missing_videos_cue", missing_videos_cue: @missing_videos_cue, missing_videos_cue_count: @missing_videos_cue_count %>
 <% end %>


### PR DESCRIPTION
The render calls in contributions/show.html.erb used `render "partial", locals: {...}`. With the positional-string form, the trailing hash *is* the locals — so `locals:` became a single local named `:locals` instead of being unpacked. Strict-locals partials raised StrictLocalsError, the show action 500'd, and Turbo rendered "Content missing" in the affected frames.

Switched to the shorthand `render "partial", key: value` so locals are passed through correctly.

## Testing Steps

- https://www.rubyevents.org/contributions

  https://github.com/user-attachments/assets/ffebab42-4a5c-453d-8a0b-39c2d36a1f5f

### This PR

- http://127.0.0.1:3000/contributions
- click all sub tabs

https://github.com/user-attachments/assets/c9a9e0b7-a39b-4ed5-bf5e-e5280342541f

