### PR TITLE
Validate `github_handle` against GitHub username format

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -139,6 +139,10 @@ class User < ApplicationRecord
 
   validates :email, format: {with: URI::MailTo::EMAIL_REGEXP}, allow_blank: true
   validates :github_handle, presence: true, uniqueness: true, allow_blank: true
+  GITHUB_HANDLE_PATTERN = /\A[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?\z/
+  validates :github_handle,
+    format: {with: GITHUB_HANDLE_PATTERN, message: "is not a valid GitHub username"},
+    allow_blank: true
   validates :canonical, exclusion: {in: ->(user) { [user] }, message: "can't be itself"}
   validates :distance, comparison: {less_than_or_equal_to: 20_000, greater_than_or_equal_to: 0}
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -68,6 +68,7 @@ class User < ApplicationRecord
     distance: 250
 
   GITHUB_URL_PATTERN = %r{\A(https?://)?(www\.)?github\.com/}i
+  GITHUB_HANDLE_PATTERN = /\A[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?\z/
 
   PRONOUNS = {
     "Not specified": :not_specified,
@@ -138,11 +139,8 @@ class User < ApplicationRecord
   has_object :merger
 
   validates :email, format: {with: URI::MailTo::EMAIL_REGEXP}, allow_blank: true
-  validates :github_handle, presence: true, uniqueness: true, allow_blank: true
-  GITHUB_HANDLE_PATTERN = /\A[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?\z/
-  validates :github_handle,
-    format: {with: GITHUB_HANDLE_PATTERN, message: "is not a valid GitHub username"},
-    allow_blank: true
+  validates :github_handle, presence: true, uniqueness: true, allow_blank: true,
+    format: {with: GITHUB_HANDLE_PATTERN, message: "is not a valid GitHub username"}
   validates :canonical, exclusion: {in: ->(user) { [user] }, message: "can't be itself"}
   validates :distance, comparison: {less_than_or_equal_to: 20_000, greater_than_or_equal_to: 0}
 

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -55,7 +55,7 @@ zero_talks:
   email: zero_talks_user@rubyevents.org
   name: Zero Talks
   twitter: zero_talks
-  github_handle: zero_talks
+  github_handle: zero-talks
   bio: "Zero Talks"
   slug: zero_talks
   password_digest: <%= BCrypt::Password.create("Secret1*3*5*") %>
@@ -131,6 +131,6 @@ developer_oauth:
 github_user:
   name: Github User
   slug: github-user
-  github_handle: GitHub_user
+  github_handle: GitHub-user
   email: github_user@example.com
   password_digest: <%= BCrypt::Password.create("password") %>

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -89,6 +89,22 @@ class UserTest < ActiveSupport::TestCase
     assert_equal "tekin", user.github_handle
   end
 
+  test "rejects github_handle with path-injection characters" do
+    user = users(:one)
+
+    ["victim/repos", "x?per_page=100", "foo#frag", "../user", "bad_handle"].each do |handle|
+      user.github_handle = handle
+      assert_not user.valid?, "expected #{handle.inspect} to be invalid"
+      assert_includes user.errors[:github_handle], "is not a valid GitHub username"
+    end
+  end
+
+  test "accepts a valid github_handle" do
+    user = users(:one)
+    user.github_handle = "matz-the-creator"
+    assert user.valid?
+  end
+
   test "should normalize mastodon handle into a profile URL" do
     user = users(:one)
 


### PR DESCRIPTION
## Description

AI Disclosure: Found with Claude Code, and this fix was Generated with Claude Code. Reviewed and tested by me.

Previously, you could set `github_handle` to a value containing path-injection characters (`/`, `?`, `#`) which would then modify the GitHub API requests that were made by rubyevents in some cases.

I'm not aware of anything harmful you could do with this despite asking Claude to try as much as it could, so I'm opening this PR publicly. The `../` case isn't actually usable as an attack because the URL isn't built in a way that would enable "path traversal" of the URL. And the OAuth token doesn't get enough permissions to really do damage anyway.

Also, underscores aren't allowed in GitHub usernames so some test fixtures were updated (I didn't know this until Claude mentioned it, I assumed it was hallucinating but it turns out it is true).

## Screenshots
N/A

## Testing Steps
- Ensure that usernames can be set still.
- Ensure that GitHub URLs/API requests still work fine

## References
N/A
