### PR TITLE
Upgrade to Yerba 0.5 and cleanup validators

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,7 @@ gem "yt"
 gem "rss", "~> 0.3.1"
 
 # YAML Editing and Refactoring with Better Accuracy
-gem "yerba", "~> 0.4.2"
+gem "yerba", "~> 0.5.0"
 
 # Powerful and seamless HTML-aware ERB parsing and tooling.
 gem "herb", "~> 0.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -785,13 +785,13 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yerba (0.4.2)
-    yerba (0.4.2-aarch64-linux-gnu)
-    yerba (0.4.2-aarch64-linux-musl)
-    yerba (0.4.2-arm-linux-gnu)
-    yerba (0.4.2-arm64-darwin)
-    yerba (0.4.2-x86_64-linux-gnu)
-    yerba (0.4.2-x86_64-linux-musl)
+    yerba (0.5.0)
+    yerba (0.5.0-aarch64-linux-gnu)
+    yerba (0.5.0-aarch64-linux-musl)
+    yerba (0.5.0-arm-linux-gnu)
+    yerba (0.5.0-arm64-darwin)
+    yerba (0.5.0-x86_64-linux-gnu)
+    yerba (0.5.0-x86_64-linux-musl)
     yt (0.34.1)
       activesupport
     zeitwerk (2.7.5)
@@ -899,7 +899,7 @@ DEPENDENCIES
   vite_rails
   web-console
   webmock
-  yerba (~> 0.4.2)
+  yerba (~> 0.5.0)
   yt
 
 RUBY VERSION

--- a/Yerbafile
+++ b/Yerbafile
@@ -1,6 +1,9 @@
 rules:
   - files: "data/**/event.yml"
     pipeline:
+      - schema:
+          file: "lib/schemas/event_schema.json"
+
       - directives:
           ensure: true
 
@@ -56,6 +59,10 @@ rules:
 
   - files: "data/**/involvements.yml"
     pipeline:
+      - schema:
+          file: "lib/schemas/involvement_schema.json"
+          path: "[]"
+
       - directives:
           ensure: true
 
@@ -82,6 +89,10 @@ rules:
 
   - files: "data/**/cfp.yml"
     pipeline:
+      - schema:
+          file: "lib/schemas/cfp_schema.json"
+          path: "[]"
+
       - directives:
           ensure: true
 
@@ -98,6 +109,10 @@ rules:
 
   - files: "data/featured_cities.yml"
     pipeline:
+      - schema:
+          file: "lib/schemas/featured_city_schema.json"
+          path: "[]"
+
       - directives:
           ensure: true
 
@@ -107,6 +122,10 @@ rules:
 
   - files: "data/**/sponsors.yml"
     pipeline:
+      - schema:
+          file: "lib/schemas/sponsors_schema.json"
+          path: "[]"
+
       - directives:
           ensure: true
 
@@ -124,6 +143,9 @@ rules:
 
   - files: "data/**/venue.yml"
     pipeline:
+      - schema:
+          file: "lib/schemas/venue_schema.json"
+
       - directives:
           ensure: true
 
@@ -133,6 +155,9 @@ rules:
 
   - files: "data/**/schedule.yml"
     pipeline:
+      - schema:
+          file: "lib/schemas/schedule_schema.json"
+
       - directives:
           ensure: true
 
@@ -150,6 +175,9 @@ rules:
 
   - files: "data/**/series.yml"
     pipeline:
+      - schema:
+          file: "lib/schemas/series_schema.json"
+
       - directives:
           ensure: true
 
@@ -163,6 +191,10 @@ rules:
 
   - files: "data/**/videos.yml"
     pipeline:
+      - schema:
+          file: "lib/schemas/video_schema.json"
+          path: "[]"
+
       - directives:
           ensure: true
 
@@ -276,6 +308,10 @@ rules:
 
   - files: "data/speakers.yml"
     pipeline:
+      - schema:
+          file: "lib/schemas/speaker_schema.json"
+          path: "[]"
+
       - directives:
           ensure: true
 
@@ -304,4 +340,4 @@ rules:
             - slug
 
       - sort:
-          by: name
+          by: ".name"

--- a/app/models/static/speakers_file.rb
+++ b/app/models/static/speakers_file.rb
@@ -8,6 +8,13 @@ module Static
     VIDEOS_GLOB = "data/**/videos.yml"
     INVOLVEMENTS_GLOB = "data/**/involvements.yml"
 
+    VIDEO_SPEAKER_SELECTORS = [
+      "[].speakers[]",
+      "[].alternative_recordings[].speakers[]",
+      "[].talks[].speakers[]",
+      "[].talks[].alternative_recordings[].speakers[]"
+    ].freeze
+
     def initialize(path = Rails.root.join(SPEAKERS_PATH).to_s)
       @document = Yerba.parse_file(path)
     end
@@ -26,7 +33,7 @@ module Static
     end
 
     def aliases
-      document.get("[].aliases[].name") || []
+      document.value_at("[].aliases[].name") || []
     end
 
     def known_names
@@ -54,24 +61,25 @@ module Static
       entry
     end
 
-    def all_referenced_names
-      @all_referenced_names ||= begin
-        selectors = [
-          "[].speakers[]",
-          "[].talks[].speakers[]",
-          "[].alternative_recordings[].speakers[]",
-          "[].talks[].alternative_recordings[].speakers[]"
-        ]
+    def all_speaker_references
+      @all_speaker_references ||= begin
+        video_refs = VIDEO_SPEAKER_SELECTORS.flat_map { |selector| Yerba::Collection.get(videos_glob, selector) }
+        involvement_refs = Yerba::Collection.get(involvements_glob, "[].users[]")
 
-        video_names = selectors.flat_map { |selector| Yerba::Collection.get(videos_glob, selector) || [] }
-        involvement_users = Yerba::Collection.get(involvements_glob, "[].users[]") || []
-
-        Set.new(video_names + involvement_users)
+        (video_refs + involvement_refs).reject { |scalar| scalar.value.blank? }
       end
     end
 
+    def all_referenced_names
+      @all_referenced_names ||= Set.new(all_speaker_references.map(&:value))
+    end
+
+    def missing_speaker_references
+      all_speaker_references.reject { |scalar| known_names.include?(scalar.value) }
+    end
+
     def missing_speakers
-      all_referenced_names.reject { |name| name.empty? || known_names.include?(name) }.sort
+      missing_speaker_references.map(&:value).uniq.sort
     end
 
     def orphaned_speakers
@@ -133,7 +141,7 @@ module Static
 
     def orphaned_entries
       referenced = all_referenced_names
-      all_values = document.get_value("")
+      all_values = document.value_at("")
 
       all_values.each_with_index.filter_map do |entry, index|
         next unless entry.is_a?(Hash)

--- a/app/models/static/validators/error.rb
+++ b/app/models/static/validators/error.rb
@@ -3,7 +3,7 @@ module Static
     class Error
       attr_reader :message, :file_path, :line, :end_line
 
-      def initialize(message, file_path:, line:, end_line:)
+      def initialize(message, file_path:, line:, end_line: nil)
         @message = message
         @file_path = file_path.sub("#{Rails.root}/", "")
         @line = line
@@ -27,6 +27,7 @@ module Static
         else
           "❌"
         end
+
         "#{prefix} #{message}"
       end
 
@@ -38,6 +39,7 @@ module Static
         else
           "⚠️"
         end
+
         "#{prefix} #{message}"
       end
     end

--- a/app/models/static/validators/speaker_exists.rb
+++ b/app/models/static/validators/speaker_exists.rb
@@ -3,6 +3,26 @@
 module Static
   module Validators
     class SpeakerExists
+      PATTERNS = ["**/videos.yml"].freeze
+
+      def initialize(file_path:)
+        @file_path = file_path.to_s.sub("#{Rails.root}/", "")
+      end
+
+      def applicable?
+        return false unless File.exist?(@file_path)
+
+        PATTERNS.any? do |pattern|
+          File.fnmatch?(pattern, @file_path, File::FNM_PATHNAME)
+        end
+      end
+
+      def errors
+        return [] unless applicable?
+
+        self.class.errors.select { |e| e.file_path == @file_path }
+      end
+
       def self.errors
         @errors ||= Static::SpeakersFile.new.missing_speaker_references.map do |scalar|
           Static::Validators::Error.new(

--- a/app/models/static/validators/speaker_exists.rb
+++ b/app/models/static/validators/speaker_exists.rb
@@ -3,84 +3,18 @@
 module Static
   module Validators
     class SpeakerExists
-      PATTERNS = ["**/videos.yml"].freeze
-      KNOWN_NAMES = Static::SpeakersFile.new.known_names.freeze
-
-      def initialize(file_path:)
-        @file_path = file_path
-      end
-
-      def applicable?
-        return false unless File.exist?(@file_path)
-
-        PATTERNS.any? do |pattern|
-          File.fnmatch?(pattern, @file_path, File::FNM_PATHNAME)
-        end
-      end
-
-      def errors
-        @errors ||= validate
-      end
-
-      def validate
-        return [] unless applicable?
-
-        errors = []
-        document = Yerba.parse_file(@file_path)
-
-        video_index, speaker_index = 0, 0
-        loop do
-          video = document.at_path("[#{video_index}]")
-          break if video.nil?
-          speaker = document.at_path("[#{video_index}].speakers[#{speaker_index}]")
-          if speaker.nil?
-            video_index += 1
-            speaker_index = 0
-            next
-          end
-          name = speaker&.value
-          speaker_index += 1
-          next if name.blank? || KNOWN_NAMES.include?(name)
-          location = speaker&.location
-          errors << Static::Validators::Error.new(
-            "Speaker '#{name}' not found in speakers.yml",
-            file_path: @file_path,
-            line: location&.start_line || 1,
-            end_line: location&.end_line
+      def self.errors
+        @errors ||= Static::SpeakersFile.new.missing_speaker_references.map do |scalar|
+          Static::Validators::Error.new(
+            %(Speaker "#{scalar.value}" not found in data/speakers.yml),
+            file_path: scalar.file_path || "",
+            line: scalar.line || 1
           )
         end
+      end
 
-        video_index, talk_index, speakers_index = 0, 0, 0
-        loop do
-          videos = document["[#{video_index}]"]
-          talks = document["[#{video_index}].talks[#{talk_index}]"]
-          talk_speakers = document["[#{video_index}].talks[#{talk_index}].speakers[#{speakers_index}]"]
-          if videos.nil?
-            break
-          elsif talks.nil?
-            video_index += 1
-            talk_index = 0
-            speakers_index = 0
-            next
-          elsif talk_speakers.nil?
-            talk_index += 1
-            speakers_index = 0
-            next
-          end
-          name = talk_speakers.value
-          unless name.blank? || KNOWN_NAMES.include?(name)
-            location = talk_speakers.location
-            errors << Static::Validators::Error.new(
-              "Speaker '#{name}' not found in speakers.yml",
-              file_path: @file_path,
-              line: location&.start_line || 1,
-              end_line: location&.end_line
-            )
-          end
-          speakers_index += 1
-        end
-
-        errors
+      def self.reset!
+        @errors = nil
       end
     end
   end

--- a/lib/tasks/validate.rake
+++ b/lib/tasks/validate.rake
@@ -171,8 +171,7 @@ namespace :validate do
   end
 
   def validate_speakers_in_videos
-    files = Dir.glob(Rails.root.join("data/**/videos.yml"))
-    errors = files.flat_map { |f| Static::Validators::SpeakerExists.new(file_path: f).errors }
+    errors = Static::Validators::SpeakerExists.errors
 
     if errors.any?
       puts Gum.style("Speakers referenced in videos.yml but missing from speakers.yml (#{errors.count}):", foreground: "1")

--- a/test/models/static/validators/speaker_exists_test.rb
+++ b/test/models/static/validators/speaker_exists_test.rb
@@ -5,6 +5,10 @@ require "test_helper"
 class Static::Validators::SpeakerExistsTest < ActiveSupport::TestCase
   VALID_VIDEOS_FILE = Dir.glob(Rails.root.join("data/**/videos.yml")).first.to_s
 
+  setup do
+    Static::Validators::SpeakerExists.reset!
+  end
+
   test "applicable? returns true for a videos.yml file" do
     validator = Static::Validators::SpeakerExists.new(file_path: VALID_VIDEOS_FILE)
     assert validator.applicable?
@@ -23,6 +27,7 @@ class Static::Validators::SpeakerExistsTest < ActiveSupport::TestCase
 
   test "returns empty errors when all speakers exist" do
     videos = [{"title" => "A talk", "speakers" => ["Aaron Bedra"]}].to_yaml
+
     with_temp_videos(videos) do |videos_path|
       validator = Static::Validators::SpeakerExists.new(file_path: videos_path)
       assert_empty validator.errors
@@ -31,22 +36,29 @@ class Static::Validators::SpeakerExistsTest < ActiveSupport::TestCase
 
   test "returns error when top-level speaker is missing" do
     videos = [{"title" => "A talk", "speakers" => ["Unknown Person XYZZY"]}].to_yaml
+
     with_temp_videos(videos) do |videos_path|
       validator = Static::Validators::SpeakerExists.new(file_path: videos_path)
-      assert validator.errors.any? { |e| e.to_h["message"].include?("Unknown Person XYZZY") }
+
+      assert_equal 1, validator.errors.length
+      assert_equal %(Speaker "Unknown Person XYZZY" not found in data/speakers.yml), validator.errors.first.message
     end
   end
 
   test "returns error when nested talk speaker is missing" do
     videos = [{"title" => "Panel", "talks" => [{"title" => "Sub", "speakers" => ["Ghost Speaker XYZZY"]}]}].to_yaml
+
     with_temp_videos(videos) do |videos_path|
       validator = Static::Validators::SpeakerExists.new(file_path: videos_path)
-      assert validator.errors.any? { |e| e.to_h["message"].include?("Ghost Speaker XYZZY") }
+
+      assert_equal 1, validator.errors.length
+      assert_equal %(Speaker "Ghost Speaker XYZZY" not found in data/speakers.yml), validator.errors.first.message
     end
   end
 
   test "recognises speaker aliases as valid" do
     videos = [{"title" => "A talk", "speakers" => ["Abdelkader \"Seuros\" Boudih"]}].to_yaml
+
     with_temp_videos(videos) do |videos_path|
       validator = Static::Validators::SpeakerExists.new(file_path: videos_path)
       assert_empty validator.errors
@@ -55,6 +67,7 @@ class Static::Validators::SpeakerExistsTest < ActiveSupport::TestCase
 
   test "errors are Static::Validators::Error objects" do
     videos = [{"title" => "A talk", "speakers" => ["No One XYZZY"]}].to_yaml
+
     with_temp_videos(videos) do |videos_path|
       validator = Static::Validators::SpeakerExists.new(file_path: videos_path)
       assert validator.errors.all? { |e| e.is_a?(Static::Validators::Error) }
@@ -63,14 +76,15 @@ class Static::Validators::SpeakerExistsTest < ActiveSupport::TestCase
 
   test "returns empty errors for a real videos.yml" do
     validator = Static::Validators::SpeakerExists.new(file_path: VALID_VIDEOS_FILE)
+
     assert_empty validator.errors
   end
 
   private
 
   def with_temp_videos(videos_yaml)
-    dir = Dir.mktmpdir
-    videos_path = File.join(dir, "data", "testconf", "2025", "videos.yml")
+    dir = Rails.root.join("data", "testconf", "testconf-#{SecureRandom.uuid}")
+    videos_path = File.join(dir, "videos.yml")
     FileUtils.mkdir_p(File.dirname(videos_path))
     File.write(videos_path, videos_yaml)
     yield videos_path


### PR DESCRIPTION
### Summary

  - Upgrade yerba from 0.4.2 to 0.5.0
  - Add JSON schema validation steps to all data file types in the Yerbafile
  - Migrate Ruby API calls from removed methods (`get`, `get_value`, `at_path`) to new API (`value_at`, `[]`)
  - Simplify `SpeakerExists` validator from manual index-walking per file to using `SpeakersFile#missing_speaker_references` with `Collection.get`, this validates all video files in parallel with file/line metadata
  - Extract `VIDEO_SPEAKER_SELECTORS` constant and `all_speaker_references` / `missing_speaker_references` methods on `SpeakersFile`
  - Make `Error#end_line` optional