### PR TITLE
Update video details for RubyConf 2026

### DIFF
--- a/data/rubyconf/rubyconf-2026/videos.yml
+++ b/data/rubyconf/rubyconf-2026/videos.yml
@@ -42,18 +42,19 @@
   speakers:
     - Michael Toppa
 
-- id: "sponsor-session-1-rubyconf-2026"
-  title: "Sponsor Session 1"
+- id: "chris-fung-rubyconf-2026"
+  title: "Stop Fighting Ruby I18n: Message Format Is All You Need"
   kind: "talk"
   event_name: "RubyConf 2026"
   date: "2026-07-14"
   language: "English"
   track: "Breakout 2 - Charleston E-B"
   video_provider: "scheduled"
-  video_id: "sponsor-session-1-rubyconf-2026"
-  description: ""
+  video_id: "chris-fung-rubyconf-2026"
+  description: |-
+    Ruby I18n tries to do the simplest thing that works in the most common situations. But do you know all of the pitfalls and trip-ups hiding within? What if there was an alternative that was just as simple and didn't require remembering gotchas? This talk is aimed at experienced Rails developers who have worked on multi-lingual applications. This talk will introduce i18n-message_format as an alternative to the built-in I18n module that ships with every Rails app.
   speakers:
-    - TODO
+    - Chris Fung
 
 - id: "jeremy-evans-rubyconf-2026"
   title: "Implementing Core Set"

--- a/data/rubyconf/rubyconf-2026/videos.yml
+++ b/data/rubyconf/rubyconf-2026/videos.yml
@@ -42,7 +42,7 @@
   speakers:
     - Michael Toppa
 
-- id: "chris-fung-rubyconf-2026"
+- id: "sponsor-session-1-rubyconf-2026"
   title: "Stop Fighting Ruby I18n: Message Format Is All You Need"
   kind: "talk"
   event_name: "RubyConf 2026"


### PR DESCRIPTION
## Description
Updating RubyConf 2026 schedule to fill in details for "Sponsor Session 1"

## Screenshots
<!-- Add screenshots or GIFs if applicable. -->

## Testing Steps
<!-- List steps to test your changes. -->
<!-- If this is a content PR, link to the affected pages -->

## References
https://rubyconf.org/schedule/
