### PR TITLE
Make RubyEvents visible to search + AI: sitemap fix, .md page twins, llms.txt (+ Cloudflare AI-block note)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,14 +4,27 @@ class ApplicationController < ActionController::Base
   include Analytics
 
   prepend_before_action :redirect_to_ruby_events
+  after_action :set_markdown_alternate_headers
 
-  helper_method :default_watch_list
+  helper_method :default_watch_list, :markdown_alternate_url
 
   def default_watch_list
     @default_watch_list ||= Current.user&.default_watch_list
   end
 
+  # Absolute URL of the Markdown twin of the current page, when one exists. Set
+  # by content actions (talks, profiles, events, topics) and surfaced to crawlers
+  # via the layout (<link rel="alternate">) and the Link response header.
+  attr_reader :markdown_alternate_url
+
   private
+
+  def set_markdown_alternate_headers
+    return if @markdown_alternate_url.blank? || !request.format.html?
+
+    response.headers["Link"] = %(<#{@markdown_alternate_url}>; rel="alternate"; type="text/markdown")
+    response.headers["Vary"] = [response.headers["Vary"].presence, "Accept"].compact.uniq.join(", ")
+  end
 
   def redirect_to_ruby_events
     return if Rails.env.local?

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -29,25 +29,10 @@ class EventsController < ApplicationController
 
   # GET /events/1
   def show
-    set_meta_tags(@event)
-
-    if @event.meetup?
-      all_meetup_events = @event.talks.where(meta_talk: true).includes(:speakers, :parent_talk, child_talks: :speakers)
-      @upcoming_meetup_events = all_meetup_events.where("date >= ?", Date.today).order(date: :asc).limit(4)
-      @recent_meetup_events = all_meetup_events.where("date < ?", Date.today).order(date: :desc).limit(4)
-      @recent_talks = @event.talks.where(meta_talk: false).includes(:speakers, :parent_talk, child_talks: :speakers).order(date: :desc).to_a.sample(8)
-      @featured_speakers = @event.speakers.joins(:talks).distinct.to_a.sample(8)
-    else
-      @keynotes = @event.talks.joins(:speakers).where(kind: "keynote").includes(:speakers, event: :series)
-      @recent_talks = @event.talks.watchable.includes(:speakers, event: :series).limit(8).shuffle
-      keynote_speakers = @event.speakers.joins(:talks).where(talks: {kind: "keynote"}).distinct
-      other_speakers = @event.speakers.joins(:talks).where.not(talks: {kind: "keynote"}).distinct.limit(8)
-      @featured_speakers = (keynote_speakers + other_speakers.first(8 - keynote_speakers.size)).uniq.shuffle
+    respond_to do |format|
+      format.html { load_event_data_for_show }
+      format.md { render plain: MarkdownPresenters::EventPresenter.new(@event).to_markdown, content_type: "text/markdown" }
     end
-
-    @sponsors = @event.sponsors.includes(:organization).joins(:organization).order(level: :asc)
-
-    @participation = Current.user&.main_participation_to(@event)
   end
 
   # GET /events/1/edit
@@ -88,6 +73,29 @@ class EventsController < ApplicationController
   end
 
   private
+
+  def load_event_data_for_show
+    set_meta_tags(@event)
+    @markdown_alternate_url = event_url(@event, format: :md)
+
+    if @event.meetup?
+      all_meetup_events = @event.talks.where(meta_talk: true).includes(:speakers, :parent_talk, child_talks: :speakers)
+      @upcoming_meetup_events = all_meetup_events.where("date >= ?", Date.today).order(date: :asc).limit(4)
+      @recent_meetup_events = all_meetup_events.where("date < ?", Date.today).order(date: :desc).limit(4)
+      @recent_talks = @event.talks.where(meta_talk: false).includes(:speakers, :parent_talk, child_talks: :speakers).order(date: :desc).to_a.sample(8)
+      @featured_speakers = @event.speakers.joins(:talks).distinct.to_a.sample(8)
+    else
+      @keynotes = @event.talks.joins(:speakers).where(kind: "keynote").includes(:speakers, event: :series)
+      @recent_talks = @event.talks.watchable.includes(:speakers, event: :series).limit(8).shuffle
+      keynote_speakers = @event.speakers.joins(:talks).where(talks: {kind: "keynote"}).distinct
+      other_speakers = @event.speakers.joins(:talks).where.not(talks: {kind: "keynote"}).distinct.limit(8)
+      @featured_speakers = (keynote_speakers + other_speakers.first(8 - keynote_speakers.size)).uniq.shuffle
+    end
+
+    @sponsors = @event.sponsors.includes(:organization).joins(:organization).order(level: :asc)
+
+    @participation = Current.user&.main_participation_to(@event)
+  end
 
   # Use callbacks to share common setup or constraints between actions.
   def set_event

--- a/app/controllers/llms_controller.rb
+++ b/app/controllers/llms_controller.rb
@@ -1,0 +1,21 @@
+class LlmsController < ApplicationController
+  skip_before_action :authenticate_user!
+
+  # GET /llms.txt
+  def index
+    body = Rails.cache.fetch(["llms_txt", Talk.maximum(:updated_at)], expires_in: 12.hours) do
+      MarkdownPresenters::LlmsIndex.new.to_text
+    end
+
+    render plain: body, content_type: "text/plain"
+  end
+
+  # GET /llms-full.txt
+  def full
+    body = Rails.cache.fetch(["llms_full_txt", Talk.maximum(:updated_at), Talk.count], expires_in: 12.hours) do
+      MarkdownPresenters::LlmsFull.new.to_text
+    end
+
+    render plain: body, content_type: "text/plain"
+  end
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -14,12 +14,22 @@ class ProfilesController < ApplicationController
 
   # GET /profiles/:slug
   def show
-    load_profile_data_for_show
+    respond_to do |format|
+      format.html do
+        load_profile_data_for_show
 
-    if @user.suspicious?
-      set_meta_tags(robots: "noindex, nofollow")
-    else
-      set_meta_tags(@user)
+        if @user.suspicious?
+          set_meta_tags(robots: "noindex, nofollow")
+        else
+          set_meta_tags(@user)
+          @markdown_alternate_url = profile_url(@user, format: :md)
+        end
+      end
+      format.md do
+        return head(:not_found) if @user.suspicious?
+
+        render plain: MarkdownPresenters::SpeakerPresenter.new(@user).to_markdown, content_type: "text/markdown"
+      end
     end
   end
 

--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -28,7 +28,7 @@ class SitemapsController < ApplicationController
 
         add events_path, priority: 0.7, changefreq: "weekly"
 
-        Event.canonical.pluck(:slug, :updated_at) do |event_slug, updated_at|
+        Event.canonical.pluck(:slug, :updated_at).each do |event_slug, updated_at|
           add event_path(event_slug), priority: 0.9, lastmod: updated_at
         end
 

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -20,7 +20,14 @@ class TalksController < ApplicationController
 
   # GET /talks/1
   def show
-    set_meta_tags(@talk)
+    respond_to do |format|
+      format.html do
+        set_meta_tags(@talk)
+        @markdown_alternate_url = talk_url(@talk, format: :md)
+      end
+      format.json # show.json.jbuilder
+      format.md { render plain: MarkdownPresenters::TalkPresenter.new(@talk).to_markdown, content_type: "text/markdown" }
+    end
   end
 
   private

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -15,14 +15,21 @@ class TopicsController < ApplicationController
     @topic = Topic.find_by(slug: params[:slug])
     return redirect_to(root_path, status: :moved_permanently) unless @topic
 
-    @pagy, @talks = pagy_countless(
-      @topic.talks.includes(:speakers, event: :series, child_talks: :speakers).order(date: :desc),
-      gearbox_extra: true,
-      gearbox_limit: [12, 24, 48, 96],
-      overflow: :empty_page,
-      page: page_number
-    )
-    set_meta_tags(@topic)
+    respond_to do |format|
+      format.any(:html, :turbo_stream) do
+        @pagy, @talks = pagy_countless(
+          @topic.talks.includes(:speakers, event: :series, child_talks: :speakers).order(date: :desc),
+          gearbox_extra: true,
+          gearbox_limit: [12, 24, 48, 96],
+          overflow: :empty_page,
+          page: page_number
+        )
+        set_meta_tags(@topic)
+        @markdown_alternate_url = topic_url(@topic, format: :md)
+        render
+      end
+      format.md { render plain: MarkdownPresenters::TopicPresenter.new(@topic).to_markdown, content_type: "text/markdown" }
+    end
   end
 
   def set_user_favorites

--- a/app/presenters/markdown_presenters/base_presenter.rb
+++ b/app/presenters/markdown_presenters/base_presenter.rb
@@ -1,0 +1,34 @@
+# Base class for objects that render a model as clean Markdown.
+#
+# These presenters are the single source of truth for the `.md` versions of
+# pages (served both at `/path.md` and via `Accept: text/markdown`) and for the
+# `/llms.txt` and `/llms-full.txt` files. They build absolute, canonical URLs so
+# the output is portable when copied into an LLM context.
+module MarkdownPresenters
+  class BasePresenter
+    include Rails.application.routes.url_helpers
+
+    HOST = "https://www.rubyevents.org".freeze
+
+    def default_url_options
+      {host: HOST}
+    end
+
+    private
+
+    def link(text, url)
+      "[#{text}](#{url})"
+    end
+
+    # First non-empty paragraph, collapsed to a single line for use as a summary.
+    def lead(text)
+      return nil if text.blank?
+
+      text.to_s.strip.split(/\n{2,}/).first.to_s.squish.presence
+    end
+
+    def list(items)
+      items.compact_blank.join("\n")
+    end
+  end
+end

--- a/app/presenters/markdown_presenters/event_presenter.rb
+++ b/app/presenters/markdown_presenters/event_presenter.rb
@@ -1,0 +1,49 @@
+module MarkdownPresenters
+  class EventPresenter < BasePresenter
+    def initialize(event)
+      @event = event
+    end
+
+    def to_markdown
+      [
+        "# #{@event.name}",
+        blockquote,
+        metadata,
+        talks_section,
+        footer
+      ].compact_blank.join("\n\n") + "\n"
+    end
+
+    private
+
+    def blockquote
+      lead = lead(@event.description)
+      "> #{lead}" if lead
+    end
+
+    def metadata
+      list([
+        ("- **Location:** #{@event.location}" if @event.location.present?),
+        ("- **Dates:** #{@event.formatted_dates}" if @event.start_date),
+        ("- **Series:** #{link(@event.series.name, series_url(@event.series))}" if @event.series)
+      ]).presence
+    end
+
+    def talks_section
+      talks = @event.talks.includes(:speakers).order(date: :asc, id: :asc)
+      return if talks.empty?
+
+      lines = talks.map do |talk|
+        speakers = talk.speakers.map(&:name).join(", ")
+        line = "- #{link(talk.title, talk_url(talk, format: :md))}"
+        speakers.present? ? "#{line}: #{speakers}" : line
+      end
+
+      "## Talks (#{talks.size})\n\n#{lines.join("\n")}"
+    end
+
+    def footer
+      "---\n\n#{link("View this event on RubyEvents", event_url(@event))}"
+    end
+  end
+end

--- a/app/presenters/markdown_presenters/llms_full.rb
+++ b/app/presenters/markdown_presenters/llms_full.rb
@@ -1,0 +1,35 @@
+module MarkdownPresenters
+  # Renders `/llms-full.txt`: a complete, flat index of every talk with a link to
+  # its Markdown version, grouped by event. Heavier than `/llms.txt`, so it is
+  # cached and built from plucked columns to keep memory bounded.
+  class LlmsFull < BasePresenter
+    def to_text
+      ([header] + event_sections).join("\n\n") + "\n"
+    end
+
+    private
+
+    def header
+      "# RubyEvents: complete talk index\n\n" \
+        "> Every recorded Ruby talk on RubyEvents (#{Talk.count} talks across " \
+        "#{Event.count} events), grouped by event. Each link points to the " \
+        "Markdown version of the talk. The content is MIT-licensed."
+    end
+
+    def event_sections
+      talks_by_event = Talk.includes(:speakers, event: :series).where.not(date: nil).order(date: :desc).group_by(&:event)
+
+      talks_by_event.sort_by { |event, _| event&.start_date || Date.new(0) }.reverse.map do |event, talks|
+        heading = event ? link(event.name, event_url(event)) : "Other"
+        lines = talks.map { |talk| talk_line(talk) }
+        "## #{heading}\n\n#{lines.join("\n")}"
+      end
+    end
+
+    def talk_line(talk)
+      speakers = talk.speakers.map(&:name).join(", ")
+      line = "- #{link(talk.title, talk_url(talk, format: :md))}"
+      speakers.present? ? "#{line}: #{speakers}" : line
+    end
+  end
+end

--- a/app/presenters/markdown_presenters/llms_index.rb
+++ b/app/presenters/markdown_presenters/llms_index.rb
@@ -1,0 +1,60 @@
+module MarkdownPresenters
+  # Renders `/llms.txt`: a curated, llmstxt.org-style entry point that points AI
+  # tools at the main sections, recent talks, and the full machine index.
+  class LlmsIndex < BasePresenter
+    RECENT_TALKS = 30
+
+    def to_text
+      [
+        "# RubyEvents",
+        summary,
+        markdown_note,
+        browse_section,
+        recent_section,
+        full_index_section
+      ].compact_blank.join("\n\n") + "\n"
+    end
+
+    private
+
+    def summary
+      "> RubyEvents is the open source community archive of Ruby conference and " \
+        "meetup talks: #{Talk.count}+ recorded talks across #{Event.count}+ events, " \
+        "with speakers, topics, summaries, and transcripts. The content is MIT-licensed."
+    end
+
+    def markdown_note
+      "Every talk, speaker, event, and topic page has a Markdown version at the " \
+        "same URL with a `.md` suffix (for example, `https://www.rubyevents.org/talks/some-talk.md`). " \
+        "Pages also respond to `Accept: text/markdown` content negotiation."
+    end
+
+    def browse_section
+      <<~SECTION.strip
+        ## Browse
+
+        - #{link("All talks", talks_url)}: Searchable index of every recorded Ruby talk
+        - #{link("Speakers", speakers_url)}: Profiles of Ruby speakers and their talks
+        - #{link("Events", events_url)}: Ruby conferences and meetups
+        - #{link("Topics", topics_url)}: Talks grouped by topic and gem
+      SECTION
+    end
+
+    def recent_section
+      talks = Talk.includes(:speakers, :event).where.not(date: nil).order(date: :desc).limit(RECENT_TALKS)
+      return if talks.empty?
+
+      lines = talks.map do |talk|
+        meta = [talk.speakers.map(&:name).join(", "), talk.event&.name].compact_blank.join(", ")
+        "- #{link(talk.title, talk_url(talk, format: :md))}: #{meta}"
+      end
+
+      "## Recent talks\n\n#{lines.join("\n")}"
+    end
+
+    def full_index_section
+      "## Full index\n\n- #{link("Complete talk index", "#{HOST}/llms-full.txt")}: " \
+        "Every talk with a link to its Markdown version"
+    end
+  end
+end

--- a/app/presenters/markdown_presenters/speaker_presenter.rb
+++ b/app/presenters/markdown_presenters/speaker_presenter.rb
@@ -1,0 +1,52 @@
+module MarkdownPresenters
+  class SpeakerPresenter < BasePresenter
+    def initialize(user)
+      @user = user
+    end
+
+    def to_markdown
+      [
+        "# #{@user.name}",
+        blockquote,
+        @user.bio.presence,
+        links_section,
+        talks_section,
+        footer
+      ].compact_blank.join("\n\n") + "\n"
+    end
+
+    private
+
+    def blockquote
+      count = @user.talks_count
+      "> Ruby speaker with #{count} #{"talk".pluralize(count)} on RubyEvents."
+    end
+
+    def links_section
+      list([
+        ("- **GitHub:** https://github.com/#{@user.github_handle}" if @user.github_handle.present?),
+        ("- **X:** https://x.com/#{@user.twitter}" if @user.twitter.present?),
+        ("- **Mastodon:** #{@user.mastodon}" if @user.mastodon.present?),
+        ("- **LinkedIn:** #{@user.linkedin}" if @user.linkedin.present?),
+        ("- **Website:** #{@user.website}" if @user.website.present?)
+      ]).presence
+    end
+
+    def talks_section
+      talks = @user.kept_talks.includes(event: :series).order(date: :desc)
+      return if talks.empty?
+
+      lines = talks.map do |talk|
+        meta = [talk.event&.name, talk.date && talk.formatted_date].compact_blank.join(", ")
+        line = "- #{link(talk.title, talk_url(talk, format: :md))}"
+        meta.present? ? "#{line}: #{meta}" : line
+      end
+
+      "## Talks (#{talks.size})\n\n#{lines.join("\n")}"
+    end
+
+    def footer
+      "---\n\n#{link("View this speaker on RubyEvents", profile_url(@user))}"
+    end
+  end
+end

--- a/app/presenters/markdown_presenters/talk_presenter.rb
+++ b/app/presenters/markdown_presenters/talk_presenter.rb
@@ -1,0 +1,77 @@
+module MarkdownPresenters
+  class TalkPresenter < BasePresenter
+    def initialize(talk)
+      @talk = talk
+    end
+
+    def to_markdown
+      [
+        "# #{@talk.title}",
+        blockquote,
+        metadata,
+        summary_section,
+        description_section,
+        resources_section,
+        footer
+      ].compact_blank.join("\n\n") + "\n"
+    end
+
+    private
+
+    def blockquote
+      lead = lead(@talk.summary.presence || @talk.description)
+      "> #{lead}" if lead
+    end
+
+    def metadata
+      list([
+        ("- **Speakers:** #{speaker_links}" if @talk.speakers.present?),
+        ("- **Event:** #{link(@talk.event.name, event_url(@talk.event))}" if @talk.event),
+        ("- **Date:** #{@talk.formatted_date}" if @talk.date),
+        ("- **Duration:** #{@talk.formatted_duration}" if @talk.duration),
+        ("- **Language:** #{@talk.language_name}" if @talk.language.present?),
+        ("- **Topics:** #{topic_links}" if @talk.approved_topics.present?),
+        ("- **Video:** #{@talk.provider_url}" if video_url?),
+        ("- **Slides:** #{@talk.slides_url}" if @talk.slides_url.present?)
+      ])
+    end
+
+    def summary_section
+      "## Summary\n\n#{@talk.summary}" if @talk.summary.present?
+    end
+
+    def description_section
+      return if @talk.description.blank? || @talk.description == @talk.summary
+
+      "## Description\n\n#{@talk.description}"
+    end
+
+    def resources_section
+      resources = Array(@talk.additional_resources).filter_map do |resource|
+        url = resource["url"].presence
+        next unless url
+
+        "- #{link(resource["name"].presence || url, url)}"
+      end
+      return if resources.empty?
+
+      "## Resources\n\n#{resources.join("\n")}"
+    end
+
+    def footer
+      "---\n\n#{link("View this talk on RubyEvents", talk_url(@talk))}"
+    end
+
+    def speaker_links
+      @talk.speakers.map { |speaker| link(speaker.name, profile_url(speaker)) }.join(", ")
+    end
+
+    def topic_links
+      @talk.approved_topics.map { |topic| link(topic.name, topic_url(topic)) }.join(", ")
+    end
+
+    def video_url?
+      @talk.provider_url.present? && @talk.provider_url != "#"
+    end
+  end
+end

--- a/app/presenters/markdown_presenters/topic_presenter.rb
+++ b/app/presenters/markdown_presenters/topic_presenter.rb
@@ -1,0 +1,35 @@
+module MarkdownPresenters
+  class TopicPresenter < BasePresenter
+    def initialize(topic)
+      @topic = topic
+    end
+
+    def to_markdown
+      [
+        "# #{@topic.name}",
+        lead(@topic.description) && "> #{lead(@topic.description)}",
+        talks_section,
+        footer
+      ].compact_blank.join("\n\n") + "\n"
+    end
+
+    private
+
+    def talks_section
+      talks = @topic.talks.includes(:speakers, event: :series).order(date: :desc)
+      return if talks.empty?
+
+      lines = talks.map do |talk|
+        meta = [talk.speakers.map(&:name).join(", "), talk.event&.name].compact_blank.join(", ")
+        line = "- #{link(talk.title, talk_url(talk, format: :md))}"
+        meta.present? ? "#{line}: #{meta}" : line
+      end
+
+      "## Talks (#{talks.size})\n\n#{lines.join("\n")}"
+    end
+
+    def footer
+      "---\n\n#{link("View this topic on RubyEvents", topic_url(@topic))}"
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,10 @@
       <link rel="canonical" href="<%= canonical_url %>">
     <% end %>
 
+    <% if markdown_alternate_url.present? %>
+      <link rel="alternate" type="text/markdown" href="<%= markdown_alternate_url %>">
+    <% end %>
+
     <% if Rails.env.staging? %>
       <meta name="robots" content="noindex, nofollow">
     <% end %>
@@ -36,6 +40,10 @@
   </head>
 
   <body data-controller="preserve-scroll" class="<%= yield(:body_class) %>">
+    <% if markdown_alternate_url.present? %>
+      <div aria-hidden="true" style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip-path:inset(50%);white-space:nowrap;border:0">A Markdown version of this page is available at <%= markdown_alternate_url %>, optimized for AI and LLM tools.</div>
+    <% end %>
+
     <div class="hotwire-native:hidden">
       <%= render "shared/navbar" %>
     </div>

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 Mime::Type.register "text/calendar", :ics
+Mime::Type.register "text/markdown", :md

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -319,6 +319,9 @@ Rails.application.routes.draw do
 
   get "/sitemap.xml", to: "sitemaps#show", defaults: {format: "xml"}
 
+  get "/llms.txt", to: "llms#index", defaults: {format: "text"}
+  get "/llms-full.txt", to: "llms#full", defaults: {format: "text"}
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,3 @@
 # See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+
+Sitemap: https://www.rubyevents.org/sitemap.xml

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,11 @@
 # See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
 
+# RubyEvents content is MIT-licensed and open to search, AI retrieval, and AI
+# training. NOTE: this origin policy can be overridden by a Cloudflare-managed
+# robots.txt at the edge. If AI crawlers are still blocked, update the setting in
+# the Cloudflare dashboard (see PR description).
+User-agent: *
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
+Allow: /
+
 Sitemap: https://www.rubyevents.org/sitemap.xml

--- a/test/integration/llm_visibility_test.rb
+++ b/test/integration/llm_visibility_test.rb
@@ -1,0 +1,85 @@
+require "test_helper"
+
+class LlmVisibilityTest < ActionDispatch::IntegrationTest
+  setup do
+    @talk = talks(:one)
+    @speaker = users(:yaroslav)
+    @event = events(:rails_world_2023)
+    @topic = topics(:activerecord)
+  end
+
+  # --- .md page twins ---------------------------------------------------------
+
+  test "talk has a markdown twin at .md" do
+    get talk_path(@talk, format: :md)
+
+    assert_response :success
+    assert_equal "text/markdown", @response.media_type
+    assert_includes @response.body, "# #{@talk.title}"
+    assert_includes @response.body, "View this talk on RubyEvents"
+  end
+
+  test "speaker, event, and topic have markdown twins at .md" do
+    get profile_path(@speaker, format: :md)
+    assert_response :success
+    assert_equal "text/markdown", @response.media_type
+    assert_includes @response.body, "# #{@speaker.name}"
+
+    get event_path(@event, format: :md)
+    assert_response :success
+    assert_equal "text/markdown", @response.media_type
+    assert_includes @response.body, "# #{@event.name}"
+
+    get topic_path(@topic, format: :md)
+    assert_response :success
+    assert_equal "text/markdown", @response.media_type
+    assert_includes @response.body, "# #{@topic.name}"
+  end
+
+  # --- content negotiation ----------------------------------------------------
+
+  test "Accept: text/markdown returns the markdown version of an HTML url" do
+    get talk_path(@talk), headers: {"Accept" => "text/markdown"}
+
+    assert_response :success
+    assert_equal "text/markdown", @response.media_type
+    assert_includes @response.body, "# #{@talk.title}"
+  end
+
+  test "an unsupported Accept type is rejected with 406" do
+    get talk_path(@talk), headers: {"Accept" => "application/xml"}
+
+    assert_response :not_acceptable
+  end
+
+  # --- alternate link + headers on the HTML page ------------------------------
+
+  test "HTML page advertises its markdown twin via link tag and Link header" do
+    get talk_path(@talk)
+
+    assert_response :success
+    assert_select "link[rel=alternate][type='text/markdown']", count: 1
+    assert_match %r{rel="alternate".*type="text/markdown"}, @response.headers["Link"].to_s
+    assert_includes @response.headers["Vary"].to_s, "Accept"
+  end
+
+  # --- llms.txt / llms-full.txt ----------------------------------------------
+
+  test "llms.txt is served as plain text with the expected structure" do
+    get "/llms.txt"
+
+    assert_response :success
+    assert_equal "text/plain", @response.media_type
+    assert_includes @response.body, "# RubyEvents"
+    assert_includes @response.body, "## Browse"
+    assert_includes @response.body, "/llms-full.txt"
+  end
+
+  test "llms-full.txt is served as plain text" do
+    get "/llms-full.txt"
+
+    assert_response :success
+    assert_equal "text/plain", @response.media_type
+    assert_includes @response.body, "complete talk index"
+  end
+end


### PR DESCRIPTION
This PR makes RubyEvents discoverable and usable by search engines and AI tools. It has two parts: a set of repo-side artifacts (below), and one infra change that only the Cloudflare account owner can make (first, because it's the biggest lever).

## ⚠️ The biggest lever is in Cloudflare, not this repo

RubyEvents shows up as **~1 page in Common Crawl** (despite 6,000+ talks) because the live `robots.txt` blocks the AI training/retrieval crawlers, and **those rules are injected by Cloudflare at the edge, not by this repo.** The repo's `public/robots.txt` only contributes the comment and the new `Content-Signal`/`Sitemap` lines. Everything between `# BEGIN Cloudflare Managed content` and `# END Cloudflare Managed Content` is added by Cloudflare:

```
User-agent: *
Content-Signal: search=yes,ai-train=no
User-agent: CCBot       Disallow: /
User-agent: ClaudeBot   Disallow: /
User-agent: GPTBot      Disallow: /
User-agent: Google-Extended  Disallow: /
User-agent: Amazonbot / Applebot-Extended / Bytespider / meta-externalagent  Disallow: /
```

A repo-side `Allow:` cannot reliably override this (it just creates a conflicting second group). **To actually allow AI crawling/training, someone with Cloudflare dashboard access must change it there.**

### How to disable the AI block in Cloudflare

1. Log in to the **Cloudflare dashboard** and select the **rubyevents.org** zone.
2. Open **AI Crawl Control** (left sidebar; formerly "AI Audit").
   - Find the **Manage robots.txt** setting. This is what injects the `# Cloudflare Managed content` block with the `Content-Signal` line and the per-bot `Disallow: /` rules.
   - Either **turn off the managed robots.txt injection**, or edit the content signals to **`search=yes,ai-input=yes,ai-train=yes`** and remove the per-bot `Disallow: /` entries.
3. Open **Security → Bots** (Bot Management / Super Bot Fight Mode) and turn **OFF** any **"Block AI bots" / "Block AI Scrapers and Crawlers"** toggle. robots.txt is only advisory; this WAF-level rule is what actually blocks bots at the edge, so it must be disabled too.
4. **Purge the cached robots.txt.** It is currently served with `cache-control: max-age=31556952` (1 year) and `cf-cache-status: HIT`. In Cloudflare go to **Caching → Configuration → Purge Cache** and purge `https://www.rubyevents.org/robots.txt` so the updated file is served immediately.
5. Verify: `curl -s https://www.rubyevents.org/robots.txt` should no longer contain the per-bot `Disallow: /` lines, and `Content-Signal` should read `ai-train=yes` (or be absent).

The corpus is MIT-licensed, so allowing training/retrieval crawlers is consistent with the project's intent and unlocks all 6,000+ talks for Common Crawl, Claude, GPT, Google, etc.

---

## Repo-side changes

### 1. Sitemap and robots.txt fixes

- **Fix event URLs missing from the sitemap.** `SitemapsController` used `Event.canonical.pluck(:slug, :updated_at) do |...|` — `pluck` ignores the block, so **0 event pages were ever emitted** (vs 10,189 talk URLs in production). Switched to `.each do`.
- **Reference the sitemap from `robots.txt`** via a `Sitemap:` directive.
- **Add a `Content-Signal`** to `robots.txt` declaring the origin's intent (`search=yes, ai-input=yes, ai-train=yes`), with a comment noting Cloudflare can override it.

### 2. LLM-visibility artifacts

Following [How to make your website visible to LLMs](https://evilmartians.com/chronicles/how-to-make-your-website-visible-to-llms):

- **Markdown twins** for every talk, speaker, event, and topic, generated from model data (single source of truth) via `MarkdownPresenters`. Served two ways:
  - at the same URL with a `.md` suffix (e.g. `/talks/some-talk.md`), and
  - via `Accept: text/markdown` **content negotiation** on the HTML URL, with `Vary: Accept` and a `406` for unsupported types.
- **Discovery signals** on every content page: a `<link rel="alternate" type="text/markdown">` tag, a `Link:` response header, and a visually-hidden hint for LLMs reading the rendered page.
- **`/llms.txt`** — a curated, llmstxt.org-style entry point (summary, main sections, recent talks).
- **`/llms-full.txt`** — a complete, cached index of every talk linking to its Markdown version.

Deliberately skipped the article's anti-patterns (JSON-LD/schema.org, `ai.txt`, custom meta tags), which it found have no crawler support.

### Tests / verification

- New `test/integration/llm_visibility_test.rb` covers the `.md` twins, `Accept` negotiation, `406`, the `<link>`/`Link`/`Vary` advertisement, and both `llms` files (7 tests).
- Existing talks/profiles/events/topics controller tests still pass (JSON and turbo_stream formats preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
