### PR TITLE
Change tense of cancelled message, don’t show coming soon if cancelled

### DIFF
--- a/app/views/events/_header.html.erb
+++ b/app/views/events/_header.html.erb
@@ -17,7 +17,7 @@
 
 <% if event.static_metadata.cancelled? %>
   <div class="bg-red-600 text-white text-center py-3 font-semibold text-lg">
-    This event <%= (event.start_date.present? && event.start_date < Date.today) ? "was cancelled." : "has been cancelled." %>
+    This event <%= event.start_date&.past? ? "was cancelled." : "has been cancelled." %>
   </div>
 <% end %>
 

--- a/app/views/events/_header.html.erb
+++ b/app/views/events/_header.html.erb
@@ -17,7 +17,7 @@
 
 <% if event.static_metadata.cancelled? %>
   <div class="bg-red-600 text-white text-center py-3 font-semibold text-lg">
-    This event has been cancelled.
+    This event <%= (event.start_date.present? && event.start_date < Date.today) ? "was cancelled." : "has been cancelled." %>
   </div>
 <% end %>
 

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -198,7 +198,7 @@
         </section>
       <% end %>
 
-      <% if @event.talks.empty? && @event.speakers.empty? && @sponsors.empty? %>
+      <% if @event.talks.empty? && @event.speakers.empty? && @sponsors.empty? && !@event.static_metadata.cancelled? %>
         <div class="text-center py-12">
           <div class="max-w-md mx-auto">
             <div class="text-6xl mb-4">🎤</div>


### PR DESCRIPTION
- for future events, banner shows "has been cancelled", for past events "was cancelled"
- don't show the Coming Soon block for empty events if event was cancelled
