### PR TITLE
Add lint check for default venue values

### DIFF
--- a/app/models/static/validators/default_venue.rb
+++ b/app/models/static/validators/default_venue.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "generators/venue/venue_generator"
+
+module Static
+  module Validators
+    class DefaultVenue
+      def initialize(file_path:)
+        @file_path = file_path
+      end
+
+      PATTERNS = [
+        "**/venue.yml"
+      ].freeze
+
+      # Placeholder values that the venue generator leaves behind and that a
+      # contributor is expected to replace. Most are sourced directly from the
+      # generator's class_options (so they can't drift), but a few placeholders
+      # live only in the template (lib/generators/venue/templates/venue.yml.tt)
+      # or come from the geocode-failed path, so they're listed explicitly here.
+      TEMPLATE_DEFAULTS = {
+        "instructions" => ["Instructions for getting to the venue - Optional"],
+        "url" => ["Venue website url - Optional"]
+      }.freeze
+
+      EXTRA_DEFAULTS = {
+        "name" => ["TODO"]
+      }.freeze
+
+      def applicable?
+        return false unless File.exist?(@file_path)
+
+        PATTERNS.any? do |pattern|
+          File.fnmatch?(pattern, @file_path, File::FNM_PATHNAME)
+        end
+      end
+
+      def errors
+        @errors ||= validate
+      end
+
+      def validate
+        return [] unless applicable?
+
+        document = Yerba.parse_file(@file_path)
+        errors = []
+
+        default_values.each do |field, defaults|
+          value = document[field]
+          next if value.nil?
+
+          if defaults.include?(value.to_s.strip)
+            errors << build_error(
+              "#{field} is still set to the default placeholder value (#{value.to_s.strip.inspect}). Replace it with the real venue #{field}.",
+              location: value.location,
+              pointer: "/#{field}"
+            )
+          end
+        end
+
+        address = document["address"]
+        display = address && address["display"]
+        if display && address_display_defaults.include?(display.to_s.strip)
+          errors << build_error(
+            "address.display is still set to the default placeholder value (#{display.to_s.strip.inspect}). Replace it with the real venue address.",
+            location: display.location,
+            pointer: "/address/display"
+          )
+        end
+
+        errors
+      end
+
+      private
+
+      # Merge the generator's option-backed defaults (name, description, url)
+      # with the template-only and extra placeholders.
+      def default_values
+        @default_values ||= begin
+          options = VenueGenerator.class_options
+          option_defaults = {
+            "name" => [options[:name].default],
+            "description" => [options[:description].default],
+            "url" => [options[:url].default]
+          }
+
+          [option_defaults, TEMPLATE_DEFAULTS, EXTRA_DEFAULTS].each_with_object(Hash.new { |h, k| h[k] = [] }) do |source, merged|
+            source.each { |field, values| merged[field].concat(values) }
+          end
+        end
+      end
+
+      def address_display_defaults
+        [VenueGenerator.class_options[:address].default]
+      end
+
+      def build_error(message, location:, pointer:)
+        Static::Validators::Error.new(
+          "#{message} at #{pointer}",
+          file_path: @file_path,
+          line: location&.start_line || 1,
+          end_line: location&.end_line
+        )
+      end
+    end
+  end
+end

--- a/data/ruby-retreat-au/ruby-retreat-au-2026/venue.yml
+++ b/data/ruby-retreat-au/ruby-retreat-au-2026/venue.yml
@@ -3,7 +3,6 @@
 name: "Land's Edge Chowder Bay"
 description: "Tucked inside Sydney Harbour National Park, the venue is right on the water. When you're ready to step away from the keyboard, you can bushwalk the headland trails, swim, snorkel, or kayak straight from the beach."
 instructions: "From Sydney Airport, take the train to Wynyard Station. From Wynyard, catch the B-Line bus to Mosman. We will provide a shuttle service from Mosman to the venue."
-url: "Venue website url - Optional"
 
 address:
   street: "1 Chowder Bay Rd"

--- a/lib/tasks/validate.rake
+++ b/lib/tasks/validate.rake
@@ -38,6 +38,39 @@ namespace :validate do
     exit 1 if validate_event_files.any?
   end
 
+  def validate_venue_files
+    validators = [
+      Static::Validators::DefaultVenue
+    ]
+    file_errors = Hash.new { |h, k| h[k] = [] }
+    files = Dir.glob(Rails.root.join("data/**/venue.yml"))
+
+    files.each do |file|
+      validators.each do |validator_class|
+        validator = validator_class.new(file_path: file)
+        validator.errors.each do |error|
+          file_errors[error.file_path] << error
+        end
+      end
+    end
+
+    if file_errors.empty?
+      puts Gum.style("✓ All venue.yml files passed validations!", foreground: "2")
+    else
+      file_errors.each do |file, errors|
+        puts Gum.style(file, foreground: "1")
+        errors.each { |e| puts e.as_error }
+        puts
+      end
+    end
+    file_errors.values.flatten
+  end
+
+  desc "Validate venue.yml files"
+  task venues: :environment do
+    exit 1 if validate_venue_files.any?
+  end
+
   def validate_speakers_file
     validators = [
       Static::Validators::UniqueSpeakerFields,
@@ -243,6 +276,9 @@ namespace :validate do
 
     puts Gum.style("Validating event.yml files", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
     results << validate_event_files.none?
+
+    puts Gum.style("Validating venue.yml files", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
+    results << validate_venue_files.none?
 
     puts Gum.style("Validating speakers.yml file", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
     results << validate_speakers_file.none?

--- a/test/models/static/validators/default_venue_test.rb
+++ b/test/models/static/validators/default_venue_test.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Static::Validators::DefaultVenueTest < ActiveSupport::TestCase
+  test "applicable? returns true for a venue.yml file" do
+    file = Dir.glob(Rails.root.join("data/**/venue.yml")).first
+    validator = Static::Validators::DefaultVenue.new(file_path: file)
+    assert validator.applicable?
+  end
+
+  test "applicable? returns false for a non-venue.yml file" do
+    file = Dir.glob(Rails.root.join("data/**/event.yml")).first
+    validator = Static::Validators::DefaultVenue.new(file_path: file)
+    assert_not validator.applicable?
+  end
+
+  test "applicable? returns false for a non-existent file" do
+    validator = Static::Validators::DefaultVenue.new(file_path: "/nonexistent/venue.yml")
+    assert_not validator.applicable?
+  end
+
+  test "returns empty errors for a filled-in venue" do
+    yaml = {
+      "name" => "The Leonardo",
+      "description" => "A science and art museum",
+      "address" => {"display" => "209 E 500 S, Salt Lake City, UT 84111, USA"}
+    }.to_yaml
+    with_temp_venue_yaml(yaml) do |path|
+      validator = Static::Validators::DefaultVenue.new(file_path: path)
+      assert_empty validator.errors
+    end
+  end
+
+  test "returns error when name is the default TODO placeholder" do
+    yaml = {"name" => "TODO"}.to_yaml
+    with_temp_venue_yaml(yaml) do |path|
+      validator = Static::Validators::DefaultVenue.new(file_path: path)
+      assert validator.errors.any? { |e| e.to_h["message"].include?("name") }
+    end
+  end
+
+  test "returns error when name is the default 'TODO Venue name' placeholder" do
+    yaml = {"name" => "TODO Venue name"}.to_yaml
+    with_temp_venue_yaml(yaml) do |path|
+      validator = Static::Validators::DefaultVenue.new(file_path: path)
+      assert validator.errors.any? { |e| e.to_h["message"].include?("name") }
+    end
+  end
+
+  test "returns error when description is the default placeholder" do
+    yaml = {
+      "name" => "Real Venue",
+      "description" => "TODO - Description of the venue - Optional"
+    }.to_yaml
+    with_temp_venue_yaml(yaml) do |path|
+      validator = Static::Validators::DefaultVenue.new(file_path: path)
+      assert validator.errors.any? { |e| e.to_h["message"].include?("description") }
+    end
+  end
+
+  test "returns error when instructions is the default placeholder" do
+    yaml = {
+      "name" => "Real Venue",
+      "instructions" => "Instructions for getting to the venue - Optional"
+    }.to_yaml
+    with_temp_venue_yaml(yaml) do |path|
+      validator = Static::Validators::DefaultVenue.new(file_path: path)
+      assert validator.errors.any? { |e| e.to_h["message"].include?("instructions") }
+    end
+  end
+
+  test "returns error when url is the default placeholder" do
+    yaml = {
+      "name" => "Real Venue",
+      "url" => "Venue website url - Optional"
+    }.to_yaml
+    with_temp_venue_yaml(yaml) do |path|
+      validator = Static::Validators::DefaultVenue.new(file_path: path)
+      assert validator.errors.any? { |e| e.to_h["message"].include?("url") }
+    end
+  end
+
+  test "returns error when address.display is the default placeholder" do
+    yaml = {
+      "name" => "Real Venue",
+      "address" => {"display" => "123 TODO St, City, State, ZIP, Country"}
+    }.to_yaml
+    with_temp_venue_yaml(yaml) do |path|
+      validator = Static::Validators::DefaultVenue.new(file_path: path)
+      assert validator.errors.any? { |e| e.to_h["message"].include?("address.display") }
+    end
+  end
+
+  test "errors are Static::Validators::Error objects" do
+    yaml = {"name" => "TODO"}.to_yaml
+    with_temp_venue_yaml(yaml) do |path|
+      validator = Static::Validators::DefaultVenue.new(file_path: path)
+      assert validator.errors.all? { |e| e.is_a?(Static::Validators::Error) }
+    end
+  end
+
+  private
+
+  def with_temp_venue_yaml(yaml_content)
+    dir = Dir.mktmpdir
+    path = File.join(dir, "data", "testconf", "2025", "venue.yml")
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, yaml_content)
+    yield path
+  ensure
+    FileUtils.rm_rf(dir)
+  end
+end


### PR DESCRIPTION
## What

Adds a venue linter that fails when a `venue.yml` still contains the placeholder values left behind by the venue generator. This catches venues that were scaffolded but never filled in before being committed.

## Details

- New validator `Static::Validators::DefaultVenue` flags default placeholders for `name`, `description`, `instructions`, `url`, and `address.display`. Where possible it sources the defaults directly from `VenueGenerator.class_options` so they can't drift from the generator; template-only literals and the bare `TODO` placeholder are listed explicitly.
- Wired into `lib/tasks/validate.rake` via a new `validate:venues` task and added to `validate:all` (the CI path).
- Added test coverage in `test/models/static/validators/default_venue_test.rb`.

## Data fix

The linter caught one pre-existing offender: `data/ruby-retreat-au/ruby-retreat-au-2026/venue.yml` still had the placeholder `url`. Removed the placeholder line (`url` is optional in `VenueSchema`). Follow-up to supply the real URL tracked in #1753.

## Testing

- `bin/rails test test/models/static/validators/default_venue_test.rb` — 11 runs, 0 failures
- `bin/rails validate:venues` — all venue.yml files pass