### PR TITLE
Show Today on the Schedule

### DIFF
--- a/app/controllers/events/schedules_controller.rb
+++ b/app/controllers/events/schedules_controller.rb
@@ -8,7 +8,7 @@ class Events::SchedulesController < ApplicationController
       return
     end
 
-    @day = @days.first
+    @day = helpers.selected_schedule_day(@days)
     set_talks(@day)
   end
 

--- a/app/helpers/events/schedules_helper.rb
+++ b/app/helpers/events/schedules_helper.rb
@@ -1,5 +1,6 @@
 module Events::SchedulesHelper
-  def selected_schedule_day(days, today: Time.zone.today.to_s)
+  def selected_schedule_day(days)
+    today = Time.zone.today.to_s
     days.detect { |day| day["date"] == today } || days.first
   end
 end

--- a/app/helpers/events/schedules_helper.rb
+++ b/app/helpers/events/schedules_helper.rb
@@ -1,5 +1,5 @@
 module Events::SchedulesHelper
   def selected_schedule_day(days, today: Time.zone.today)
-    days.detect{ |day| day["date"] == today } || days.first
+    days.detect { |day| day["date"] == today } || days.first
   end
 end

--- a/app/helpers/events/schedules_helper.rb
+++ b/app/helpers/events/schedules_helper.rb
@@ -1,0 +1,5 @@
+module Events::SchedulesHelper
+  def selected_schedule_day(days, today: Time.zone.today)
+    days.detect{ |day| day["date"] == today } || days.first
+  end
+end

--- a/app/helpers/events/schedules_helper.rb
+++ b/app/helpers/events/schedules_helper.rb
@@ -1,5 +1,5 @@
 module Events::SchedulesHelper
-  def selected_schedule_day(days, today: Time.zone.today)
+  def selected_schedule_day(days, today: Time.zone.today.to_s)
     days.detect { |day| day["date"] == today } || days.first
   end
 end

--- a/test/helpers/events/schedules_helper_test.rb
+++ b/test/helpers/events/schedules_helper_test.rb
@@ -2,8 +2,8 @@ require "test_helper"
 
 class Events::SchedulesHelperTest < ActionView::TestCase
   setup do
-    @day1 = { "date" => "2026-07-20" }
-    @day2 = { "date" => "2026-07-21" }
+    @day1 = {"date" => "2026-07-20"}
+    @day2 = {"date" => "2026-07-21"}
     @days = [@day1, @day2]
   end
 

--- a/test/helpers/events/schedules_helper_test.rb
+++ b/test/helpers/events/schedules_helper_test.rb
@@ -8,14 +8,20 @@ class Events::SchedulesHelperTest < ActionView::TestCase
   end
 
   test "selects the schedule day matching today" do
-    assert_equal @day2, selected_schedule_day(@days, today: "2026-07-21")
+    travel_to Date.new(2026, 7, 21) do
+      assert_equal @day2, selected_schedule_day(@days)
+    end
   end
 
   test "returns the first day before the event" do
-    assert_equal @day1, selected_schedule_day(@days, today: "2026-01-01")
+    travel_to Date.new(2026, 7, 19) do
+      assert_equal @day1, selected_schedule_day(@days)
+    end
   end
 
   test "returns the first day after the event" do
-    assert_equal @day1, selected_schedule_day(@days, today: "2027-01-01")
+    travel_to Date.new(2026, 7, 22) do
+      assert_equal @day1, selected_schedule_day(@days)
+    end
   end
 end

--- a/test/helpers/events/schedules_helper_test.rb
+++ b/test/helpers/events/schedules_helper_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class Events::SchedulesHelperTest < ActionView::TestCase
+  setup do
+    @day1 = { "date" => "2026-07-20" }
+    @day2 = { "date" => "2026-07-21" }
+    @days = [@day1, @day2]
+  end
+
+  test "selects the schedule day matching today" do
+    assert_equal @day2, selected_schedule_day(@days, today: "2026-07-21")
+  end
+
+  test "returns the first day before the event" do
+    assert_equal @day1, selected_schedule_day(@days, today: "2026-01-01")
+  end
+
+  test "returns the first day after the event" do
+    assert_equal @day1, selected_schedule_day(@days, today: "2027-01-01")
+  end
+end


### PR DESCRIPTION
Add selected_schedule_day helper method, and use it to determine the day to show:

If today is:
* before or after the event, display the first day of the event
* during the event, display today

## Description
<!-- Please describe your changes. -->
Added:
* a helper (Events::SchedulesHelper) with the `selected_schedule_day` method
* invoking it from the events/schedules_controller
* tests for the new helper

## Screenshots
<!-- Add screenshots or GIFs if applicable. -->

## Testing Steps
<!-- List steps to test your changes. -->
<!-- If this is a content PR, link to the affected pages -->
1. Visit the schedule page for an event that has already happened, and the first day of the schedule should display by default
2. Visit the schedule page for an event that hasn't happened yet, and the first day of the schedule should display by default
3. Visit the schedule page for an event that is currently in progress, and whichever tab in the schedule corresponds to "today" should be displayed by default.  This is the trickiest part of the process to test since it requires a multi-day event to currently be in progress and on day 2 or higher in order to see behavior different from cases 1 and 2 above.

## References
<!-- Link to related issues, discussions, other PRs, or references you used to write the PR. -->
- closes #1628 
