### PR TITLE
Small fixes/improvements for ical export

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -361,7 +361,7 @@ class Event < ApplicationRecord
     Icalendar::Event.new.tap do |event|
       event.uid = "RUBYEVENTS-#{id}"
       event.dtstart = Icalendar::Values::Date.new(start_date)
-      event.dtend = Icalendar::Values::Date.new(end_date + 1.day) # dtend is exclusive, add 1 day to make it inclusive
+      event.dtend = Icalendar::Values::Date.new(end_date)
       event.summary = name
       event.description = description
       event.location = static_metadata.location

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -367,6 +367,7 @@ class Event < ApplicationRecord
       event.description = description.strip
       event.location = static_metadata.location
       event.url = website
+      event.status = static_metadata.cancelled? ? "CANCELLED" : "CONFIRMED"
     end
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -360,10 +360,11 @@ class Event < ApplicationRecord
   def to_ical
     Icalendar::Event.new.tap do |event|
       event.uid = "RUBYEVENTS-#{id}"
+      event.last_modified = updated_at
       event.dtstart = Icalendar::Values::Date.new(start_date)
       event.dtend = Icalendar::Values::Date.new(end_date)
       event.summary = name
-      event.description = description
+      event.description = description.strip
       event.location = static_metadata.location
       event.url = website
     end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -290,6 +290,7 @@ class EventTest < ActiveSupport::TestCase
         DESCRIPTION:RailsWorld is a yearly conference held in Netherlands.
         LAST-MODIFIED:20260101T000000
         LOCATION:Amsterdam\\, Netherlands
+        STATUS:CONFIRMED
         SUMMARY:Rails World 2023
         URL;VALUE=URI:https://rubyonrails.org/world
         END:VEVENT

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -285,7 +285,7 @@ class EventTest < ActiveSupport::TestCase
         DTSTAMP:20260101T000000Z
         UID:RUBYEVENTS-#{event.id}
         DTSTART;VALUE=DATE:20231026
-        DTEND;VALUE=DATE:20231027
+        DTEND;VALUE=DATE:20231026
         DESCRIPTION:RailsWorld is a yearly conference held in Netherlands.\\n
         LOCATION:Amsterdam\\, Netherlands
         SUMMARY:Rails World 2023

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -279,6 +279,7 @@ class EventTest < ActiveSupport::TestCase
   test "to_ical serializes to a ical formatted string with the event details" do
     travel_to DateTime.new(2026, 1, 1) do
       event = events(:rails_world_2023)
+      event.updated_at = Time.now
 
       assert_equal <<~ICAL.gsub("\n", "\r\n"), event.to_ical.to_ical
         BEGIN:VEVENT
@@ -286,7 +287,8 @@ class EventTest < ActiveSupport::TestCase
         UID:RUBYEVENTS-#{event.id}
         DTSTART;VALUE=DATE:20231026
         DTEND;VALUE=DATE:20231026
-        DESCRIPTION:RailsWorld is a yearly conference held in Netherlands.\\n
+        DESCRIPTION:RailsWorld is a yearly conference held in Netherlands.
+        LAST-MODIFIED:20260101T000000
         LOCATION:Amsterdam\\, Netherlands
         SUMMARY:Rails World 2023
         URL;VALUE=URI:https://rubyonrails.org/world


### PR DESCRIPTION
Another round, follow up of #1714.

Four things:
- No longer +1 the end date as that's not needed now we're using full dates instead of datetime ranges.
- Add support for cancelled events, with Baltic 2026 cancelled this now shows up properly in the exported event as well.
- Strips an unnecessary new line from the end of the description.
- Added a 'last modified' property, hopefully this will help with cache invalidation as I still see old data in my gcal from days ago (the full date fix is not propagated to all events for some reason). Not sure though, this is a bit of a shot in the dark 🤷

@ChaelCodes would you mind another look? 😇