### PR TITLE
Fix sticker count on tabs

### DIFF
--- a/app/controllers/concerns/profile_data.rb
+++ b/app/controllers/concerns/profile_data.rb
@@ -52,7 +52,7 @@ module ProfileData
 
   def set_mutual_events
     @mutual_events = if Current.user
-      @user.participated_events.where(id: Current.user.participated_events).distinct.order(start_date: :desc)
+      @user.participated_events.where(id: Current.user.participated_events).order(start_date: :desc)
     else
       Event.none
     end

--- a/app/controllers/concerns/profile_data.rb
+++ b/app/controllers/concerns/profile_data.rb
@@ -17,7 +17,7 @@ module ProfileData
     @talks = @user.kept_talks
     @events = @user.participated_events
     @stamps = Stamp.for_user(@user)
-    @events_with_stickers = @events.select(&:sticker?)
+    @stickers = Sticker.for_user(@user, events: @events)
     @involvements_by_role = @user.event_involvements.group_by(&:role).transform_values(&:any?)
     @countries_with_events = @events.group_by(&:country_code).any? ? [true] : []
     @topics = @user.topics.approved.tally.sort_by(&:last).reverse.map(&:first)

--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -106,6 +106,7 @@ class PageController < ApplicationController
 
   def stickers
     @events = Event.all.select(&:sticker?)
+    @stickers = @events.flat_map(&:stickers)
   end
 
   def contributors

--- a/app/controllers/profiles/events_controller.rb
+++ b/app/controllers/profiles/events_controller.rb
@@ -2,7 +2,7 @@ class Profiles::EventsController < ApplicationController
   include ProfileData
 
   def index
-    @events = @user.participated_events.includes(:series).distinct.in_order_of(:attended_as, EventParticipation.attended_as.keys)
+    @events = @user.participated_events.includes(:series).in_order_of(:attended_as, EventParticipation.attended_as.keys)
     event_participations = @user.event_participations.includes(:event).where(event: @events)
     @participations = event_participations.index_by(&:event_id)
     @events_by_year = @events.group_by { |event| event.start_date&.year || "Unknown" }

--- a/app/controllers/profiles/stickers_controller.rb
+++ b/app/controllers/profiles/stickers_controller.rb
@@ -3,6 +3,6 @@ class Profiles::StickersController < ApplicationController
 
   def index
     @events = @user.participated_events.includes(:series)
-    @events_with_stickers = @events.select(&:sticker?)
+    @stickers = Sticker.for_user(@user, events: @events)
   end
 end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -57,7 +57,7 @@ class ProfilesController < ApplicationController
     @talks_by_kind = @talks.group_by(&:kind)
     @topics = @user.topics.approved.tally.sort_by(&:last).reverse.map(&:first)
     # Load participated events (from event_participations)
-    @events = @user.participated_events.includes(:series).distinct.in_order_of(:attended_as, EventParticipation.attended_as.keys)
+    @events = @user.participated_events.includes(:series).in_order_of(:attended_as, EventParticipation.attended_as.keys)
     @stickers = Sticker.for_user(@user, events: @events)
 
     event_participations = @user.event_participations.includes(:event).where(event: @events)
@@ -139,7 +139,7 @@ class ProfilesController < ApplicationController
 
   def set_mutual_events
     @mutual_events = if Current.user
-      @user.participated_events.where(id: Current.user.participated_events).distinct.order(start_date: :desc)
+      @user.participated_events.where(id: Current.user.participated_events).order(start_date: :desc)
     else
       Event.none
     end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -58,7 +58,7 @@ class ProfilesController < ApplicationController
     @topics = @user.topics.approved.tally.sort_by(&:last).reverse.map(&:first)
     # Load participated events (from event_participations)
     @events = @user.participated_events.includes(:series).distinct.in_order_of(:attended_as, EventParticipation.attended_as.keys)
-    @events_with_stickers = @events.select(&:sticker?)
+    @stickers = Sticker.for_user(@user, events: @events)
 
     event_participations = @user.event_participations.includes(:event).where(event: @events)
     @participations = event_participations.index_by(&:event_id)

--- a/app/models/sticker.rb
+++ b/app/models/sticker.rb
@@ -23,6 +23,10 @@ class Sticker
     }
   end
 
+  def self.for_user(user, events: user.participated_events)
+    events.flat_map { for_event(it) }
+  end
+
   def asset_path
     ActionController::Base.helpers.asset_path(file_path)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -110,7 +110,7 @@ class User < ApplicationRecord
 
   # Event participation associations
   has_many :event_participations, dependent: :destroy
-  has_many :participated_events, through: :event_participations, source: :event
+  has_many :participated_events, -> { distinct }, through: :event_participations, source: :event
   has_many :speaker_events, -> { where(event_participations: {attended_as: :speaker}) },
     through: :event_participations, source: :event
   has_many :keynote_speaker_events, -> { where(event_participations: {attended_as: :keynote_speaker}) },

--- a/app/views/page/stickers.html.erb
+++ b/app/views/page/stickers.html.erb
@@ -1,6 +1,6 @@
 <div class="bg-black">
   <div class="container">
-    <%= render partial: "shared/stickers_display", locals: {events: @events} %>
+    <%= render partial: "shared/stickers_display", locals: {stickers: @stickers} %>
 
     <div class="pb-12">
       <h2 class="text-3xl font-bold text-center text-white mb-8">Available Stickers</h2>

--- a/app/views/profiles/_navigation.html.erb
+++ b/app/views/profiles/_navigation.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (user:, favorite_user:, talks:, events:, mutual_events:, stamps:, events_with_stickers:, involvements_by_role:, countries_with_events:) %>
+<%# locals: (user:, favorite_user:, talks:, events:, mutual_events:, stamps:, stickers:, involvements_by_role:, countries_with_events:) %>
 
 <div role="tablist" class="tabs tabs-bordered">
   <% if talks.length.positive? %>
@@ -25,8 +25,8 @@
     <%= active_link_to "Stamps (#{stamps.size})", profile_stamps_path(user), class: "tab px-6", active_class: "tab-active", role: "tab" %>
   <% end %>
 
-  <% if events_with_stickers.any? %>
-    <%= active_link_to "Stickers (#{events_with_stickers.size})", profile_stickers_path(user), class: "tab px-6", active_class: "tab-active", role: "tab" %>
+  <% if stickers.any? %>
+    <%= active_link_to "Stickers (#{stickers.size})", profile_stickers_path(user), class: "tab px-6", active_class: "tab-active", role: "tab" %>
   <% end %>
 
   <% if countries_with_events&.any? %>

--- a/app/views/profiles/_stickers.html.erb
+++ b/app/views/profiles/_stickers.html.erb
@@ -1,3 +1,3 @@
-<% if events_with_stickers.any? %>
-  <%= render partial: "shared/stickers_display", locals: {events: events_with_stickers} %>
+<% if stickers.any? %>
+  <%= render partial: "shared/stickers_display", locals: {stickers: stickers} %>
 <% end %>

--- a/app/views/profiles/_tab_layout.html.erb
+++ b/app/views/profiles/_tab_layout.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (user:, topics:, favorite_user:, talks:, events:, mutual_events:, stamps:, events_with_stickers:, involvements_by_role:, countries_with_events:) %>
+<%# locals: (user:, topics:, favorite_user:, talks:, events:, mutual_events:, stamps:, stickers:, involvements_by_role:, countries_with_events:) %>
 
 <%= turbo_refreshes_with method: :morph, scroll: :preserve %>
 <%= turbo_stream_from user %>
@@ -17,7 +17,7 @@
           events: events,
           mutual_events: mutual_events,
           stamps: stamps,
-          events_with_stickers: events_with_stickers,
+          stickers: stickers,
           involvements_by_role: involvements_by_role,
           countries_with_events: countries_with_events
         } %>

--- a/app/views/profiles/aliases/index.html.erb
+++ b/app/views/profiles/aliases/index.html.erb
@@ -5,7 +5,7 @@
       events: @events,
       mutual_events: @mutual_events,
       stamps: @stamps,
-      events_with_stickers: @events_with_stickers,
+      stickers: @stickers,
       involvements_by_role: @involvements_by_role,
       countries_with_events: @countries_with_events,
       favorite_user: @favorite_user

--- a/app/views/profiles/events/index.html.erb
+++ b/app/views/profiles/events/index.html.erb
@@ -5,7 +5,7 @@
       events: @events,
       mutual_events: @mutual_events,
       stamps: @stamps,
-      events_with_stickers: @events_with_stickers,
+      stickers: @stickers,
       involvements_by_role: @involvements_by_role,
       countries_with_events: @countries_with_events,
       favorite_user: @favorite_user

--- a/app/views/profiles/involvements/index.html.erb
+++ b/app/views/profiles/involvements/index.html.erb
@@ -5,7 +5,7 @@
       events: @events,
       mutual_events: @mutual_events,
       stamps: @stamps,
-      events_with_stickers: @events_with_stickers,
+      stickers: @stickers,
       involvements_by_role: @involvements_by_role,
       countries_with_events: @countries_with_events,
       favorite_user: @favorite_user

--- a/app/views/profiles/map/index.html.erb
+++ b/app/views/profiles/map/index.html.erb
@@ -5,7 +5,7 @@
       events: @events,
       mutual_events: @mutual_events,
       stamps: @stamps,
-      events_with_stickers: @events_with_stickers,
+      stickers: @stickers,
       involvements_by_role: @involvements_by_role,
       countries_with_events: @countries_with_events,
       favorite_user: @favorite_user

--- a/app/views/profiles/mutual_events/index.html.erb
+++ b/app/views/profiles/mutual_events/index.html.erb
@@ -5,7 +5,7 @@
       events: @events,
       mutual_events: @mutual_events,
       stamps: @stamps,
-      events_with_stickers: @events_with_stickers,
+      stickers: @stickers,
       involvements_by_role: @involvements_by_role,
       countries_with_events: @countries_with_events,
       favorite_user: @favorite_user

--- a/app/views/profiles/notes/edit.html.erb
+++ b/app/views/profiles/notes/edit.html.erb
@@ -5,7 +5,7 @@
       events: @events,
       mutual_events: @mutual_events,
       stamps: @stamps,
-      events_with_stickers: @events_with_stickers,
+      stickers: @stickers,
       involvements_by_role: @involvements_by_role,
       countries_with_events: @countries_with_events,
       favorite_user: @favorite_user

--- a/app/views/profiles/notes/show.html.erb
+++ b/app/views/profiles/notes/show.html.erb
@@ -5,7 +5,7 @@
       events: @events,
       mutual_events: @mutual_events,
       stamps: @stamps,
-      events_with_stickers: @events_with_stickers,
+      stickers: @stickers,
       involvements_by_role: @involvements_by_role,
       countries_with_events: @countries_with_events,
       favorite_user: @favorite_user

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -15,7 +15,7 @@
           events: @events,
           mutual_events: @mutual_events,
           stamps: @stamps,
-          events_with_stickers: @events_with_stickers,
+          stickers: @stickers,
           involvements_by_role: @involvements_by_role,
           countries_with_events: @countries_with_events
         } %>

--- a/app/views/profiles/stamps/index.html.erb
+++ b/app/views/profiles/stamps/index.html.erb
@@ -5,7 +5,7 @@
       events: @events,
       mutual_events: @mutual_events,
       stamps: @stamps,
-      events_with_stickers: @events_with_stickers,
+      stickers: @stickers,
       involvements_by_role: @involvements_by_role,
       countries_with_events: @countries_with_events,
       favorite_user: @favorite_user

--- a/app/views/profiles/stickers/index.html.erb
+++ b/app/views/profiles/stickers/index.html.erb
@@ -5,10 +5,10 @@
       events: @events,
       mutual_events: @mutual_events,
       stamps: @stamps,
-      events_with_stickers: @events_with_stickers,
+      stickers: @stickers,
       involvements_by_role: @involvements_by_role,
       countries_with_events: @countries_with_events,
       favorite_user: @favorite_user
     } do %>
-  <%= render partial: "profiles/stickers", locals: {events_with_stickers: @events_with_stickers} %>
+  <%= render partial: "profiles/stickers", locals: {stickers: @stickers} %>
 <% end %>

--- a/app/views/profiles/talks/index.html.erb
+++ b/app/views/profiles/talks/index.html.erb
@@ -5,7 +5,7 @@
       events: @events,
       mutual_events: @mutual_events,
       stamps: @stamps,
-      events_with_stickers: @events_with_stickers,
+      stickers: @stickers,
       involvements_by_role: @involvements_by_role,
       countries_with_events: @countries_with_events,
       favorite_user: @favorite_user

--- a/app/views/shared/_stickers_display.html.erb
+++ b/app/views/shared/_stickers_display.html.erb
@@ -3,7 +3,7 @@
     <div class="mx-auto w-full overflow-hidden rounded-[40px] bg-gradient-to-b from-gray-300 via-gray-600 to-gray-600 p-[4px]">
       <div class="back flex overflow-hidden aspect-[16/11] w-full items-center justify-center rounded-[40px] bg-gradient-to-b from-gray-400 via-gray-500 to-gray-600">
         <div class="grid grid-cols-3 gap-[5vw] w-full h-full p-12">
-          <% events.shuffle.flat_map(&:stickers).each do |sticker| %>
+          <% stickers.shuffle.each do |sticker| %>
             <%= link_to sticker.event, class: "max-w-[10vw]", style: "transform: rotate(#{(-20...20).to_a.sample}deg) translateY(#{(0...5).to_a.sample}vw) translateX(#{(0...5).to_a.sample}vh) scale(#{100 + (-10...10).to_a.sample}%)", data: {turbo_frame: "_top"} do %>
               <%= image_tag sticker.asset_path, class: "transition transition-transform hover:scale-105" %>
             <% end %>

--- a/test/controllers/events/archive_controller_test.rb
+++ b/test/controllers/events/archive_controller_test.rb
@@ -30,7 +30,7 @@ class Events::ArchiveControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should get index and return events in the correct order" do
-    event_names = %i[brightonruby_2024 no_sponsors_event new_rb_meetup railsconf_2017 rails_world_2023 tropical_rb_2024 future_conference rubyconfth_2022 wnb_rb_meetup].map { |event| events(event) }.map(&:name)
+    event_names = %i[brightonruby_2024 no_sponsors_event new_rb_meetup railsconf_2017 railsconf_2025 rails_world_2023 tropical_rb_2024 future_conference rubyconfth_2022 wnb_rb_meetup].map { |event| events(event) }.map(&:name)
 
     get archive_events_path
 

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -133,3 +133,15 @@ new_rb_meetup:
   kind: meetup
   name: new Meetup
   slug: new-rb-meetup
+
+railsconf_2025:
+  date: 2025-07-08
+  start_date: 2025-07-08
+  end_date: 2025-07-10
+  series: railsconf
+  city: Philadelphia
+  country_code: US
+  state_code: PA
+  kind: conference
+  name: RailsConf 2025
+  slug: railsconf-2025

--- a/test/fixtures/organizations.yml
+++ b/test/fixtures/organizations.yml
@@ -54,3 +54,13 @@ three:
   logo_background: white
   domain: sponsorthree.com
   main_location: London, UK
+
+four:
+  name: D Sponsor
+  website: https://sponsorfour.com
+  description: D Sponsor is a sponsor
+  slug: sponsor-four
+  logo_url: https://sponsorfour.com/logo.png
+  logo_background: white
+  domain: sponsorfour.com
+  main_location: Berlin, DE

--- a/test/fixtures/sponsors.yml
+++ b/test/fixtures/sponsors.yml
@@ -43,3 +43,9 @@ three:
   badge: "Bronze Sponsor"
   event: railsconf_2017
   organization: three
+
+four:
+  tier: "gold"
+  badge: "Gold Sponsor"
+  event: railsconf_2025
+  organization: four

--- a/test/models/sticker_test.rb
+++ b/test/models/sticker_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class StickerTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:one)
+  end
+
+  test ".for_user returns every sticker for each event the user attended" do
+    @user.event_participations.create!(event: events(:railsconf_2025), attended_as: :visitor)
+    @user.event_participations.create!(event: events(:rails_world_2023), attended_as: :visitor)
+
+    slug_counts = Sticker.for_user(@user).map(&:event_slug).tally
+
+    assert_equal({"railsconf-2025" => 2, "rails-world-2023" => 1}, slug_counts)
+  end
+
+  test ".for_user accepts an events override" do
+    slug_counts = Sticker.for_user(@user, events: [events(:railsconf_2025)]).map(&:event_slug).tally
+
+    assert_equal({"railsconf-2025" => 2}, slug_counts)
+  end
+end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -610,4 +610,15 @@ class UserTest < ActiveSupport::TestCase
     assert_equal "Amsterdam", user.city_record.name
     assert user.city_record.users.include?(user)
   end
+
+  test "participated_events returns each event once even with multiple participations" do
+    user = users(:one)
+    event = events(:railsconf_2025)
+
+    user.event_participations.create!(event: event, attended_as: :keynote_speaker)
+    user.event_participations.create!(event: event, attended_as: :speaker)
+
+    assert_equal 2, user.event_participations.where(event: event).count
+    assert_equal [event], user.participated_events.where(id: event.id).to_a
+  end
 end


### PR DESCRIPTION
## Description
The sticker count on the tab in user profiles was incorrectly counting
only the actual number of events, not the number of stickers (some have
more than one).

In doing this, I introduced a `Sticker.for_user` as a small abstraction,
similar to the `Stamp.for_user` helper. This also makes it more
testable.

None of the fixtures included events with multiple stickers, so I pulled
in railsconf 2025 which has two stickers. This broke the
archive_controller_test, hence the change there.

## Screenshots
<img width="588" height="506" alt="image" src="https://github.com/user-attachments/assets/5af43e60-dfad-4bbd-9821-59b2d824b4fe" />

## Testing Steps
- Browse to a user with more stickers than events (e.g. anyone who attended Rubycon Italy, probably)
- Check sticker count in tab vs actual stickers shown

## References
None
