### PR TITLE
Remove `imagemagick` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install ImageMagick
-        run: sudo apt-get update && sudo apt-get install -y imagemagick
-
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Looks like we don't need to install `imagemagick` in CI anymore, so let's remove it.