### PR TITLE
Add schedule for Blastoff Rails 2026

### DIFF
--- a/data/blastoffrails/blastoffrails-2026/schedule.yml
+++ b/data/blastoffrails/blastoffrails-2026/schedule.yml
@@ -1,0 +1,116 @@
+# Schedule: https://blastoffrails.com/schedule
+---
+days:
+  - name: "Day 1"
+    date: "2026-06-11"
+    grid:
+      - start_time: "08:30"
+        end_time: "09:30"
+        slots: 1
+        items:
+          - "Registration & Light Breakfast"
+
+      - start_time: "09:30"
+        end_time: "10:00"
+        slots: 1
+        items:
+          - "Opening Remarks"
+
+      - start_time: "10:00"
+        end_time: "10:30"
+        slots: 1
+
+      - start_time: "10:30"
+        end_time: "11:00"
+        slots: 1
+        items:
+          - "Break"
+
+      - start_time: "11:00"
+        end_time: "11:30"
+        slots: 1
+
+      - start_time: "11:30"
+        end_time: "12:00"
+        slots: 1
+        items:
+          - "Break"
+
+      - start_time: "12:00"
+        end_time: "12:30"
+        slots: 1
+
+      - start_time: "12:30"
+        end_time: "14:30"
+        slots: 1
+        items:
+          - "Lunch"
+
+      - start_time: "14:30"
+        end_time: "15:30"
+        slots: 1
+        items:
+          - "Activity Slot"
+
+      - start_time: "15:30"
+        end_time: "16:00"
+        slots: 1
+
+  - name: "Day 2"
+    date: "2026-06-12"
+    grid:
+      - start_time: "08:30"
+        end_time: "09:30"
+        slots: 1
+        items:
+          - "Light Breakfast"
+
+      - start_time: "09:30"
+        end_time: "10:00"
+        slots: 1
+
+      - start_time: "10:00"
+        end_time: "10:30"
+        slots: 1
+        items:
+          - "Break"
+
+      - start_time: "10:30"
+        end_time: "11:00"
+        slots: 1
+
+      - start_time: "11:00"
+        end_time: "11:30"
+        slots: 1
+        items:
+          - "Break"
+
+      - start_time: "11:30"
+        end_time: "12:00"
+        slots: 1
+
+      - start_time: "12:00"
+        end_time: "14:00"
+        slots: 1
+        items:
+          - "Lunch"
+
+      - start_time: "14:00"
+        end_time: "15:00"
+        slots: 1
+        items:
+          - "Activity Slot"
+
+      - start_time: "15:00"
+        end_time: "15:30"
+        slots: 1
+
+      - start_time: "15:30"
+        end_time: "16:00"
+        slots: 1
+        items:
+          - "Break"
+
+      - start_time: "16:00"
+        end_time: "16:30"
+        slots: 1

--- a/data/blastoffrails/blastoffrails-2026/videos.yml
+++ b/data/blastoffrails/blastoffrails-2026/videos.yml
@@ -9,26 +9,6 @@
   speakers:
     - Irina Nazarova
 
-- id: "kieran-klaassen-blastoffrails-2026"
-  title: "Keynote: Kieran Klaassen"
-  date: "2026-06-11"
-  video_provider: "scheduled"
-  video_id: "blastoffrails-2026-kieran-klaassen-keynote"
-  description: |-
-    General Manager of Cora, Kieran Klaassen is a serial entrepreneur and a proponent of agentic coding and compounding engineering.
-  speakers:
-    - Kieran Klaassen
-
-- id: "avi-flombaum-blastoffrails-2026"
-  title: "How to become a famous Ruby, Rails, Agentic Developer"
-  date: "2026-06-11"
-  video_provider: "scheduled"
-  video_id: "avi-flombaum-blastoffrails-2026"
-  description: |-
-    The next generation of great developers will not just write code. They will design workflows. They will build tools. They will publish their thinking. In this talk, Avi will show you how to understand and design your own development workflow, build your own tools while intelligently leveraging the ecosystem, create an Agentic Workbench tailored to how you think and ship, and write and publish in a way that compounds your reputation. Fame is not luck. It is output plus distribution. Let's build both.
-  speakers:
-    - Avi Flombaum
-
 - id: "neha-abraham-blastoffrails-2026"
   title: "Powerful Data: Making Rails Apps Faster with Aggregation"
   date: "2026-06-11"
@@ -39,35 +19,15 @@
   speakers:
     - Neha Abraham
 
-- id: "nikky-southerland-blastoffrails-2026"
-  title: "Spaceships, Radiation Therapy, and Power Users"
+- id: "matheus-richard-blastoffrails-2026"
+  title: "Rubyists can make games too!"
   date: "2026-06-11"
   video_provider: "scheduled"
-  video_id: "nikky-southerland-blastoffrails-2026"
+  video_id: "matheus-richard-blastoffrails-2026"
   description: |-
-    We build software that our users interact with daily, and it's only natural that over time they become really, really good at navigating the interfaces we've designed. This is great! Except their skill makes them more prone to introducing unintended behavior to the system. We'll zoom in on a couple of notable interface designs from history: Apollo's guidance computer and the Therac-25 radiation therapy machine. We'll explore how to proactively keep power users in mind to increase efficiency and reduce frustration.
+    Every developer dreams of making a game but eventually gets swallowed by the corporate job world. Dream no more. You don't need engines or new languages. You already have everything you need: Ruby. Let's build a real game together and scratch that gamedev itch you never outgrew.
   speakers:
-    - Nikky Southerland
-
-- id: "andrew-mason-blastoffrails-2026"
-  title: "We Are the Ruby Community"
-  date: "2026-06-11"
-  video_provider: "scheduled"
-  video_id: "andrew-mason-blastoffrails-2026"
-  description: |-
-    Many developers feel like observers of the Ruby community rather than participants in it. This talk reframes what community actually means, breaks down the invisible barriers that make people feel like they don't belong, and shows practical ways anyone can participate right away. The goal is to show that the Ruby community isn't something you join, it's something you help create.
-  speakers:
-    - Andrew Mason
-
-- id: "ifat-ribon-blastoffrails-2026"
-  title: "Fewer Tests, More Confidence"
-  date: "2026-06-11"
-  video_provider: "scheduled"
-  video_id: "ifat-ribon-blastoffrails-2026"
-  description: |-
-    AI can write tests in seconds, but it can't tell you which ones matter (yet). This talk shows how Rails teams can build high-confidence test suites when AI generates most specs, using clear testing principles and practical guidelines to write fewer, better, and more maintainable tests.
-  speakers:
-    - Ifat Ribon
+    - Matheus Richard
 
 - id: "stephen-mckeon-blastoffrails-2026"
   title: "Why We're Still Training Rails Developers in an Age of AI"
@@ -79,12 +39,52 @@
   speakers:
     - Stephen McKeon
 
-- id: "matheus-richard-blastoffrails-2026"
-  title: "Rubyists can make games too!"
-  date: "2026-06-11"
+- id: "kieran-klaassen-blastoffrails-2026"
+  title: "Keynote: Kieran Klaassen"
+  date: "2026-06-12"
   video_provider: "scheduled"
-  video_id: "matheus-richard-blastoffrails-2026"
+  video_id: "blastoffrails-2026-kieran-klaassen-keynote"
   description: |-
-    Every developer dreams of making a game but eventually gets swallowed by the corporate job world. Dream no more. You don't need engines or new languages. You already have everything you need: Ruby. Let's build a real game together and scratch that gamedev itch you never outgrew.
+    General Manager of Cora, Kieran Klaassen is a serial entrepreneur and a proponent of agentic coding and compounding engineering.
   speakers:
-    - Matheus Richard
+    - Kieran Klaassen
+
+- id: "nikky-southerland-blastoffrails-2026"
+  title: "Spaceships, Radiation Therapy, and Power Users"
+  date: "2026-06-12"
+  video_provider: "scheduled"
+  video_id: "nikky-southerland-blastoffrails-2026"
+  description: |-
+    We build software that our users interact with daily, and it's only natural that over time they become really, really good at navigating the interfaces we've designed. This is great! Except their skill makes them more prone to introducing unintended behavior to the system. We'll zoom in on a couple of notable interface designs from history: Apollo's guidance computer and the Therac-25 radiation therapy machine. We'll explore how to proactively keep power users in mind to increase efficiency and reduce frustration.
+  speakers:
+    - Nikky Southerland
+
+- id: "avi-flombaum-blastoffrails-2026"
+  title: "Don't Read the Code: Trusting AI With Your Rails Codebase"
+  date: "2026-06-12"
+  video_provider: "scheduled"
+  video_id: "avi-flombaum-blastoffrails-2026"
+  description: |-
+    Details coming soon.
+  speakers:
+    - Avi Flombaum
+
+- id: "ifat-ribon-blastoffrails-2026"
+  title: "Fewer Tests, More Confidence"
+  date: "2026-06-12"
+  video_provider: "scheduled"
+  video_id: "ifat-ribon-blastoffrails-2026"
+  description: |-
+    AI can write tests in seconds, but it can't tell you which ones matter (yet). This talk shows how Rails teams can build high-confidence test suites when AI generates most specs, using clear testing principles and practical guidelines to write fewer, better, and more maintainable tests.
+  speakers:
+    - Ifat Ribon
+
+- id: "andrew-mason-blastoffrails-2026"
+  title: "We Are the Ruby Community"
+  date: "2026-06-12"
+  video_provider: "scheduled"
+  video_id: "andrew-mason-blastoffrails-2026"
+  description: |-
+    Many developers feel like observers of the Ruby community rather than participants in it. This talk reframes what community actually means, breaks down the invisible barriers that make people feel like they don't belong, and shows practical ways anyone can participate right away. The goal is to show that the Ruby community isn't something you join, it's something you help create.
+  speakers:
+    - Andrew Mason


### PR DESCRIPTION
## Description
Adding schedule for Blastoff Rails 2026, update some talk details

## Screenshots
Spun up locally to make it works
<img width="3156" height="1712" alt="image" src="https://github.com/user-attachments/assets/c7534167-5d3b-4a47-bd42-b6a284454a6e" />


