### PR TITLE
Latest Talks should display the talks that occurred most recently

### DIFF
--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -3,7 +3,7 @@ class PageController < ApplicationController
 
   def home
     home_page_cached_data = Rails.cache.fetch("home_page_content", expires_in: 1.hour) do
-      latest_talks = Talk.watchable.with_speakers.order(published_at: :desc).limit(10)
+      latest_talks = Talk.watchable.with_speakers.order(date: :desc).limit(10)
       {
         talks_count: Talk.count,
         speakers_count: User.speakers.count,

--- a/app/views/page/home.html.erb
+++ b/app/views/page/home.html.erb
@@ -108,7 +108,7 @@
     <div class="flex flex-col gap-12 mt-12">
       <section class="flex flex-col w-full gap-4">
         <div class="flex items-center justify-between w-full">
-          <h2 class="text-primary shrink-0">Latest talks</h2>
+          <h2 class="text-primary shrink-0">Latest videos</h2>
           <%= link_to "see all talks", talks_path, class: "link text-right w-full" %>
         </div>
 


### PR DESCRIPTION
Ordering on `published_at` results in the talks that were published most recently being displayed as the "Latest Talks", meaning if there's a significant delay between giving the talk and the video being published, it would be considered more recent than talks that were given since then.  Ordering by date seems like the more desired behavior here.

## Description
<!-- Please describe your changes. -->
Changed `Talk.watchable.with_speakers.order(published_at: :desc)` to `Talk.watchable.with_speakers.order(date: :desc)`

## Screenshots
<!-- Add screenshots or GIFs if applicable. -->

## Testing Steps
<!-- List steps to test your changes. -->
<!-- If this is a content PR, link to the affected pages -->
1. Bring up the main page: localhost:3000
2. Scroll down to the "Latest Talks" section
3. The displayed talks should all be from "Ruby Community Conference Winter Edition 2026", as that currently appears to be the most recent set of talks that are watchable.  At the time of writing this PR the displayed latest talks are all from "Ruby Montevideo Meetup July 2025"
<img width="1560" height="387" alt="Screenshot 2026-05-05 at 7 16 22 PM" src="https://github.com/user-attachments/assets/a13aa863-132b-49fd-9c3c-09703d8d4601" />


## References
<!-- Link to related issues, discussions, other PRs, or references you used to write the PR. -->
- closes #1674 
