### PR TITLE
Validate `speakerdeck` handles in `speakers.yml`

### DIFF
--- a/app/models/static/speakers_file.rb
+++ b/app/models/static/speakers_file.rb
@@ -40,10 +40,26 @@ module Static
       @known_names ||= Set.new(names + aliases)
     end
 
+    def index_by(field)
+      @indexes ||= {}
+
+      @indexes[field] ||= begin
+        result = {}
+
+        document.value_at("").each_with_index do |entry, index|
+          result[entry[field.to_s]] = index if entry.is_a?(Hash) && entry[field.to_s]
+        end
+
+        result
+      end
+    end
+
     def find_by(name: nil, slug: nil, github: nil)
-      (slug && document.find_by(slug: slug)) ||
-        (github && document.find_by(github: github)) ||
-        (name && document.find_by(name: name))
+      index = (slug && index_by(:slug)[slug]) ||
+        (github && index_by(:github)[github]) ||
+        (name && index_by(:name)[name])
+
+      document[index] if index
     end
 
     def where(**criteria)

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -16325,6 +16325,7 @@
 - name: "Yara Debian"
   github: "YaraDebian"
   linkedin: "yara-debian-512a011a0"
+  speakerdeck: "yaradeb123"
   slug: "yara-debian"
 - name: "Yarden Laifenfeld"
   github: "yardenlai"

--- a/lib/tasks/speakerdeck.rake
+++ b/lib/tasks/speakerdeck.rake
@@ -1,15 +1,69 @@
 namespace :speakerdeck do
   require "gum"
 
-  desc "Set speakerdeck name in speakers.yml from slides_url in videos"
-  task set_usernames_from_slides_url: :environment do
+  desc "Check for speakers with slides URLs but missing speakerdeck handle"
+  task check: :environment do
+    exit 1 unless validate_speakerdeck_handles
+  end
+
+  def validate_speakerdeck_handles
+    scanner = Speakerdeck::SlidesScanner.new.scan
+    speakers_file = Static::SpeakersFile.new
+    candidates = scanner.candidates
+    multi = scanner.multi_handle_speakers
+    passed = true
+
+    if multi.any?
+      puts Gum.style("Speakers with multiple SpeakerDeck handles (#{multi.size}):", foreground: "1")
+      puts
+
+      multi.each do |name, handles|
+        puts Gum.style("  ❌ #{name}: #{handles.to_a.join(", ")}", foreground: "1")
+      end
+
+      puts
+      puts Gum.style("If generic/shared: add to Speakerdeck::SlidesScanner::IGNORED_HANDLES", foreground: "3")
+      puts Gum.style("If legitimate: manually set 'speakerdeck' in speakers.yml", foreground: "3")
+      puts
+
+      passed = false
+    end
+
+    missing = candidates.select do |name, _handles|
+      speaker = speakers_file.find_by(name: name)
+      speaker && speaker.value_at("speakerdeck").nil?
+    end
+
+    if missing.any?
+      puts Gum.style("Speakers with slides URLs but no speakerdeck handle (#{missing.size}):", foreground: "1")
+      puts
+
+      missing.each do |name, handles|
+        puts Gum.style("  ❌ #{name} → #{handles.first}", foreground: "1")
+      end
+
+      puts
+      puts Gum.style("Run: rails speakerdeck:sync", foreground: "3")
+
+      passed = false
+    end
+
+    if passed
+      puts Gum.style("✓ All SpeakerDeck handles are valid", foreground: "2")
+    end
+
+    passed
+  end
+
+  desc "Sync speakerdeck handles from slides URLs in videos to speakers.yml"
+  task sync: :environment do
     puts Gum.style("Setting SpeakerDeck usernames from slides URLs", border: "rounded", padding: "0 2", border_foreground: "5")
     puts
 
     scanner = Speakerdeck::SlidesScanner.new.scan
     speakers_file = Static::SpeakersFile.new
-
     multi = scanner.multi_handle_speakers
+
     if multi.any?
       puts Gum.style("Speakers with multiple SpeakerDeck handles:", foreground: "3")
 
@@ -17,6 +71,8 @@ namespace :speakerdeck do
         puts "  ⚠ #{name}: #{handles.to_a.join(", ")}"
       end
 
+      puts
+      puts Gum.style("If any of these are generic/shared handles, add them to Speakerdeck::SlidesScanner::IGNORED_HANDLES", foreground: "3")
       puts
     end
 
@@ -31,13 +87,10 @@ namespace :speakerdeck do
       next unless speaker
 
       handle = handles.first
-      next if speaker.key?("speakerdeck") && speaker["speakerdeck"].to_s == handle
+      next if speaker.value_at("speakerdeck") == handle
 
-      if speaker.key?("speakerdeck")
-        speaker["speakerdeck"] = handle
-      else
-        speaker.insert(:speakerdeck, handle)
-      end
+      speaker["speakerdeck"] = handle
+
       puts Gum.style("✓ #{name} → #{handle}", foreground: "2")
       updated += 1
     end

--- a/lib/tasks/validate.rake
+++ b/lib/tasks/validate.rake
@@ -590,6 +590,9 @@ namespace :validate do
     puts Gum.style("Validating SpeakerDeck slides URLs", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
     results << validate_speakerdeck_urls
 
+    puts Gum.style("Validating SpeakerDeck handles", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
+    results << validate_speakerdeck_handles
+
     puts Gum.style("Validating event city names", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
     results << validate_event_city_names
 


### PR DESCRIPTION
This pull request adds a validation to make sure all referenced speakerdeck handles referenced in the `videos.yml` files are also present in the `speakers.yml` file.

We also added two new rake tasks for this:

* `rails speakerdeck:check` to check if any speakerdeck handles are missing in `speakers.yml`
* `rails speakerdeck:sync`  to write any missing speakerdeck handles back to the `speakers.yml` file

We renamed `speakerdeck:set_usernames_from_slides_url` to `speakerdeck:sync`.