### PR TITLE
Fix copy for calendar url to not include whitespace

### DIFF
--- a/app/views/events/years/_header.html.erb
+++ b/app/views/events/years/_header.html.erb
@@ -34,9 +34,7 @@
               data-copy-to-clipboard-success-class="scale-95">
               <pre
                 class="text-sm font-mono text-gray-800 whitespace-pre-wrap break-words"
-                data-copy-to-clipboard-target="source">
-                <%= events_url(format: :ics) %>
-              </pre>
+                data-copy-to-clipboard-target="source"><%= events_url(format: :ics) %></pre>
               <button
                 class="btn btn-sm btn-outline transition-transform duration-150 ease-in-out"
                 data-action="click->copy-to-clipboard#copy"


### PR DESCRIPTION
`<pre>` preserves whitespace, so the copied text would have whitespace around it.

Fixes #1731

cc @marcoroth 
