### PR TITLE
The Red Hat auto-formatter splits long urls with a \

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -48,5 +48,6 @@
     "lib/schemas/tiers_sponsors_schema.json": "data/**/sponsors.yml",
     "lib/schemas/venue_schema.json": "data/**/venue.yml",
     "lib/schemas/videos_schema.json": "**/videos.yml",
-  }
+  },
+  "yaml.format.enable": false
 }


### PR DESCRIPTION
## Description
<!-- Please describe your changes. -->
The red-hat auto-formatter splits long urls with a `\`. That's weird, and it looks weird. We should turn it off.

## Screenshots
<!-- Add screenshots or GIFs if applicable. -->

## Testing Steps
<!-- List steps to test your changes. -->
<!-- If this is a content PR, link to the affected pages -->
Edit a file with a long link or url - perhaps a CFP using VS Code and the default recommended extensions.
Observe the the link is **not** split or auto-formatted by red hat.

## References
<!-- Link to related issues, discussions, other PRs, or references you used to write the PR. -->
- closes #<!-- issue number -->
