### PR TITLE
Use dates without timezones for full date coverage in ical export

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -360,8 +360,8 @@ class Event < ApplicationRecord
   def to_ical
     Icalendar::Event.new.tap do |event|
       event.uid = "RUBYEVENTS-#{id}"
-      event.dtstart = start_date
-      event.dtend = end_date + 1.day # dtend is exclusive, add 1 day to make it inclusive
+      event.dtstart = Icalendar::Values::Date.new(start_date)
+      event.dtend = Icalendar::Values::Date.new(end_date + 1.day) # dtend is exclusive, add 1 day to make it inclusive
       event.summary = name
       event.description = description
       event.location = static_metadata.location

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -272,6 +272,26 @@ class EventTest < ActiveSupport::TestCase
 
   test "to_ical returns a Icalendar::Event" do
     event = events(:rails_world_2023)
+
     assert_kind_of Icalendar::Event, event.to_ical
+  end
+
+  test "to_ical serializes to a ical formatted string with the event details" do
+    travel_to DateTime.new(2026, 1, 1) do
+      event = events(:rails_world_2023)
+
+      assert_equal <<~ICAL.gsub("\n", "\r\n"), event.to_ical.to_ical
+        BEGIN:VEVENT
+        DTSTAMP:20260101T000000Z
+        UID:RUBYEVENTS-#{event.id}
+        DTSTART;VALUE=DATE:20231026
+        DTEND;VALUE=DATE:20231027
+        DESCRIPTION:RailsWorld is a yearly conference held in Netherlands.\\n
+        LOCATION:Amsterdam\\, Netherlands
+        SUMMARY:Rails World 2023
+        URL;VALUE=URI:https://rubyonrails.org/world
+        END:VEVENT
+      ICAL
+    end
   end
 end


### PR DESCRIPTION
This is a follow up of #1007 to fix a small bug, where events are shown with an offset if you are in a different time zone. I didn't catch this in development for some reason.

## Description

Currently the dates are returned with a timezone:

```
BEGIN:VEVENT
DTSTAMP:20260512T080332Z
UID:RUBYEVENTS-331
DTSTART:20260515T000000
DTEND:20260517T000000
DESCRIPTION:Balkan Ruby is a yearly conference held in Bulgaria and feature
 s 13 talks from various speakers.\n
LOCATION:Sofia\, Bulgaria
SUMMARY:Balkan Ruby 2026
URL;VALUE=URI:https://balkanruby.com
END:VEVENT
```

To make sure they show up as full day for everyone, we need dates without timezones. The `Icalendar::Values::Date` class is there for that.

After:

```
BEGIN:VEVENT
DTSTAMP:20260512T080706Z
UID:RUBYEVENTS-1
DTSTART;VALUE=DATE:20260515
DTEND;VALUE=DATE:20260517
DESCRIPTION:Balkan Ruby is a yearly conference held in Bulgaria and feature
 s 12 talks from various speakers.\n
LOCATION:Sofia\, Bulgaria
SUMMARY:Balkan Ruby 2026
URL;VALUE=URI:https://balkanruby.com
END:VEVENT
```

Also added a test to compare the full string output, which makes it easier to catch potential regressions in the output.

## Screenshots

Currently:

<img width="2282" height="936" alt="CleanShot 2026-05-12 at 10 01 02@2x" src="https://github.com/user-attachments/assets/4a58f0a8-1609-4798-8822-1e1d425e82d7" />

