### PR TITLE
Add Friendly.rb 2025 Schedule

### DIFF
--- a/data/friendly-rb/friendly-rb-2025/schedule.yml
+++ b/data/friendly-rb/friendly-rb-2025/schedule.yml
@@ -98,8 +98,6 @@ days:
       - start_time: "15:00"
         end_time: "15:30"
         slots: 1
-        items:
-          - "Dan Singerman - Code is writing, know your reader"
 
       - start_time: "15:30"
         end_time: "16:00"

--- a/data/friendly-rb/friendly-rb-2025/schedule.yml
+++ b/data/friendly-rb/friendly-rb-2025/schedule.yml
@@ -8,98 +8,123 @@ days:
         end_time: "10:00"
         slots: 1
         items:
-          - Registration
+          - "Registration"
+
       - start_time: "10:00"
         end_time: "10:30"
         slots: 1
         items:
-          - Opening
+          - "Opening"
+
       - start_time: "10:30"
         end_time: "11:00"
         slots: 1
+
       - start_time: "11:00"
         end_time: "11:30"
         slots: 1
+
       - start_time: "11:30"
         end_time: "12:00"
         slots: 1
+
       - start_time: "12:00"
         end_time: "12:30"
         slots: 1
+
       - start_time: "13:00"
         end_time: "15:00"
         slots: 1
         items:
-          - Lunch
+          - "Lunch"
+
       - start_time: "15:00"
         end_time: "15:30"
         slots: 1
+
       - start_time: "15:30"
         end_time: "16:00"
         slots: 1
+
       - start_time: "16:00"
         end_time: "16:30"
         slots: 1
+
       - start_time: "16:30"
         end_time: "17:00"
         slots: 1
+
       - start_time: "17:00"
         end_time: "17:30"
         slots: 1
+
       - start_time: "18:30"
         end_time: "20:00"
         slots: 1
         items:
-          - Guided Bucharest Walking Tour
+          - "Guided Bucharest Walking Tour"
+
       - start_time: "20:00"
         end_time: "20:00"
         slots: 1
         items:
-          - Afterparty at Fire Club
+          - "Afterparty at Fire Club"
+
   - name: "Day 2"
     date: "2025-09-11"
     grid:
       - start_time: "10:00"
         end_time: "10:30"
         slots: 1
+
       - start_time: "10:30"
         end_time: "11:00"
         slots: 1
+
       - start_time: "11:00"
         end_time: "11:30"
         slots: 1
+
       - start_time: "11:30"
         end_time: "12:00"
         slots: 1
+
       - start_time: "13:00"
         end_time: "15:00"
         slots: 1
         items:
-          - Lunch
+          - "Lunch"
+
       - start_time: "15:00"
         end_time: "15:30"
         slots: 1
         items:
-          - Dan Singerman - Code is writing, know your reader
+          - "Dan Singerman - Code is writing, know your reader"
+
       - start_time: "15:30"
         end_time: "16:00"
         slots: 1
+
       - start_time: "16:00"
         end_time: "16:30"
         slots: 1
+
       - start_time: "16:30"
         end_time: "17:00"
         slots: 1
+
       - start_time: "18:30"
         end_time: "18:30"
         slots: 1
         items:
           - "Closing"
+
       - start_time: "18:30"
         end_time: "19:00"
         slots: 1
         items:
           - "Drinks at Ironic Taproom"
+
   - name: "Day 3"
     date: "2025-09-12"
     grid:
@@ -107,4 +132,4 @@ days:
         end_time: "09:20"
         slots: 1
         items:
-          - Train Ride to the Mountains
+          - "Train Ride to the Mountains"

--- a/data/friendly-rb/friendly-rb-2025/schedule.yml
+++ b/data/friendly-rb/friendly-rb-2025/schedule.yml
@@ -1,0 +1,110 @@
+# Schedule: https://friendlyrb.com/edition-2025.html
+---
+days:
+  - name: "Day 1"
+    date: "2025-09-10"
+    grid:
+      - start_time: "09:00"
+        end_time: "10:00"
+        slots: 1
+        items:
+          - Registration
+      - start_time: "10:00"
+        end_time: "10:30"
+        slots: 1
+        items:
+          - Opening
+      - start_time: "10:30"
+        end_time: "11:00"
+        slots: 1
+      - start_time: "11:00"
+        end_time: "11:30"
+        slots: 1
+      - start_time: "11:30"
+        end_time: "12:00"
+        slots: 1
+      - start_time: "12:00"
+        end_time: "12:30"
+        slots: 1
+      - start_time: "13:00"
+        end_time: "15:00"
+        slots: 1
+        items:
+          - Lunch
+      - start_time: "15:00"
+        end_time: "15:30"
+        slots: 1
+      - start_time: "15:30"
+        end_time: "16:00"
+        slots: 1
+      - start_time: "16:00"
+        end_time: "16:30"
+        slots: 1
+      - start_time: "16:30"
+        end_time: "17:00"
+        slots: 1
+      - start_time: "17:00"
+        end_time: "17:30"
+        slots: 1
+      - start_time: "18:30"
+        end_time: "20:00"
+        slots: 1
+        items:
+          - Guided Bucharest Walking Tour
+      - start_time: "20:00"
+        end_time: "20:00"
+        slots: 1
+        items:
+          - Afterparty at Fire Club
+  - name: "Day 2"
+    date: "2025-09-11"
+    grid:
+      - start_time: "10:00"
+        end_time: "10:30"
+        slots: 1
+      - start_time: "10:30"
+        end_time: "11:00"
+        slots: 1
+      - start_time: "11:00"
+        end_time: "11:30"
+        slots: 1
+      - start_time: "11:30"
+        end_time: "12:00"
+        slots: 1
+      - start_time: "13:00"
+        end_time: "15:00"
+        slots: 1
+        items:
+          - Lunch
+      - start_time: "15:00"
+        end_time: "15:30"
+        slots: 1
+        items:
+          - Dan Singerman - Code is writing, know your reader
+      - start_time: "15:30"
+        end_time: "16:00"
+        slots: 1
+      - start_time: "16:00"
+        end_time: "16:30"
+        slots: 1
+      - start_time: "16:30"
+        end_time: "17:00"
+        slots: 1
+      - start_time: "18:30"
+        end_time: "18:30"
+        slots: 1
+        items:
+          - "Closing"
+      - start_time: "18:30"
+        end_time: "19:00"
+        slots: 1
+        items:
+          - "Drinks at Ironic Taproom"
+  - name: "Day 3"
+    date: "2025-09-12"
+    grid:
+      - start_time: "09:20"
+        end_time: "09:20"
+        slots: 1
+        items:
+          - Train Ride to the Mountains

--- a/data/friendly-rb/friendly-rb-2025/videos.yml
+++ b/data/friendly-rb/friendly-rb-2025/videos.yml
@@ -177,6 +177,19 @@
   speakers:
     - Nicolas Erlichman
 
+- id: "dan-singerman-friendly-rb-2025"
+  title: "Code is writing, know your reader"
+  raw_title: "Friendly.rb 2025 - Code is writing, know your reader by Dan Singerman"
+  event_name: "Friendly.rb 2025"
+  date: "2025-09-11"
+  language: "en"
+  video_provider: "not_published"
+  video_id: "dan-singerman-friendly-rb-2025"
+  description: |-
+    Highlighting code as a narrative intended for a human audiences from Dan Singerman, CTO at Reason Factory.
+  speakers:
+    - Dan Singerman
+
 - id: "jakob-cosoroaba-friendly-rb-2025"
   title: "Game Show"
   raw_title: "Friendly.rb 2025 - ✨Game show✨ by Jakob Cosoroabă"


### PR DESCRIPTION
## Description
This change adds the three-day schedule for [Friendly.rb 2025](https://www.rubyevents.org/events/friendly-rb-2025/schedule).

**Please note**: Day 3 - Friday (Sep 12, 2025), is simply a gathering (Train Ride to the Mountains). There are no speakers, but I added it for posterity and am happy to remove. I'm pulling the schedule data from [https://friendlyrb.com/edition-2025.html](https://friendlyrb.com/edition-2025.html), and am assuming talks are 30min in length.

Also, we don't currently have the 2nd day speaker data which appears at 15:00, so I added it manually (Dan Singerman - Code is writing, know your reader).

## Screenshots

### Day 1
<img width="3966" height="6726" alt="friendly-rb-2025-schedule-day-1" src="https://github.com/user-attachments/assets/21f4f7e4-44b5-4225-8542-6fccba5f5b55" />

### Day 2
<img width="3966" height="5844" alt="friendly-rb-2025-schedule-day-2" src="https://github.com/user-attachments/assets/73a5ede2-38e9-4daf-a743-d82e904ad516" />

### Day 3
<img width="3966" height="2916" alt="friendly-rb-2025-schedule-day-3" src="https://github.com/user-attachments/assets/a45bb750-3154-427d-8fe5-9483263edfc6" />


## Testing Steps
I ran `bin/rails db:seed:all` since the event is from 2025, and `bin/lint` to format the `schedule.yml` file.
<!-- If this is a content PR, link to the affected pages -->

## References
This is in reference to the current list found on [https://www.rubyevents.org/contributions](https://www.rubyevents.org/contributions).