### PR TITLE
Update sponsors for rubyconf-austria-2026

### DIFF
--- a/data/rubyconf-austria/rubyconf-austria-2026/sponsors.yml
+++ b/data/rubyconf-austria/rubyconf-austria-2026/sponsors.yml
@@ -26,6 +26,16 @@
           slug: "appsignal"
           logo_url: "https://rubyconf.at/assets/images/sponsors/appsignal.png"
 
+        - name: "Teamtailor"
+          website: "https://teamtailor.com"
+          slug: "teamtailor"
+          logo_url: "https://rubyconf.at/assets/images/sponsors/teamtailor.png"
+
+        - name: "Undercover"
+          website: "https://undercover-ci.com/"
+          slug: "undercover"
+          logo_url: "https://rubyconf.at/assets/images/sponsors/undercover.png"
+
     - name: "Online"
       level: 3
       sponsors:
@@ -48,6 +58,11 @@
           website: "https://sultandrinks.com"
           slug: "sultan-drinks"
           logo_url: "https://rubyconf.at/assets/images/sponsors/sultandrinks.png"
+
+        - name: "Tidewave"
+          website: "https://tidewave.ai"
+          slug: "tidewave"
+          logo_url: "https://rubyconf.at/assets/images/sponsors/sponsor_tidewave.png"
 
     - name: "Community Partners"
       level: 4


### PR DESCRIPTION
## Description
<!-- Please describe your changes. -->
Add sponsors to rubyconf-austria-2026.
- Teamtailor
- Undercover
- Tidewave

## Screenshots
<!-- Add screenshots or GIFs if applicable. -->
<img width="1416" height="839" alt="Screenshot 2026-05-25 at 9 39 22 AM" src="https://github.com/user-attachments/assets/c03e11f9-e796-4bc7-b2b7-50c77ac20674" />
> Undercover is white text and so's typesense, but we've likely got other logos in production.

## Testing Steps
<!-- List steps to test your changes. -->
<!-- If this is a content PR, link to the affected pages -->
- https://rubyevents.org/events/rubyconf-austria-2026

## References
<!-- Link to related issues, discussions, other PRs, or references you used to write the PR. -->
- closes #<!-- issue number -->
