### PR TITLE
Fix future events sort order on speaker profile page

### DIFF
--- a/app/views/profiles/_events.html.erb
+++ b/app/views/profiles/_events.html.erb
@@ -1,6 +1,6 @@
 <%# Event Participations v1 %>
 
-<% future_events = events.upcoming.sort_by(&:sort_date).reverse %>
+<% future_events = events.upcoming.sort_by(&:sort_date) %>
 <% past_events = (events.to_a - future_events).sort_by(&:sort_date).reverse %>
 <% event_kinds = events.map(&:kind).uniq.sort %>
 


### PR DESCRIPTION
## What

Remove `.reverse` from the `future_events` sort in the profile events view so
that upcoming events are displayed in ascending order (soonest first).

Past events keep their existing descending sort order unchanged.

## Why

Future events were being sorted descending (furthest first) instead of
ascending (soonest first), making it hard for users to see which event
is coming up next on a speaker's profile.

## Changes

- `app/views/profiles/_events.html.erb` — removed `.reverse` from
  `future_events` sort on line 1

Before:
```ruby
<% future_events = events.upcoming.sort_by(&:sort_date).reverse %>
```

After:
```ruby
<% future_events = events.upcoming.sort_by(&:sort_date) %>
```

## Related

Fixes #1788