### PR TITLE
Calendar: fix multi day events by making dtend inclusive again

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -362,7 +362,11 @@ class Event < ApplicationRecord
       event.uid = "RUBYEVENTS-#{id}"
       event.last_modified = updated_at
       event.dtstart = Icalendar::Values::Date.new(start_date)
-      event.dtend = Icalendar::Values::Date.new(end_date)
+
+      if end_date > start_date
+        event.dtend = Icalendar::Values::Date.new(end_date + 1.day) # dtend is exclusive, add 1 day to make it inclusive
+      end
+
       event.summary = name
       event.description = description.strip
       event.location = static_metadata.location

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -286,7 +286,6 @@ class EventTest < ActiveSupport::TestCase
         DTSTAMP:20260101T000000Z
         UID:RUBYEVENTS-#{event.id}
         DTSTART;VALUE=DATE:20231026
-        DTEND;VALUE=DATE:20231026
         DESCRIPTION:RailsWorld is a yearly conference held in Netherlands.
         LAST-MODIFIED:20260101T000000
         LOCATION:Amsterdam\\, Netherlands
@@ -296,5 +295,14 @@ class EventTest < ActiveSupport::TestCase
         END:VEVENT
       ICAL
     end
+  end
+
+  test "to_ical sets an inclusive DTEND for multi-day events" do
+    event = events(:railsconf_2025)
+
+    ical = event.to_ical.to_ical
+
+    assert_includes ical, "DTSTART;VALUE=DATE:20250708"
+    assert_includes ical, "DTEND;VALUE=DATE:20250711"
   end
 end


### PR DESCRIPTION
I removed this in #1727 based on wrong assumptions. I don't remember what caused me to remove it. This adds it back, but only in case the event span multiple days.

## Screenshots
Before:

- You can see Blastoff Rails, Baltic Ruby and Ruby Retreat being one day too short. The one day events are displayed properly.

<img width="3824" height="2484" alt="CleanShot 2026-06-01 at 15 53 40@2x" src="https://github.com/user-attachments/assets/8c7224a5-da25-4823-aea0-41da4991e9bd" />

After:
<img width="3824" height="2484" alt="CleanShot 2026-06-01 at 15 49 48@2x" src="https://github.com/user-attachments/assets/29e03b92-f9be-4b20-ac3b-924c8508c3f6" />

## References
- #1727 