### PR TITLE
Add Nantes RB event mai 2026

### DIFF
--- a/data/nantes-rb/nantes-rb-meetup/videos.yml
+++ b/data/nantes-rb/nantes-rb-meetup/videos.yml
@@ -15,7 +15,39 @@
     Après les présentations, place à l'apéro ! Une belle occasion pour échanger, rencontrer d'autres membres de la communauté Ruby et élargir votre réseau dans une ambiance détendue.
     https://www.meetup.com/nantes-rb/events/312784976/
   language: "french"
-  talks: []
+  talks:
+    - title: "Une application Rails pour partager trop de photos avec trop peu de gens"
+      raw_title: "Une application Rails pour partager trop de photos avec trop peu de gens"
+      speakers:
+        - Louis Quenault
+      event_name: "Nantes.rb Meetup janvier 2026"
+      language: "french"
+      date: "2026-01-27"
+      published_at: "2026-01-01"
+      video_provider: "children"
+      id: "louis-nantes-rb-meetup-january-2026"
+      video_id: "NantesLouis20260127"
+      description: |-
+        Par Louis
+        Nantes.rb Meetup janvier 2026
+        Merci au Wagon Nantes de nous avoir accueillis.
+        https://www.lewagon.com/nantes
+    - title: "Coolify une alternative aux PaaS"
+      raw_title: "Coolify une alternative aux PaaS"
+      speakers:
+        - Francoise Dumas
+      event_name: "Nantes.rb Meetup janvier 2026"
+      language: "french"
+      date: "2026-01-27"
+      published_at: "2026-01-01"
+      video_provider: "children"
+      id: "francois-nantes-rb-meetup-january-2026"
+      video_id: "NantesFrancois20260127"
+      description: |-
+        Par François
+        Nantes.rb Meetup janvier 2026
+        Merci au Wagon Nantes de nous avoir accueillis.
+        https://www.lewagon.com/nantes
 - id: "nantes-rb-meetup-february-2026"
   title: "Nantes.rb Meetup February 2026"
   date: "2026-02-26"
@@ -32,7 +64,39 @@
     Après la conférence, nous vous proposons d'aller boire un verre dans le bar le plus proche. C'est une occasion idéale pour se connecter avec des professionnels du même domaine et élargir votre réseau.
     https://www.meetup.com/nantes-rb/events/313202692/
   language: "french"
-  talks: []
+  talks:
+    - title: "Ecoconception et accessibilité Web"
+      raw_title: "Ecoconception et accessibilité Web"
+      speakers:
+        - Mathieu Vigou
+      event_name: "Nantes.rb Meetup février 2026"
+      language: "french"
+      date: "2026-02-26"
+      published_at: "2026-02-01"
+      video_provider: "children"
+      id: "mathieu-nantes-rb-meetup-february-2026"
+      video_id: "NantesMathieu20260226"
+      description: |-
+        Par Mathieu
+        Nantes.rb Meetup février 2026
+        Merci à l'Ouvre-Boites de nous avoir accueillis.
+        https://www.ouvre-boites.coop/
+    - title: "Comment construire ses images Docker plus rapidement"
+      raw_title: "Comment construire ses images Docker plus rapidement"
+      speakers:
+        - Benoit Tigeot
+      event_name: "Nantes.rb Meetup février 2026"
+      language: "french"
+      date: "2026-02-26"
+      published_at: "2026-02-01"
+      video_provider: "children"
+      id: "benoit-nantes-rb-meetup-february-2026"
+      video_id: "NantesBenoit20260226"
+      description: |-
+        Par Benoit
+        Nantes.rb Meetup février 2026
+        Merci à l'Ouvre-Boites de nous avoir accueillis.
+        https://www.ouvre-boites.coop/
 - id: "nantes-rb-meetup-march-2026"
   title: "Nantes.rb Meetup mars 2026"
   date: "2026-03-24"
@@ -62,5 +126,55 @@
     Après la conférence, nous dans le bar le plus proche pour échanger avec d'autres membres de la communauté Ruby. C'est une occasion idéale pour se connecter avec des professionnels du même domaine et élargir votre réseau.
 
     https://www.meetup.com/nantes-rb/events/314193140/
+  language: "french"
+  talks:
+    - title: "Clever Cloud news"
+      raw_title: "Clever Cloud news"
+      speakers:
+        - Horacio Gonzalez
+      event_name: "Nantes.rb Meetup avril 2026"
+      language: "french"
+      date: "2026-04-30"
+      published_at: "2026-04-01"
+      video_provider: "children"
+      id: "horacio-nantes-rb-meetup-april-2026"
+      video_id: "NantesHoracio20260430"
+      description: |-
+        Par Horacio
+        Nantes.rb Meetup avril 2026
+        Merci à Clever Cloud de nous avoir accueillis.
+        https://www.clever.cloud/
+    - title: "Packwerk chez Osponso"
+      raw_title: "Packwerk chez Osponso"
+      speakers:
+        - Vincent Piau
+      event_name: "Nantes.rb Meetup avril 2026"
+      language: "french"
+      date: "2026-04-30"
+      published_at: "2026-04-01"
+      video_provider: "children"
+      id: "vincent-nantes-rb-meetup-april-2026"
+      video_id: "NantesVincent20260430"
+      description: |-
+        Par Vincent
+        Nantes.rb Meetup avril 2026
+        Merci à Clever Cloud de nous avoir accueillis.
+        https://www.clever.cloud/
+- id: "nantes-rb-meetup-mai-2026"
+  title: "Nantes.rb Meetup mai 2026"
+  date: "2026-05-28"
+  video_id: "nantes-rb-meetup-mai-2026"
+  video_provider: "children"
+  description: |-
+    Ce mois ci Nantes RB se déroulera au sein de l'événement La nuit des communautés!
+
+    Pour vous inscrire le lien ci dessous
+    https://my.weezevent.com/la-nuit-des-meetups-5
+
+    Le programme complet de la soirée
+    https://celestial-infinity-698.notion.site/la-nuit-des-communautes-2026
+    Soyez nombreuses et nombreux à venir!
+
+    https://www.meetup.com/nantes-rb/events/314623266
   language: "french"
   talks: []

--- a/data/nantes-rb/nantes-rb-meetup/videos.yml
+++ b/data/nantes-rb/nantes-rb-meetup/videos.yml
@@ -26,7 +26,7 @@
       published_at: "2026-01-01"
       video_provider: "children"
       id: "louis-nantes-rb-meetup-january-2026"
-      video_id: "NantesLouis20260127"
+      video_id: "louis-nantes-rb-meetup-january-2026"
       description: |-
         Par Louis
         Nantes.rb Meetup janvier 2026
@@ -42,7 +42,7 @@
       published_at: "2026-01-01"
       video_provider: "children"
       id: "francois-nantes-rb-meetup-january-2026"
-      video_id: "NantesFrancois20260127"
+      video_id: "francois-nantes-rb-meetup-january-2026"
       description: |-
         Par François
         Nantes.rb Meetup janvier 2026
@@ -75,7 +75,7 @@
       published_at: "2026-02-01"
       video_provider: "children"
       id: "mathieu-nantes-rb-meetup-february-2026"
-      video_id: "NantesMathieu20260226"
+      video_id: "mathieu-nantes-rb-meetup-february-2026"
       description: |-
         Par Mathieu
         Nantes.rb Meetup février 2026
@@ -91,7 +91,7 @@
       published_at: "2026-02-01"
       video_provider: "children"
       id: "benoit-nantes-rb-meetup-february-2026"
-      video_id: "NantesBenoit20260226"
+      video_id: "benoit-nantes-rb-meetup-february-2026"
       description: |-
         Par Benoit
         Nantes.rb Meetup février 2026
@@ -138,7 +138,7 @@
       published_at: "2026-04-01"
       video_provider: "children"
       id: "horacio-nantes-rb-meetup-april-2026"
-      video_id: "NantesHoracio20260430"
+      video_id: "horacio-nantes-rb-meetup-april-2026"
       description: |-
         Par Horacio
         Nantes.rb Meetup avril 2026
@@ -154,7 +154,7 @@
       published_at: "2026-04-01"
       video_provider: "children"
       id: "vincent-nantes-rb-meetup-april-2026"
-      video_id: "NantesVincent20260430"
+      video_id: "vincent-nantes-rb-meetup-april-2026"
       description: |-
         Par Vincent
         Nantes.rb Meetup avril 2026


### PR DESCRIPTION
## Description
Add Mai event

## Screenshots
<img width="625" height="224" alt="Screenshot 2026-05-04 at 14 57 05" src="https://github.com/user-attachments/assets/db3ca916-95f1-447f-b9ce-90b807fc5520" />


## Testing Steps
Event displayed without issue after running seeds

## Questions
@ChaelCodes I added talks as exchanged last time https://github.com/rubyevents/rubyevents/pull/1622#pullrequestreview-4109285251 but I wonder how we should generate the `video_id`, I used a pattern `{City}{Speaker}{date}` `"NantesFrancois20260127"` hopefully it's ok!

