### PR TITLE
Fix latest event sampling on home page

### DIFF
--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -10,7 +10,7 @@ class PageController < ApplicationController
         events_count: Event.count,
         latest_talk_ids: latest_talks.pluck(:id),
         upcoming_talk_ids: Talk.with_speakers.where(date: Date.today..).order(date: :asc).limit(15).pluck(:id),
-        latest_event_ids: Event.order(date: :desc).limit(10).pluck(:id).sample(4),
+        latest_event_ids: Event.conference.past.limit(10).pluck(:id),
         featured_speaker_ids: User.with_github
           .joins(:talks)
           .where(talks: {date: 12.months.ago..})

--- a/app/views/page/home.html.erb
+++ b/app/views/page/home.html.erb
@@ -146,10 +146,23 @@
           <h2 class="text-primary shrink-0">Latest events</h2>
           <%= link_to "see all events", events_path, class: "link text-right w-full" %>
         </div>
-        <div class="grid min-w-full grid-cols-1 gap-8 sm:grid-cols-2 md:grid-cols-3 md:[&>:nth-child(4)]:hidden lg:grid-cols-4 lg:[&>:nth-child(4)]:block">
-          <%= cache @latest_events do %>
-            <%= render partial: "events/card", collection: @latest_events, as: :event, cached: true %>
-          <% end %>
+        <div class="relative" data-controller="scroll">
+          <div class="overflow-x-auto scroll-smooth snap-x snap-mandatory"
+               data-scroll-target="container"
+               data-action="scroll->scroll#checkScroll">
+            <div class="flex pb-4 gap-4">
+              <%= cache @latest_events do %>
+                <% @latest_events.each do |event| %>
+                  <div class="snap-start shrink-0 w-64 sm:w-72" data-scroll-target="card">
+                    <%= render partial: "events/card", locals: {event: event} %>
+                  </div>
+                <% end %>
+              <% end %>
+            </div>
+          </div>
+          <div
+            class="absolute right-0 top-0 h-full w-24 bg-gradient-to-l from-white to-transparent pointer-events-none"
+            data-scroll-target="gradient"></div>
         </div>
       </section>
 


### PR DESCRIPTION
## Description
Sampling 4 events from last 10 events ordered by descending dates was causing confusion.
This commit fixes the issue and adds the scroll to last 10 events.

## Screenshots
<img width="1548" height="769" alt="Screenshot 2026-06-20 at 01 01 54" src="https://github.com/user-attachments/assets/b437d013-90c5-49e4-a02a-f88536b8574b" />


fixes: #1749
