### PR TITLE
adding content for ArtificialRuby.ai July 2025 meetup

### DIFF
--- a/data/artificialruby/artificialruby/videos.yml
+++ b/data/artificialruby/artificialruby/videos.yml
@@ -188,14 +188,13 @@
       speakers:
         - Brian Fountain
 
-# July 2025
-
 - id: "artificial-ruby-meetup-july-2025"
   title: "ArtificialRuby.ai Meetup July 2025"
   raw_title: "ArtificialRuby.ai NYC Meetup"
   video_id: "artificial-ruby-meetup-july-2025"
   video_provider: "children"
   date: "2025-07-16"
+  published_at: "2025-07-23"
   thumbnail_xs: "https://images.lumacdn.com/cdn-cgi/image/format=auto,fit=cover,dpr=2,background=white,quality=75,width=400,height=400/event-covers/f6/89634ba1-0ca2-46e6-b0a6-b2a7117a894b.png"
   thumbnail_sm: "https://images.lumacdn.com/cdn-cgi/image/format=auto,fit=cover,dpr=2,background=white,quality=75,width=400,height=400/event-covers/f6/89634ba1-0ca2-46e6-b0a6-b2a7117a894b.png"
   thumbnail_md: "https://images.lumacdn.com/cdn-cgi/image/format=auto,fit=cover,dpr=2,background=white,quality=75,width=400,height=400/event-covers/f6/89634ba1-0ca2-46e6-b0a6-b2a7117a894b.png"
@@ -217,7 +216,9 @@
 
     Demos:
 
-    [COMING SOON]
+    * Patrick Karsh: “From Senior Rails Engineer to Startup Builder with Rails and AI”
+    * Sameen Karim: “Auto-documenting your analytics setup with AI”
+    * Amanda Bizzinotto: “Building a multi-agent system in Rails”
 
     If you are interested in speaking at future events, please fill out the form below. The demos are usually about 10 minutes and feature a cool AI tool or feature built in Ruby/Rails.
 
@@ -244,5 +245,37 @@
     By registering for this event, you agree to receive email communication from the Artificial Ruby team about future events and other community activities.
 
     https://lu.ma/vbbdhwm1
-  speakers:
-    - TBD
+  talks:
+    - title: "From Senior Rails Engineer to Startup Builder with Rails and AI"
+      event_name: "ArtificialRuby.ai Meetup July 2025"
+      date: "2025-07-16"
+      published_at: "2025-07-23"
+      video_provider: "youtube"
+      id: "patrick-karsh-artificialrubyai-meetup-july-2025"
+      video_id: "bNJhEa8m8Oo"
+      description: |-
+        How I scaled Rocket Advertiser Intelligence from 0 to 1,300 users in a year--while working full-time--using Rails and AI tools.
+      speakers:
+        - Patrick Karsh
+
+    - title: "Auto-documenting your analytics setup with AI"
+      event_name: "ArtificialRuby.ai Meetup July 2025"
+      date: "2025-07-16"
+      published_at: "2025-07-23"
+      video_provider: "youtube"
+      id: "sameen-karim-artificialrubyai-meetup-july-2025"
+      video_id: "9juEzPzOrNw"
+      description: |-
+        Every mature codebase has a rat's nest of data trackers and no one quite knows what they do. Can we use static analysis and LLMs to untangle it--and keep it clean forever?
+      speakers:
+        - Sameen Karim
+
+    - title: "Building a multi-agent system in Rails"
+      event_name: "ArtificialRuby.ai Meetup July 2025"
+      date: "2025-07-16"
+      published_at: "2025-07-23"
+      video_provider: "youtube"
+      id: "amanda-bizzinotto-artificialrubyai-meetup-july-2025"
+      video_id: "zPsog5Kg5zw"
+      speakers:
+        - Amanda Bizzinotto


### PR DESCRIPTION
## Description
<!-- Please describe your changes. -->
Adding content for the July 2025 ArtificialRuby.ai meetup

## Screenshots
<!-- Add screenshots or GIFs if applicable. -->

Events
<img width="1067" height="639" alt="Screenshot 2026-05-06 at 11 21 44 PM" src="https://github.com/user-attachments/assets/2f4355df-20bb-409e-a58c-d48a43f83e02" />

Talks
<img width="1548" height="417" alt="Screenshot 2026-05-06 at 11 21 51 PM" src="https://github.com/user-attachments/assets/d819196f-cb62-4cfd-a0bc-d7330e04a4e4" />


## Testing Steps
<!-- List steps to test your changes. -->
<!-- If this is a content PR, link to the affected pages -->
http://localhost:3000/events/artificialruby

## References
<!-- Link to related issues, discussions, other PRs, or references you used to write the PR. -->
- small piece of #1654 
