### PR TITLE
removed description from 'Things I don't have time for' talk

### DIFF
--- a/data/helsinki-ruby/helsinki-ruby-brigade/videos.yml
+++ b/data/helsinki-ruby/helsinki-ruby-brigade/videos.yml
@@ -237,7 +237,6 @@
       published_at: "2026-05-29"
       video_provider: "youtube"
       video_id: "Ao0qf_ylbi4"
-      description: |-
-        Helsinki Ruby Brigade, 2025-05-29.
+      description: ""
       speakers:
         - Ville Lautanala


### PR DESCRIPTION
## Description
Removed the description from the "Things I don't have time for" talk, [Helsinki Ruby Brigade 2026.](https://www.rubyevents.org/talks/things-i-don-t-have-time-for-slow-ruby-and-learning-rust)
Description created a duplicate event name and date.