### PR TITLE
Normalize Mastodon handle into profile URL and reject dangerous schemas.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -153,7 +153,11 @@ class User < ApplicationRecord
   normalizes :linkedin, with: ->(value) { value.gsub(%r{https?://(?:www\.)?(?:linkedin\.com/in)/}, "") }
 
   normalizes :mastodon, with: ->(value) {
-    return value if value&.match?(URI::DEFAULT_PARSER.make_regexp)
+    return "" if value.blank?
+
+    # Only allow http(s) URLs through verbatim; reject javascript: and other
+    # potentially dangerous schemas.
+    return value if value.match?(%r{\Ahttps?://}i)
     return "" unless value.count("@") == 2
 
     _, handle, instance = value.split("@")

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -89,6 +89,30 @@ class UserTest < ActiveSupport::TestCase
     assert_equal "tekin", user.github_handle
   end
 
+  test "should normalize mastodon handle into a profile URL" do
+    user = users(:one)
+
+    user.mastodon = "@matz@ruby.social"
+    user.save
+    assert_equal "https://ruby.social/@matz", user.mastodon
+
+    user.mastodon = "https://ruby.social/@matz"
+    user.save
+    assert_equal "https://ruby.social/@matz", user.mastodon
+  end
+
+  test "should reject dangerous mastodon URI schemes" do
+    user = users(:one)
+
+    user.mastodon = "javascript:alert(document.cookie)"
+    user.save
+    assert_equal "", user.mastodon
+
+    user.mastodon = "data:text/html,<script>alert(1)</script>"
+    user.save
+    assert_equal "", user.mastodon
+  end
+
   test "find_by_name_or_alias finds user by exact name" do
     user = User.create!(name: "Yukihiro Matsumoto", github_handle: "matz-test-1")
 


### PR DESCRIPTION
## Description

AI Disclosure: Changeset generated with Claude Code, reviewed and tested by me.

This isn't actually realistically abusable by an attacker right now because the link is `target="_blank"` which removes all ability to use the `javascript:` schema in modern browsers, but I figure it's best to be safe here just in case.

This normalizes the Mastodon URL on user profiles to prevent any URLs outside the normal `http`/`https` schema. It still allows the `@username@mastodon.host` format as well.

## Screenshots

Previously I was able to set the value to a malicious javascript command, but it will not save that to the database anymore after this PR:

<img width="736" height="704" alt="Screenshot 2026-06-07 at 3 27 28 PM" src="https://github.com/user-attachments/assets/9c7f9d74-0f2a-4f55-8e36-fc29e8041647" />

But normal usernames/URLs continue to work fine:

<img width="446" height="297" alt="Screenshot 2026-06-07 at 3 28 46 PM" src="https://github.com/user-attachments/assets/77e32fe5-57e7-4521-902b-ce0d6013519b" />

## Testing Steps

- Set a Mastodon username using a URL, ensure the user page renders and the link works.
- Set a Mastodon username using the `@name@host.com` format, ensure the user page renders and the link works correctly.
- Set a Mastodon username as `javascript:alert(document.cookie)`, see that it gets reset to blank string. 

## References

N/A