### PR TITLE
Fix attendance count on attendance toggle

### DIFF
--- a/app/views/talks/watched_talks/toggle_attendance.turbo_stream.erb
+++ b/app/views/talks/watched_talks/toggle_attendance.turbo_stream.erb
@@ -11,3 +11,12 @@
         watched_online: @watched_online,
         has_feedback: watched_talk&.has_rating_feedback? || false %>
 <% end %>
+
+<%= turbo_stream.replace "attendance-counter" do %>
+  <% attended_count = @talk.event.talks.joins(:watched_talks).where(watched_talks: { user: Current.user, watched_on: "in_person" }).count %>
+  <% total_talks = @talk.event.talks.count %>
+  <div id="attendance-counter" class="text-right">
+    <div class="text-xl font-bold text-primary"><%= attended_count %>/<%= total_talks %></div>
+    <div class="text-xs text-gray-500">in-person</div>
+  </div>
+<% end %>


### PR DESCRIPTION
## Description
When User wants to manage the attendance on events attendance page, and toggles the in-person attendance, then total count on top right showing total in person attendance against the total talks was not getting updated.
This commit fix that issue.

## Screenshots

https://github.com/user-attachments/assets/ddf4a98a-27a5-4ce0-9abf-99c1df9d3b44


## Testing Steps
1. Login as user with Omniauth.
2. Select any event and click `Add to my Events`, and then click on `Manage my attendance`.
3. Toggle in-person attendance by selecting radio button and see that attendance count on top-right getting updated.

Fixes #1739