### PR TITLE
Add Friendly.rb 2023 Schedule

### DIFF
--- a/data/friendly-rb/friendly-rb-2023/schedule.yml
+++ b/data/friendly-rb/friendly-rb-2023/schedule.yml
@@ -1,0 +1,125 @@
+# Talk order: https://www.visuality.pl/posts/a-look-back-at-friendly-rb-2023
+---
+days:
+  - name: "Day 1"
+    date: "2023-09-27"
+    grid:
+      - start_time: "09:00"
+        end_time: "10:00"
+        slots: 1
+        items:
+          - "Registration"
+
+      - start_time: "10:00"
+        end_time: "10:15"
+        slots: 1
+        items:
+          - "Opening"
+
+      - start_time: "10:15"
+        end_time: "11:15"
+        slots: 1
+
+      - start_time: "11:30"
+        end_time: "11:50"
+        slots: 1
+
+      - start_time: "12:00"
+        end_time: "12:05"
+        slots: 1
+
+      - start_time: "12:15"
+        end_time: "12:35"
+        slots: 1
+
+      - start_time: "12:40"
+        end_time: "12:45"
+        slots: 1
+
+      - start_time: "13:00"
+        end_time: "15:00"
+        slots: 1
+        items:
+          - "Lunch Break"
+
+      - start_time: "15:00"
+        end_time: "15:30"
+        slots: 1
+
+      - start_time: "15:45"
+        end_time: "15:50"
+        slots: 1
+
+      - start_time: "16:15"
+        end_time: "16:35"
+        slots: 1
+
+      - start_time: "16:45"
+        end_time: "16:50"
+        slots: 1
+
+      - start_time: "17:15"
+        end_time: "17:55"
+        slots: 1
+
+      - start_time: "18:30"
+        end_time: "20:00"
+        slots: 1
+        items:
+          - "Guided Bucharest Walking Tour"
+
+      - start_time: "20:00"
+        end_time: "20:00"
+        slots: 1
+        items:
+          - "Drinks"
+
+  - name: "Day 2"
+    date: "2023-09-28"
+    grid:
+      - start_time: "10:00"
+        end_time: "10:20"
+        slots: 1
+
+      - start_time: "10:30"
+        end_time: "11:00"
+        slots: 1
+
+      - start_time: "11:15"
+        end_time: "11:45"
+        slots: 1
+
+      - start_time: "13:00"
+        end_time: "15:00"
+        slots: 1
+        items:
+          - "Lunch Break"
+
+      - start_time: "15:00"
+        end_time: "15:40"
+        slots: 1
+
+      - start_time: "15:45"
+        end_time: "15:50"
+        slots: 1
+
+      - start_time: "16:15"
+        end_time: "16:35"
+        slots: 1
+
+      - start_time: "16:45"
+        end_time: "16:50"
+        slots: 1
+
+      - start_time: "17:20"
+        end_time: "18:00"
+        slots: 1
+
+  - name: "Day 3"
+    date: "2023-09-29"
+    grid:
+      - start_time: "09:00"
+        end_time: "13:00"
+        slots: 1
+        items:
+          - "Day Trip to Sinaia"

--- a/data/friendly-rb/friendly-rb-2023/videos.yml
+++ b/data/friendly-rb/friendly-rb-2023/videos.yml
@@ -1,7 +1,4 @@
-# TODO: talks running order
-# TODO: talk dates
-# TODO: conference website
-# TODO: schedule website
+# Schedule: https://web.archive.org/web/20230925041806/https://friendlyrb.com/
 ---
 - id: "xavier-noria-friendlyrb-2023"
   title: "Zeitwerk Internals"
@@ -16,96 +13,18 @@
   speakers:
     - Xavier Noria
 
-- id: "marian-posceanu-friendlyrb-2023"
-  title: "Lightning Talk: Ruby and the Lisp"
-  raw_title: "Marian Posăceanu - Ruby and the Lisp - Lightning Talk"
-  event_name: "Friendly.rb 2023"
-  date: "2023-09-27"
-  published_at: "2023-12-07"
-  video_provider: "youtube"
-  video_id: "eOmF9SnIG5A"
-  description: |-
-    Marian is a talented Ruby developer from the seaside of Romania, where he's making the World Economic Forum stay on track while exploring his passions. He shared his passion for lisp at Friendly.rb.
-  speakers:
-    - Marian Posăceanu
-
-- id: "julian-cheal-friendlyrb-2023"
-  title: "Lightning Talk: Making music with Ruby and Sonic Pi"
-  raw_title: "Julian Cheal - Making music with Ruby and Sonic Pi - Lightning Talk"
-  event_name: "Friendly.rb 2023"
-  date: "2023-09-27"
-  published_at: "2023-12-06"
-  video_provider: "youtube"
-  video_id: "-oZVEAtdXDM"
-  description: |-
-    Julian Cheal is a British Ruby/Rails developer with a pen­chant for tweed, fine coffee, and homebrewing. At Friendly.rb he gave a cool demo on how one can create music using Sonic Pi and Ruby.
-  speakers:
-    - Julian Cheal
-
-- id: "ayush-newatia-friendlyrb-2023"
-  title: "Use Turbo Native to make hybrid apps that don't suck"
-  raw_title: "Ayush Newatia - Use Turbo Native to make hybrid apps that don't suck"
-  event_name: "Friendly.rb 2023"
-  date: "2023-09-27"
-  published_at: "2023-12-15"
-  video_provider: "youtube"
-  video_id: "N4g_raRF-cE"
-  description: |-
-    Ayush is the author of The Rails and Hotwire codex, Bridgetown core member, and Just a spec podcast host.
-  speakers:
-    - Ayush Newatia
-
-- id: "jason-swett-friendlyrb-2023"
-  title: "Getting the most out of Chat GPT"
-  raw_title: "Jason Swett - Getting the most out of Chat GPT"
+- id: "svyatoslav-kryukov-friendlyrb-2023"
+  title: "Let there be docs!"
+  raw_title: "Svyatoslav Kryukov - Let there be docs!"
   event_name: "Friendly.rb 2023"
   date: "2023-09-27"
   published_at: "2023-12-28"
   video_provider: "youtube"
-  video_id: "ga0h17TUuX0"
+  video_id: "P86lC2EskaY"
   description: |-
-    Jason Swett is the host of the Code with Jason podcast, Code with Jason Meetup, and author of his snail mail Nonsense Monthly and The Complete Guide to Rails Testing book.
+    Svyat is the funny one from Evil Martians.
   speakers:
-    - Jason Swett
-
-- id: "marian-dumitru-friendlyrb-2023"
-  title: "Lightning Talk: Become a Roma connoisseur in less than 5 minutes"
-  raw_title: "Marian Dumitru - Become a Roma connoisseur in less than 5 minutes - Lightning Talk"
-  event_name: "Friendly.rb 2023"
-  date: "2023-09-27"
-  published_at: "2023-12-14"
-  video_provider: "youtube"
-  video_id: "nN7MtpSNyhI"
-  description: |-
-    Marian Dumitru is a funny self-taught developer that shared with us the history of the Roma people.
-  speakers:
-    - Marian Dumitru
-
-- id: "irina-paraschiv-friendlyrb-2023"
-  title: "Mental Health for Developers"
-  raw_title: "Irina Paraschiv - Mental Health for Developers"
-  event_name: "Friendly.rb 2023"
-  date: "2023-09-27"
-  published_at: "2023-12-28"
-  video_provider: "youtube"
-  video_id: "bnKjnxUL1MI"
-  description: |-
-    Irina is a licensed Psychotherapist, Emotional Educator, and the Co-founder of Acertivo, the Mental Health platform, designed for agile teams
-  speakers:
-    - Irina Paraschiv
-
-- id: "elena-tnsoiu-friendlyrb-2023"
-  title: "Service modeling at GitHub"
-  raw_title: "Elena Tănăsoiu - Service modeling at GitHub"
-  event_name: "Friendly.rb 2023"
-  date: "2023-09-27"
-  published_at: "2023-12-28"
-  video_provider: "youtube"
-  video_id: "2G35mRB0WFk"
-  description: |-
-    Elena Tănăsoiu is a Senior Engineer at GitHub. She spoke about how they do service modeling and other things at GitHub.
-  speakers:
-    - Elena Tănăsoiu
+    - Svyatoslav Kryukov
 
 - id: "lorin-thwaits-friendlyrb-2023"
   title: "Lightning Talk: From a spreadsheet to a Rails app in 5 minutes"
@@ -133,59 +52,18 @@
   speakers:
     - Naijeria Toweett
 
-- id: "lucian-ghind-friendlyrb-2023"
-  title: "The state of the Rubyverse"
-  raw_title: "Lucian Ghindă - The state of the Rubyverse"
+- id: "marian-posceanu-friendlyrb-2023"
+  title: "Lightning Talk: Ruby and the Lisp"
+  raw_title: "Marian Posăceanu - Ruby and the Lisp - Lightning Talk"
   event_name: "Friendly.rb 2023"
   date: "2023-09-27"
-  published_at: "2023-12-08"
+  published_at: "2023-12-07"
   video_provider: "youtube"
-  video_id: "QrH2A70JlsM"
+  video_id: "eOmF9SnIG5A"
   description: |-
-    Lucian Ghindă is a passionate Ruby developer and the author of the Short Ruby Newsletter.
-    He was the best person to deliver the State of the Rubyverse with us as he watches everything that happens online with our beloved programming language.
+    Marian is a talented Ruby developer from the seaside of Romania, where he's making the World Economic Forum stay on track while exploring his passions. He shared his passion for lisp at Friendly.rb.
   speakers:
-    - Lucian Ghindă
-
-- id: "gabriela-luhova-friendlyrb-2023"
-  title: "The Power of We: Unleashing the Collective Strength of Your Team"
-  raw_title: "Gabriela Luhova - The Power of We: Unleashing the Collective Strength of Your Team"
-  event_name: "Friendly.rb 2023"
-  date: "2023-09-27"
-  published_at: "2023-12-28"
-  video_provider: "youtube"
-  video_id: "SLqb5x-Mu7w"
-  description: |-
-    Gabriela Luhova is a prominent Ruby community member from Bulgaria, Rails Girls, and Balkan Ruby co-organizer.
-  speakers:
-    - Gabriela Luhova
-
-- id: "jeremy-smith-friendlyrb-2023"
-  title: "Making it as an Indie Developer"
-  raw_title: "Jeremy Smith - Making it as an Indie Developer"
-  event_name: "Friendly.rb 2023"
-  date: "2023-09-27"
-  published_at: "2023-12-28"
-  slides_url: "https://speakerdeck.com/jeremysmithco/making-it-as-an-indie-developer"
-  video_provider: "youtube"
-  video_id: "HC2T5ekVXPg"
-  description: |-
-    Jeremy Smith is the co-host of the IndieRails podcast and Blue Ridge Ruby organizer.
-  speakers:
-    - Jeremy Smith
-
-- id: "svyatoslav-kryukov-friendlyrb-2023"
-  title: "Let there be docs!"
-  raw_title: "Svyatoslav Kryukov - Let there be docs!"
-  event_name: "Friendly.rb 2023"
-  date: "2023-09-27"
-  published_at: "2023-12-28"
-  video_provider: "youtube"
-  video_id: "P86lC2EskaY"
-  description: |-
-    Svyat is the funny one from Evil Martians.
-  speakers:
-    - Svyatoslav Kryukov
+    - Marian Posăceanu
 
 - id: "tom-de-bruijn-friendlyrb-2023"
   title: "Crafting elegant code with ruby DSLs"
@@ -201,32 +79,31 @@
   speakers:
     - Tom de Bruijn
 
-- id: "nick-sutterer-friendlyrb-2023"
-  title: "Beyond the service object"
-  raw_title: "Nick Sutterer - Beyond the service object"
+- id: "marian-dumitru-friendlyrb-2023"
+  title: "Lightning Talk: Become a Roma connoisseur in less than 5 minutes"
+  raw_title: "Marian Dumitru - Become a Roma connoisseur in less than 5 minutes - Lightning Talk"
   event_name: "Friendly.rb 2023"
   date: "2023-09-27"
-  published_at: "2023-12-28"
+  published_at: "2023-12-14"
   video_provider: "youtube"
-  video_id: "Eh2wATXq0_8"
+  video_id: "nN7MtpSNyhI"
   description: |-
-    Nick is an Open-Source developer at Trailblazer GmbH, pushing the limits of Ruby with his alternative frameworks.
+    Marian Dumitru is a funny self-taught developer that shared with us the history of the Roma people.
   speakers:
-    - Nick Sutterer
+    - Marian Dumitru
 
-- id: "yaroslav-shmarov-friendlyrb-2023"
-  title: "Lightning Talk: Hotwire Cookbook and common use cases"
-  raw_title: "Yaroslav Shmarov - Hotwire Cookbook and common use cases - Lightning Talk"
+- id: "irina-paraschiv-friendlyrb-2023"
+  title: "Mental Health for Developers"
+  raw_title: "Irina Paraschiv - Mental Health for Developers"
   event_name: "Friendly.rb 2023"
   date: "2023-09-27"
   published_at: "2023-12-28"
   video_provider: "youtube"
-  video_id: "fdMGUV_E4yU"
+  video_id: "bnKjnxUL1MI"
   description: |-
-    Yaroslav Shmarov is the co-host of the Friendly Show podcast, a content creator on SupeRails.com, and a prominent Ruby community member who focuses on education.
-    He gave a surprise (even from him) talk, encouraging us to try Hotwire.
+    Irina is a licensed Psychotherapist, Emotional Educator, and the Co-founder of Acertivo, the Mental Health platform, designed for agile teams
   speakers:
-    - Yaroslav Shmarov
+    - Irina Paraschiv
 
 - id: "victor-motogna-friendlyrb-2023"
   title: "Lightning Talk: Ruby, the hidden programming teacher"
@@ -240,3 +117,123 @@
     Victor Motogna is the Head of Web Development at Wolfpack Digital a well-known development agency from Cluj.
   speakers:
     - Victor Motogna
+
+- id: "nick-sutterer-friendlyrb-2023"
+  title: "Beyond the service object"
+  raw_title: "Nick Sutterer - Beyond the service object"
+  event_name: "Friendly.rb 2023"
+  date: "2023-09-27"
+  published_at: "2023-12-28"
+  video_provider: "youtube"
+  video_id: "Eh2wATXq0_8"
+  description: |-
+    Nick is an Open-Source developer at Trailblazer GmbH, pushing the limits of Ruby with his alternative frameworks.
+  speakers:
+    - Nick Sutterer
+
+- id: "elena-tnsoiu-friendlyrb-2023"
+  title: "Service modeling at GitHub"
+  raw_title: "Elena Tănăsoiu - Service modeling at GitHub"
+  event_name: "Friendly.rb 2023"
+  date: "2023-09-28"
+  published_at: "2023-12-28"
+  video_provider: "youtube"
+  video_id: "2G35mRB0WFk"
+  description: |-
+    Elena Tănăsoiu is a Senior Engineer at GitHub. She spoke about how they do service modeling and other things at GitHub.
+  speakers:
+    - Elena Tănăsoiu
+
+- id: "jason-swett-friendlyrb-2023"
+  title: "Getting the most out of Chat GPT"
+  raw_title: "Jason Swett - Getting the most out of Chat GPT"
+  event_name: "Friendly.rb 2023"
+  date: "2023-09-28"
+  published_at: "2023-12-28"
+  video_provider: "youtube"
+  video_id: "ga0h17TUuX0"
+  description: |-
+    Jason Swett is the host of the Code with Jason podcast, Code with Jason Meetup, and author of his snail mail Nonsense Monthly and The Complete Guide to Rails Testing book.
+  speakers:
+    - Jason Swett
+
+- id: "ayush-newatia-friendlyrb-2023"
+  title: "Use Turbo Native to make hybrid apps that don't suck"
+  raw_title: "Ayush Newatia - Use Turbo Native to make hybrid apps that don't suck"
+  event_name: "Friendly.rb 2023"
+  date: "2023-09-28"
+  published_at: "2023-12-15"
+  video_provider: "youtube"
+  video_id: "N4g_raRF-cE"
+  description: |-
+    Ayush is the author of The Rails and Hotwire codex, Bridgetown core member, and Just a spec podcast host.
+  speakers:
+    - Ayush Newatia
+
+- id: "lucian-ghind-friendlyrb-2023"
+  title: "The state of the Rubyverse"
+  raw_title: "Lucian Ghindă - The state of the Rubyverse"
+  event_name: "Friendly.rb 2023"
+  date: "2023-09-28"
+  published_at: "2023-12-08"
+  video_provider: "youtube"
+  video_id: "QrH2A70JlsM"
+  description: |-
+    Lucian Ghindă is a passionate Ruby developer and the author of the Short Ruby Newsletter.
+    He was the best person to deliver the State of the Rubyverse with us as he watches everything that happens online with our beloved programming language.
+  speakers:
+    - Lucian Ghindă
+
+- id: "julian-cheal-friendlyrb-2023"
+  title: "Lightning Talk: Making music with Ruby and Sonic Pi"
+  raw_title: "Julian Cheal - Making music with Ruby and Sonic Pi - Lightning Talk"
+  event_name: "Friendly.rb 2023"
+  date: "2023-09-28"
+  published_at: "2023-12-06"
+  video_provider: "youtube"
+  video_id: "-oZVEAtdXDM"
+  description: |-
+    Julian Cheal is a British Ruby/Rails developer with a pen­chant for tweed, fine coffee, and homebrewing. At Friendly.rb he gave a cool demo on how one can create music using Sonic Pi and Ruby.
+  speakers:
+    - Julian Cheal
+
+- id: "gabriela-luhova-friendlyrb-2023"
+  title: "The Power of We: Unleashing the Collective Strength of Your Team"
+  raw_title: "Gabriela Luhova - The Power of We: Unleashing the Collective Strength of Your Team"
+  event_name: "Friendly.rb 2023"
+  date: "2023-09-28"
+  published_at: "2023-12-28"
+  video_provider: "youtube"
+  video_id: "SLqb5x-Mu7w"
+  description: |-
+    Gabriela Luhova is a prominent Ruby community member from Bulgaria, Rails Girls, and Balkan Ruby co-organizer.
+  speakers:
+    - Gabriela Luhova
+
+- id: "yaroslav-shmarov-friendlyrb-2023"
+  title: "Lightning Talk: Hotwire Cookbook and common use cases"
+  raw_title: "Yaroslav Shmarov - Hotwire Cookbook and common use cases - Lightning Talk"
+  event_name: "Friendly.rb 2023"
+  date: "2023-09-28"
+  published_at: "2023-12-28"
+  video_provider: "youtube"
+  video_id: "fdMGUV_E4yU"
+  description: |-
+    Yaroslav Shmarov is the co-host of the Friendly Show podcast, a content creator on SupeRails.com, and a prominent Ruby community member who focuses on education.
+    He gave a surprise (even from him) talk, encouraging us to try Hotwire.
+  speakers:
+    - Yaroslav Shmarov
+
+- id: "jeremy-smith-friendlyrb-2023"
+  title: "Making it as an Indie Developer"
+  raw_title: "Jeremy Smith - Making it as an Indie Developer"
+  event_name: "Friendly.rb 2023"
+  date: "2023-09-28"
+  published_at: "2023-12-28"
+  slides_url: "https://speakerdeck.com/jeremysmithco/making-it-as-an-indie-developer"
+  video_provider: "youtube"
+  video_id: "HC2T5ekVXPg"
+  description: |-
+    Jeremy Smith is the co-host of the IndieRails podcast and Blue Ridge Ruby organizer.
+  speakers:
+    - Jeremy Smith


### PR DESCRIPTION
## Description
I added the [Friendly.rb Conf 2023](https://friendlyrb.com/edition-2023.html) schedule. The most accurate reference that I found was from an [archived version of the event](https://web.archive.org/web/20230925041806/https://friendlyrb.com/), supplemented with a [Visuality blog post](https://www.visuality.pl/posts/a-look-back-at-friendly-rb-2023) recapping everything. For speaker timings, I tried to stay true to the video lengths while assuming brief breaks between talks—blocking everything to the quarter hour.

## Screenshots
### Day 1
<img width="1280" height="2940" alt="friendly-rb-2023-day-1" src="https://github.com/user-attachments/assets/94fde366-dfaf-44ac-bc62-8dd2fa49398c" />

### Day 2
<img width="1280" height="2312" alt="friendly-rb-2023-day-2" src="https://github.com/user-attachments/assets/8de5f83d-885e-46c5-aebb-e06d923292e8" />

### Day 3
<img width="1280" height="1127" alt="friendly-rb-2023-day-3" src="https://github.com/user-attachments/assets/94786397-77d6-426f-8569-87257a30e718" />

## Testing Steps
Lint: `bin/lint`
Seed everything from prod for safety: `bin/rails db:seed:all`

This PR adds content for [https://www.rubyevents.org/events/friendly-rb-2023/schedule](https://www.rubyevents.org/events/friendly-rb-2023/schedule).

## References
Reference: [https://github.com/rubyevents/rubyevents/blob/main/docs/ADDING_SCHEDULES.md](https://github.com/rubyevents/rubyevents/blob/main/docs/ADDING_SCHEDULES.md)