### PR TITLE
Replace `validate` schema checks with `yerba check` and refactor validations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,9 @@ jobs:
       - name: StandardJS Check
         run: yarn lint
 
+      - name: Check speakers.yml is in sync
+        run: bin/rails speakers_file:check
+
       - name: Validate YAML data schemas
         run: bin/rails validate:all
 

--- a/Gemfile
+++ b/Gemfile
@@ -73,10 +73,10 @@ gem "active_record-associated_object"
 gem "cuprite"
 
 # A single delightful Ruby way to work with AI.
-gem "ruby_llm", "~> 1.9.1"
+gem "ruby_llm", "~> 1.15.0"
 
 # A simple and clean Ruby DSL for creating JSON schemas.
-gem "ruby_llm-schema"
+gem "ruby_llm-schema", github: "marcoroth/ruby_llm-schema", branch: "required-if"
 
 # JSON Schema validator
 gem "json_schemer"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,13 @@ GIT
       thor (>= 1.3.1)
 
 GIT
+  remote: https://github.com/marcoroth/ruby_llm-schema.git
+  revision: 98cba8044b471bcb18b5cea3e64b5248d0a88b02
+  branch: required-if
+  specs:
+    ruby_llm-schema (0.3.0)
+
+GIT
   remote: https://github.com/rails/rails.git
   revision: fac8810bcdec7b796a471b56a6dcbaa6648e2984
   specs:
@@ -663,17 +670,16 @@ GEM
     ruby-vips (2.3.0)
       ffi (~> 1.12)
       logger
-    ruby_llm (1.9.2)
+    ruby_llm (1.15.0)
       base64
       event_stream_parser (~> 1)
       faraday (>= 1.10.0)
       faraday-multipart (>= 1)
       faraday-net_http (>= 1)
       faraday-retry (>= 1)
-      marcel (~> 1.0)
-      ruby_llm-schema (~> 0.2.1)
+      marcel (~> 1)
+      ruby_llm-schema (~> 0)
       zeitwerk (~> 2)
-    ruby_llm-schema (0.2.5)
     rubyzip (3.2.2)
     safely_block (0.5.0)
     securerandom (0.4.1)
@@ -880,8 +886,8 @@ DEPENDENCIES
   rss (~> 0.3.1)
   ruby-lsp-rails
   ruby-openai
-  ruby_llm (~> 1.9.1)
-  ruby_llm-schema
+  ruby_llm (~> 1.15.0)
+  ruby_llm-schema!
   selenium-webdriver
   sitemap_generator (~> 6.3)
   solid_cache

--- a/app/models/static/speakers_file.rb
+++ b/app/models/static/speakers_file.rb
@@ -136,6 +136,26 @@ module Static
       document.pluck(field.to_sym).select(&:present?).tally.select { |_, count| count > 1 }
     end
 
+    def same_name_duplicates
+      names.tally.select { |_, count| count > 1 }
+    end
+
+    def reversed_name_duplicates
+      name_set = Set.new(names.map(&:downcase))
+
+      names.each_with_object({}) do |name, result|
+        next unless name.include?(" ")
+
+        reversed = name.split(" ").reverse.join(" ")
+
+        next if reversed.downcase == name.downcase
+        next unless name_set.include?(reversed.downcase)
+
+        key = [name, reversed].sort
+        result[key] ||= key
+      end.values
+    end
+
     def save!
       document.sort(by: :name)
       document.save!(apply: true)

--- a/app/schemas/additional_resource_schema.rb
+++ b/app/schemas/additional_resource_schema.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AdditionalResourceSchema < RubyLLM::Schema
+  string :name, description: "Display name for the resource", required: true
+  string :url, description: "URL to the resource", required: true
+  string :type, description: "Type of resource", enum: ["write-up", "blog", "article", "source-code", "code", "repo", "github", "documentation", "docs", "presentation", "video", "podcast", "audio", "gem", "library", "transcript", "handout", "notes", "photos", "link", "book"], required: true
+  string :title, description: "Full title of the resource", required: false
+end

--- a/app/schemas/alternative_recording_schema.rb
+++ b/app/schemas/alternative_recording_schema.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AlternativeRecordingSchema < RubyLLM::Schema
+  string :title, required: false
+  string :raw_title, required: false
+  string :language, required: false
+  string :date, required: false
+  string :description, required: false
+  string :published_at, required: false
+  string :event_name, required: false
+  array :speakers, of: :string, required: false
+  string :video_provider, required: false
+  string :video_id, required: false
+  string :url, required: false
+  string :external_url, required: false
+end

--- a/app/schemas/sub_video_schema.rb
+++ b/app/schemas/sub_video_schema.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class SubVideoSchema < RubyLLM::Schema
+  string :id, required: true
+  string :title, required: false
+  string :raw_title, required: false
+  string :description, required: false
+  string :kind, description: "Type of video (e.g., 'keynote', 'lightning')", required: false
+  array :speakers, of: :string, required: false
+  string :event_name, required: false
+  string :date, required: false
+  string :published_at, required: false
+  string :announced_at, required: false
+  string :video_provider, description: "Use 'parent' if there is one video", required: true
+  string :video_id, required: true
+  string :language, required: false
+  string :track, required: false
+  string :location, description: "Location within the venue", required: false
+  string :start_cue, description: "Start time cue in video", required: false
+  string :end_cue, description: "End time cue in video", required: false
+  string :thumbnail_cue, description: "Thumbnail time cue", required: false
+  string :slides_url, required: false
+  array :additional_resources, of: AdditionalResourceSchema, required: false
+  string :thumbnail_xs, required: false
+  string :thumbnail_sm, required: false
+  string :thumbnail_md, required: false
+  string :thumbnail_lg, required: false
+  string :thumbnail_xl, required: false
+  string :thumbnail_classes, required: false
+  array :alternative_recordings, of: AlternativeRecordingSchema, required: false
+
+  require_if :video_provider, equals: "youtube" do
+    requires :published_at
+    validates :published_at, not_value: "TODO", min_length: 1, pattern: "^\\d{4}-\\d{2}-\\d{2}"
+  end
+end

--- a/app/schemas/video_schema.rb
+++ b/app/schemas/video_schema.rb
@@ -11,55 +11,7 @@ class VideoSchema < RubyLLM::Schema
   string :status, description: "Status of the video", required: false
 
   array :speakers, of: :string, description: "List of speaker names", required: false
-
-  array :talks, description: "Sub-talks for panel discussions", required: false do
-    object do
-      string :id, required: true
-      string :title, required: false
-      string :raw_title, required: false
-      string :description, required: false
-      string :kind, description: "Type of video (e.g., 'keynote', 'lightning')", required: false
-      array :speakers, of: :string, required: false
-      string :event_name, required: false
-      string :date, required: false
-      string :published_at, required: false
-      string :announced_at, required: false
-      string :video_provider, description: "Use 'parent' if there is one video", required: true
-      string :video_id, required: true
-      string :language, required: false
-      string :track, required: false
-      string :location, description: "Location within the venue", required: false
-      string :start_cue, description: "Start time cue in video", required: false
-      string :end_cue, description: "End time cue in video", required: false
-      string :thumbnail_cue, description: "Thumbnail time cue", required: false
-      string :slides_url, required: false
-      array :additional_resources, required: false do
-        object do
-          string :name, required: true
-          string :url, required: true
-          string :type, enum: ["write-up", "blog", "article", "source-code", "code", "repo", "github", "documentation", "docs", "presentation", "video", "podcast", "audio", "gem", "library", "transcript", "handout", "notes", "photos", "link"], required: true
-          string :title, required: false
-        end
-      end
-      string :thumbnail_xs, required: false
-      string :thumbnail_sm, required: false
-      string :thumbnail_md, required: false
-      string :thumbnail_lg, required: false
-      string :thumbnail_xl, required: false
-      string :thumbnail_classes, required: false
-      array :alternative_recordings, required: false do
-        object do
-          string :title, required: false
-          string :raw_title, required: false
-          string :published_at, required: false
-          array :speakers, of: :string, required: false
-          string :video_provider, required: false
-          string :video_id, required: false
-          string :url, required: false
-        end
-      end
-    end
-  end
+  array :talks, of: SubVideoSchema, description: "Sub-talks for panel discussions", required: false
 
   string :event_name, description: "Name of the event (e.g., 'RailsConf 2024')", required: false
   string :date, description: "Date of the talk (YYYY-MM-DD format)", required: true
@@ -75,36 +27,12 @@ class VideoSchema < RubyLLM::Schema
 
   boolean :external_player, description: "Whether to use external player", required: false
   string :external_player_url, description: "URL for external player", required: false
-
-  array :alternative_recordings, description: "Alternative video recordings", required: false do
-    object do
-      string :title, required: false
-      string :raw_title, required: false
-      string :language, required: false
-      string :date, required: false
-      string :description, required: false
-      string :published_at, required: false
-      string :event_name, required: false
-      array :speakers, of: :string, required: false
-      string :video_provider, required: false
-      string :video_id, required: false
-      string :external_url, required: false
-    end
-  end
-
   string :track, description: "Conference track (e.g., 'Main Stage', 'Workshop')", required: false
   string :language, description: "Language of the talk", required: false
-
   string :slides_url, description: "URL to the slides", required: false
 
-  array :additional_resources, description: "Additional resources related to the talk", required: false do
-    object do
-      string :name, description: "Display name for the resource", required: true
-      string :url, description: "URL to the resource", required: true
-      string :type, description: "Type of resource", enum: ["write-up", "blog", "article", "source-code", "code", "repo", "github", "documentation", "docs", "presentation", "video", "podcast", "audio", "gem", "library", "transcript", "handout", "notes", "photos", "link", "book"], required: true
-      string :title, description: "Full title of the resource", required: false
-    end
-  end
+  array :alternative_recordings, of: AlternativeRecordingSchema, description: "Alternative video recordings", required: false
+  array :additional_resources, of: AdditionalResourceSchema, description: "Additional resources related to the talk", required: false
 
   string :thumbnail_xs, description: "Extra small thumbnail URL", required: false
   string :thumbnail_sm, description: "Small thumbnail URL", required: false
@@ -112,4 +40,9 @@ class VideoSchema < RubyLLM::Schema
   string :thumbnail_lg, description: "Large thumbnail URL", required: false
   string :thumbnail_xl, description: "Extra large thumbnail URL", required: false
   string :thumbnail_classes, description: "CSS classes for thumbnail", required: false
+
+  require_if :video_provider, equals: "youtube" do
+    requires :published_at
+    validates :published_at, not_value: "TODO", min_length: 1, pattern: "^\\d{4}-\\d{2}-\\d{2}"
+  end
 end

--- a/bin/lint
+++ b/bin/lint
@@ -3,21 +3,26 @@
 # Exit when any command fails
 set -e
 
-# Check Ruby code formatting
-echo "Checking Ruby code formatting..."
-bundle exec standardrb --fix
-
-# Check Ruby code formatting
-echo "Checking JS code formatting..."
-yarn format
-
-# Check erb file formatting
-echo "Checking erb file formatting..."
-bundle exec erb_lint --lint-all --autocorrect
-
-# Check YAML file formatting
 echo "Checking YAML file formatting in data/ ..."
 bundle exec yerba apply
 
+echo "Syncing speakers.yml ..."
+bin/rails speakers_file:sync
+
+echo "Syncing SpeakerDeck usernames ..."
+bin/rails speakerdeck:sync
+
+echo "Exporting JSON schemas ..."
+bin/rails schema:export
+
 echo "Validating Schema of files in data/ ..."
 bin/rails validate:all
+
+echo "Checking Ruby code formatting..."
+bundle exec standardrb --fix
+
+echo "Checking JS code formatting..."
+yarn format
+
+echo "Checking erb file formatting..."
+bundle exec erb_lint --lint-all --autocorrect

--- a/lib/schemas/additional_resource_schema.json
+++ b/lib/schemas/additional_resource_schema.json
@@ -1,0 +1,51 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Display name for the resource"
+    },
+    "url": {
+      "type": "string",
+      "description": "URL to the resource"
+    },
+    "type": {
+      "type": "string",
+      "enum": [
+        "write-up",
+        "blog",
+        "article",
+        "source-code",
+        "code",
+        "repo",
+        "github",
+        "documentation",
+        "docs",
+        "presentation",
+        "video",
+        "podcast",
+        "audio",
+        "gem",
+        "library",
+        "transcript",
+        "handout",
+        "notes",
+        "photos",
+        "link",
+        "book"
+      ],
+      "description": "Type of resource"
+    },
+    "title": {
+      "type": "string",
+      "description": "Full title of the resource"
+    }
+  },
+  "required": [
+    "name",
+    "url",
+    "type"
+  ],
+  "additionalProperties": false,
+  "strict": true
+}

--- a/lib/schemas/alternative_recording_schema.json
+++ b/lib/schemas/alternative_recording_schema.json
@@ -1,0 +1,47 @@
+{
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "raw_title": {
+      "type": "string"
+    },
+    "language": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "published_at": {
+      "type": "string"
+    },
+    "event_name": {
+      "type": "string"
+    },
+    "speakers": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "video_provider": {
+      "type": "string"
+    },
+    "video_id": {
+      "type": "string"
+    },
+    "url": {
+      "type": "string"
+    },
+    "external_url": {
+      "type": "string"
+    }
+  },
+  "required": [],
+  "additionalProperties": false,
+  "strict": true
+}

--- a/lib/schemas/sub_video_schema.json
+++ b/lib/schemas/sub_video_schema.json
@@ -1,0 +1,223 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "raw_title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string",
+      "description": "Type of video (e.g., 'keynote', 'lightning')"
+    },
+    "speakers": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "event_name": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string"
+    },
+    "published_at": {
+      "type": "string"
+    },
+    "announced_at": {
+      "type": "string"
+    },
+    "video_provider": {
+      "type": "string",
+      "description": "Use 'parent' if there is one video"
+    },
+    "video_id": {
+      "type": "string"
+    },
+    "language": {
+      "type": "string"
+    },
+    "track": {
+      "type": "string"
+    },
+    "location": {
+      "type": "string",
+      "description": "Location within the venue"
+    },
+    "start_cue": {
+      "type": "string",
+      "description": "Start time cue in video"
+    },
+    "end_cue": {
+      "type": "string",
+      "description": "End time cue in video"
+    },
+    "thumbnail_cue": {
+      "type": "string",
+      "description": "Thumbnail time cue"
+    },
+    "slides_url": {
+      "type": "string"
+    },
+    "additional_resources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Display name for the resource"
+          },
+          "url": {
+            "type": "string",
+            "description": "URL to the resource"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "write-up",
+              "blog",
+              "article",
+              "source-code",
+              "code",
+              "repo",
+              "github",
+              "documentation",
+              "docs",
+              "presentation",
+              "video",
+              "podcast",
+              "audio",
+              "gem",
+              "library",
+              "transcript",
+              "handout",
+              "notes",
+              "photos",
+              "link",
+              "book"
+            ],
+            "description": "Type of resource"
+          },
+          "title": {
+            "type": "string",
+            "description": "Full title of the resource"
+          }
+        },
+        "required": [
+          "name",
+          "url",
+          "type"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "thumbnail_xs": {
+      "type": "string"
+    },
+    "thumbnail_sm": {
+      "type": "string"
+    },
+    "thumbnail_md": {
+      "type": "string"
+    },
+    "thumbnail_lg": {
+      "type": "string"
+    },
+    "thumbnail_xl": {
+      "type": "string"
+    },
+    "thumbnail_classes": {
+      "type": "string"
+    },
+    "alternative_recordings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "raw_title": {
+            "type": "string"
+          },
+          "language": {
+            "type": "string"
+          },
+          "date": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string"
+          },
+          "event_name": {
+            "type": "string"
+          },
+          "speakers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "video_provider": {
+            "type": "string"
+          },
+          "video_id": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "external_url": {
+            "type": "string"
+          }
+        },
+        "required": [],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "id",
+    "video_provider",
+    "video_id"
+  ],
+  "additionalProperties": false,
+  "strict": true,
+  "if": {
+    "properties": {
+      "video_provider": {
+        "const": "youtube"
+      }
+    },
+    "required": [
+      "video_provider"
+    ]
+  },
+  "then": {
+    "required": [
+      "published_at"
+    ],
+    "properties": {
+      "published_at": {
+        "type": "string",
+        "not": {
+          "const": "TODO"
+        },
+        "minLength": 1,
+        "pattern": "^\\d{4}-\\d{2}-\\d{2}"
+      }
+    }
+  }
+}

--- a/lib/schemas/video_schema.json
+++ b/lib/schemas/video_schema.json
@@ -118,10 +118,12 @@
               "type": "object",
               "properties": {
                 "name": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Display name for the resource"
                 },
                 "url": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "URL to the resource"
                 },
                 "type": {
                   "type": "string",
@@ -145,11 +147,14 @@
                     "handout",
                     "notes",
                     "photos",
-                    "link"
-                  ]
+                    "link",
+                    "book"
+                  ],
+                  "description": "Type of resource"
                 },
                 "title": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Full title of the resource"
                 }
               },
               "required": [
@@ -189,7 +194,19 @@
                 "raw_title": {
                   "type": "string"
                 },
+                "language": {
+                  "type": "string"
+                },
+                "date": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
                 "published_at": {
+                  "type": "string"
+                },
+                "event_name": {
                   "type": "string"
                 },
                 "speakers": {
@@ -206,6 +223,9 @@
                 },
                 "url": {
                   "type": "string"
+                },
+                "external_url": {
+                  "type": "string"
                 }
               },
               "required": [],
@@ -218,7 +238,32 @@
           "video_provider",
           "video_id"
         ],
-        "additionalProperties": false
+        "additionalProperties": false,
+        "if": {
+          "properties": {
+            "video_provider": {
+              "const": "youtube"
+            }
+          },
+          "required": [
+            "video_provider"
+          ]
+        },
+        "then": {
+          "required": [
+            "published_at"
+          ],
+          "properties": {
+            "published_at": {
+              "type": "string",
+              "not": {
+                "const": "TODO"
+              },
+              "minLength": 1,
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}"
+            }
+          }
+        }
       }
     },
     "event_name": {
@@ -271,6 +316,18 @@
       "type": "string",
       "description": "URL for external player"
     },
+    "track": {
+      "type": "string",
+      "description": "Conference track (e.g., 'Main Stage', 'Workshop')"
+    },
+    "language": {
+      "type": "string",
+      "description": "Language of the talk"
+    },
+    "slides_url": {
+      "type": "string",
+      "description": "URL to the slides"
+    },
     "alternative_recordings": {
       "type": "array",
       "description": "Alternative video recordings",
@@ -310,6 +367,9 @@
           "video_id": {
             "type": "string"
           },
+          "url": {
+            "type": "string"
+          },
           "external_url": {
             "type": "string"
           }
@@ -317,18 +377,6 @@
         "required": [],
         "additionalProperties": false
       }
-    },
-    "track": {
-      "type": "string",
-      "description": "Conference track (e.g., 'Main Stage', 'Workshop')"
-    },
-    "language": {
-      "type": "string",
-      "description": "Language of the talk"
-    },
-    "slides_url": {
-      "type": "string",
-      "description": "URL to the slides"
     },
     "additional_resources": {
       "type": "array",
@@ -418,5 +466,30 @@
     "video_id"
   ],
   "additionalProperties": false,
-  "strict": true
+  "strict": true,
+  "if": {
+    "properties": {
+      "video_provider": {
+        "const": "youtube"
+      }
+    },
+    "required": [
+      "video_provider"
+    ]
+  },
+  "then": {
+    "required": [
+      "published_at"
+    ],
+    "properties": {
+      "published_at": {
+        "type": "string",
+        "not": {
+          "const": "TODO"
+        },
+        "minLength": 1,
+        "pattern": "^\\d{4}-\\d{2}-\\d{2}"
+      }
+    }
+  }
 }

--- a/lib/schemas/video_talk_schema.json
+++ b/lib/schemas/video_talk_schema.json
@@ -1,0 +1,203 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "title": {
+      "type": "string"
+    },
+    "raw_title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "kind": {
+      "type": "string",
+      "description": "Type of video (e.g., 'keynote', 'lightning')"
+    },
+    "speakers": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "event_name": {
+      "type": "string"
+    },
+    "date": {
+      "type": "string"
+    },
+    "published_at": {
+      "type": "string"
+    },
+    "announced_at": {
+      "type": "string"
+    },
+    "video_provider": {
+      "type": "string",
+      "description": "Use 'parent' if there is one video"
+    },
+    "video_id": {
+      "type": "string"
+    },
+    "language": {
+      "type": "string"
+    },
+    "track": {
+      "type": "string"
+    },
+    "location": {
+      "type": "string",
+      "description": "Location within the venue"
+    },
+    "start_cue": {
+      "type": "string",
+      "description": "Start time cue in video"
+    },
+    "end_cue": {
+      "type": "string",
+      "description": "End time cue in video"
+    },
+    "thumbnail_cue": {
+      "type": "string",
+      "description": "Thumbnail time cue"
+    },
+    "slides_url": {
+      "type": "string"
+    },
+    "additional_resources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "write-up",
+              "blog",
+              "article",
+              "source-code",
+              "code",
+              "repo",
+              "github",
+              "documentation",
+              "docs",
+              "presentation",
+              "video",
+              "podcast",
+              "audio",
+              "gem",
+              "library",
+              "transcript",
+              "handout",
+              "notes",
+              "photos",
+              "link"
+            ]
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "url",
+          "type"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "thumbnail_xs": {
+      "type": "string"
+    },
+    "thumbnail_sm": {
+      "type": "string"
+    },
+    "thumbnail_md": {
+      "type": "string"
+    },
+    "thumbnail_lg": {
+      "type": "string"
+    },
+    "thumbnail_xl": {
+      "type": "string"
+    },
+    "thumbnail_classes": {
+      "type": "string"
+    },
+    "alternative_recordings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "raw_title": {
+            "type": "string"
+          },
+          "published_at": {
+            "type": "string"
+          },
+          "speakers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "video_provider": {
+            "type": "string"
+          },
+          "video_id": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "id",
+    "video_provider",
+    "video_id"
+  ],
+  "additionalProperties": false,
+  "strict": true,
+  "if": {
+    "properties": {
+      "video_provider": {
+        "const": "youtube"
+      }
+    },
+    "required": [
+      "video_provider"
+    ]
+  },
+  "then": {
+    "required": [
+      "published_at"
+    ],
+    "properties": {
+      "published_at": {
+        "type": "string",
+        "not": {
+          "const": "TODO"
+        },
+        "minLength": 1,
+        "pattern": "^\\d{4}-\\d{2}-\\d{2}"
+      }
+    }
+  }
+}

--- a/lib/tasks/validate.rake
+++ b/lib/tasks/validate.rake
@@ -1,93 +1,8 @@
 # frozen_string_literal: true
 
 require "gum"
-require "json_schemer"
-require "yaml"
 
 namespace :validate do
-  def validate_files(glob_pattern, file_type)
-    files = Dir.glob(Rails.root.join(glob_pattern))
-    valid_count = 0
-    invalid_files = []
-
-    files.each do |file|
-      file_errors = Static::Validators::Schema.new(file_path: file).errors
-
-      if file_errors.empty?
-        valid_count += 1
-      else
-        relative_path = file.sub("#{Rails.root}/", "")
-        invalid_files << {path: relative_path, errors: file_errors}
-      end
-    end
-
-    if invalid_files.any?
-      puts Gum.style("Invalid #{file_type} files (#{invalid_files.count}):", foreground: "1")
-      puts
-      invalid_files.each do |file|
-        puts Gum.style("❌ #{file[:path]}", foreground: "1")
-        file[:errors].each { |e| puts e.as_error }
-        puts
-      end
-    end
-
-    if invalid_files.any?
-      puts Gum.style("#{file_type}: #{valid_count} valid, #{invalid_files.count} invalid out of #{files.count} files", foreground: "1")
-    else
-      puts Gum.style("#{file_type}: #{valid_count} valid out of #{files.count} files", foreground: "2")
-    end
-
-    invalid_files.empty?
-  end
-
-  def validate_array_files(glob_pattern, file_type)
-    files = Dir.glob(Rails.root.join(glob_pattern))
-    valid_count = 0
-    invalid_files = []
-
-    files.each do |file|
-      file_errors = Static::Validators::SchemaArray.new(file_path: file).errors
-
-      if file_errors.empty?
-        valid_count += 1
-      else
-        relative_path = file.sub("#{Rails.root}/", "")
-        invalid_files << {path: relative_path, errors: file_errors}
-      end
-    end
-
-    if invalid_files.any?
-      puts Gum.style("Invalid #{file_type} files (#{invalid_files.count}):", foreground: "1")
-      puts
-      invalid_files.each do |file|
-        puts Gum.style("❌ #{file[:path]}", foreground: "1")
-        file[:errors].first(10).each do |e|
-          puts e.as_error
-        end
-        puts "... and #{file[:errors].count - 10} more errors" if file[:errors].count > 10
-        puts
-      end
-    end
-
-    if invalid_files.any?
-      puts Gum.style("#{file_type}: #{valid_count} valid, #{invalid_files.count} invalid out of #{files.count} files", foreground: "1")
-    else
-      puts Gum.style("#{file_type}: #{valid_count} valid out of #{files.count} files", foreground: "2")
-    end
-
-    invalid_files.empty?
-  end
-
-  desc "Validate all cfp.yml files against CFPSchema"
-  task cfps: :environment do
-    exit 1 unless validate_array_files("data/**/cfp.yml", "cfp.yml")
-  end
-
-  desc "Validate all event.yml files against EventSchema"
-  task events: :environment do
-    exit 1 unless validate_files("data/**/event.yml", "event.yml")
-  end
-
   def validate_event_dates
     files = Dir.glob(Rails.root.join("data/**/event.yml"))
     errors = []
@@ -102,6 +17,7 @@ namespace :validate do
       puts
       errors.concat(file_errors)
     end
+
     errors
   end
 
@@ -110,54 +26,12 @@ namespace :validate do
     exit 1 if validate_event_dates.any?
   end
 
-  desc "Validate all series.yml files against SeriesSchema"
-  task series: :environment do
-    exit 1 unless validate_files("data/*/series.yml", "series.yml")
-  end
-
-  desc "Validate all sponsors.yml files against SeriesSchema"
-  task sponsors: :environment do
-    exit 1 unless validate_array_files("data/**/sponsors.yml", "sponsors.yml")
-  end
-
-  desc "Validate all venue.yml files against VenueSchema"
-  task venues: :environment do
-    exit 1 unless validate_files("data/**/venue.yml", "venue.yml")
-  end
-
-  desc "Validate all videos.yml files against VideoSchema"
-  task videos: :environment do
-    exit 1 unless validate_array_files("data/**/videos.yml", "videos.yml")
-  end
-
-  desc "Validate all schedule.yml files against ScheduleSchema"
-  task schedules: :environment do
-    exit 1 unless validate_files("data/**/schedule.yml", "schedule.yml")
-  end
-
-  desc "Validate featured_cities.yml against FeaturedCitySchema"
-  task featured_cities: :environment do
-    exit 1 unless validate_array_files("data/featured_cities.yml", "featured_cities.yml")
-  end
-
-  desc "Validate all involvements.yml files against InvolvementSchema"
-  task involvements: :environment do
-    exit 1 unless validate_array_files("data/**/involvements.yml", "involvements.yml")
-  end
-
-  desc "Validate all transcripts.yml files against TranscriptSchema"
-  task transcripts: :environment do
-    exit 1 unless validate_array_files("data/**/transcripts.yml", "transcripts.yml")
-  end
-
   def validate_speakers
     file = Rails.root.join("data/speakers.yml").to_s
-    errors = []
-    errors.concat(Static::Validators::UniqueSpeakerFields.new(file_path: file).errors)
-    errors.concat(Static::Validators::SchemaArray.new(file_path: file).errors)
+    errors = Static::Validators::UniqueSpeakerFields.new(file_path: file).errors
 
     if errors.empty?
-      puts Gum.style("✓ All speakers are valid!", foreground: "2")
+      puts Gum.style("✓ All speaker fields are unique!", foreground: "2")
     else
       errors.each { |e| puts e.as_error }
     end
@@ -217,55 +91,41 @@ namespace :validate do
     end
   end
 
-  desc "Validate that all YouTube videos have a published_at date"
-  task youtube_published_at: :environment do
-    missing_published_at = []
-
-    Static::Video.all.each do |video|
-      if video.video_provider == "youtube" && (video.published_at.blank? || video.published_at == "TODO")
-        missing_published_at << video
-      end
-
-      video.talks.each do |talk|
-        if talk.video_provider == "youtube" && (talk.published_at.blank? || talk.published_at == "TODO")
-          missing_published_at << talk
-        end
-      end
-    end
-
-    if missing_published_at.any?
-      puts Gum.style("YouTube videos missing published_at date (#{missing_published_at.count}):", foreground: "1")
-      puts
-
-      missing_published_at.each do |video|
-        puts Gum.style("❌ #{video.id} (#{video.title})", foreground: "1")
-      end
-
-      puts
-
-      exit 1
-    else
-      puts Gum.style("✓ All YouTube videos have a published_at date", foreground: "2")
-    end
-  end
-
   def validate_speaker_duplicates
-    report = Gum.spin("Checking for speaker duplicates...", spinner: "dot") do
-      User::DuplicateDetector.report
+    speakers_file = Static::SpeakersFile.new
+    passed = true
+
+    same = speakers_file.same_name_duplicates
+
+    if same.any?
+      puts Gum.style("Same name duplicates (#{same.count}):", foreground: "1")
+
+      same.each do |name, count|
+        puts Gum.style("  ❌ #{name} (#{count} occurrences)", foreground: "1")
+      end
+
+      puts
+      passed = false
     end
 
-    has_duplicates = report != "No duplicates found."
+    reversed = speakers_file.reversed_name_duplicates
 
-    if has_duplicates
-      puts Gum.style(report, foreground: "1")
+    if reversed.any?
+      puts Gum.style("Reversed name duplicates (#{reversed.count} pairs):", foreground: "1")
+
+      reversed.each do |pair|
+        puts Gum.style("  ❌ #{pair[0]} ↔ #{pair[1]}", foreground: "1")
+      end
+
       puts
-      puts Gum.style("To fix: Make sure the name in speakers.yml matches the reference in the videos.yml files.", foreground: "3")
-      puts
-    else
-      puts Gum.style("✓ No unresolved speaker duplicates found", foreground: "2")
+      passed = false
     end
 
-    !has_duplicates
+    if passed
+      puts Gum.style("✓ No speaker duplicates found", foreground: "2")
+    end
+
+    passed
   end
 
   desc "Validate that there are no unresolved speaker duplicates"
@@ -465,38 +325,18 @@ namespace :validate do
   task all: :environment do
     results = []
 
-    puts Gum.style("Validating event.yml files", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
-    results << validate_files("data/**/event.yml", "event.yml")
+    puts Gum.style("Running yerba check (schemas, formatting, uniqueness)", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
+    yerba_passed = system("bundle exec yerba check")
+    results << yerba_passed
+
+    if yerba_passed
+      puts Gum.style("✓ All Yerbafile rules passed", foreground: "2")
+    end
+
+    puts Gum.style("Validating event dates", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
     results << validate_event_dates.none?
 
-    puts Gum.style("Validating series.yml files", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
-    results << validate_files("data/*/series.yml", "series.yml")
-
-    puts Gum.style("Validating cfp.yml files", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
-    results << validate_array_files("data/**/cfp.yml", "cfp.yml")
-
-    puts Gum.style("Validating sponsors.yml files", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
-    results << validate_array_files("data/**/sponsors.yml", "sponsors.yml")
-
-    puts Gum.style("Validating venue.yml files", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
-    results << validate_files("data/**/venue.yml", "venue.yml")
-
-    puts Gum.style("Validating videos.yml files", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
-    results << validate_array_files("data/**/videos.yml", "videos.yml")
-
-    puts Gum.style("Validating schedule.yml files", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
-    results << validate_files("data/**/schedule.yml", "schedule.yml")
-
-    puts Gum.style("Validating featured_cities.yml", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
-    results << validate_array_files("data/featured_cities.yml", "featured_cities.yml")
-
-    puts Gum.style("Validating involvements.yml files", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
-    results << validate_array_files("data/**/involvements.yml", "involvements.yml")
-
-    puts Gum.style("Validating transcripts.yml files", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
-    results << validate_array_files("data/**/transcripts.yml", "transcripts.yml")
-
-    puts Gum.style("Validating data/speakers.yml", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
+    puts Gum.style("Validating unique speaker fields", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
     results << validate_speakers.none?
 
     puts Gum.style("Validating speakers in videos.yml exist in speakers.yml", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
@@ -549,43 +389,8 @@ namespace :validate do
       results << true
     end
 
-    puts Gum.style("Validating YouTube videos have published_at", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
-
-    missing_published_at = []
-
-    Static::Video.all.each do |video|
-      if video.video_provider == "youtube" && (video.published_at.blank? || video.published_at == "TODO")
-        missing_published_at << video
-      end
-
-      video.talks.each do |talk|
-        if talk.video_provider == "youtube" && (talk.published_at.blank? || talk.published_at == "TODO")
-          missing_published_at << talk
-        end
-      end
-    end
-
-    if missing_published_at.any?
-      puts Gum.style("YouTube videos missing published_at date (#{missing_published_at.count}):", foreground: "1")
-      puts
-
-      missing_published_at.each do |video|
-        puts Gum.style("❌ #{video.id} (#{video.title})", foreground: "1")
-      end
-
-      puts
-
-      results << false
-    else
-      puts Gum.style("✓ All YouTube videos have a published_at date", foreground: "2")
-
-      results << true
-    end
-
-    if Rails.env.development?
-      puts Gum.style("Validating speaker duplicates", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
-      results << validate_speaker_duplicates
-    end
+    puts Gum.style("Validating speaker duplicates", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
+    results << validate_speaker_duplicates
 
     puts Gum.style("Validating SpeakerDeck slides URLs", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
     results << validate_speakerdeck_urls


### PR DESCRIPTION
  - Replace per-file schema validation tasks with single `yerba check` call
  - Remove `validate_files`, `validate_array_files` helpers and individual schema tasks, they are now all covered by the `Yerbafile`
  - Remove `youtube_published_at` check. This is now enforced via JSON Schema `if`/`then` rule
  - Refactor `validate_speaker_duplicates` to use `SpeakersFile` instead of `User::DuplicateDetector`
  - Add `SpeakersFile#same_name_duplicates` and `#reversed_name_duplicates`
  - Extract `SubVideoSchema`, `AdditionalResourceSchema`, `AlternativeRecordingSchema` for schema composition using `of:`
  - Add `require_if` conditional DSL to `ruby_llm-schema` for if/then JSON Schema support
  - Update `bin/lint` and CI workflow