### PR TITLE
Add featured columns to `events` database table

### DIFF
--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -376,19 +376,13 @@ class BrowseController < ApplicationController
   end
 
   def featured_events_query
-    imported_slugs = Event.not_meetup.with_watchable_talks.pluck(:slug)
-    featurable_slugs = Static::Event.where.not(featured_background: nil).pluck(:slug)
-    slug_candidates = imported_slugs & featurable_slugs
-
-    featured_slugs = Static::Event.all
-      .select { |event| slug_candidates.include?(event.slug) }
-      .select(&:home_sort_date)
-      .sort_by(&:home_sort_date)
-      .reverse
-      .take(5)
-      .map(&:slug)
-
-    Event.where(slug: featured_slugs).in_order_of(:slug, featured_slugs)
+    Event
+      .not_meetup
+      .with_watchable_talks
+      .featurable
+      .where.not(home_sort_date: nil)
+      .order(home_sort_date: :desc)
+      .limit(5)
   end
 
   def recently_published_query

--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -30,23 +30,14 @@ class PageController < ApplicationController
     @featured_organizations = Organization.joins(:sponsors).includes(:events).group("organizations.id").order("COUNT(sponsors.id) DESC").limit(10)
     @recommended_talks = Current.user.talk_recommender.talks(limit: 4) if Current.user
 
-    imported_slugs = Event.not_meetup.with_watchable_talks.pluck(:slug)
-    today_slugs = Event.not_meetup.with_talks.where(start_date: ..Date.today, end_date: Date.today..).pluck(:slug)
-    featurable_slugs = Static::Event.where.not(featured_background: nil).pluck(:slug)
-    slug_candidates = (imported_slugs | today_slugs) & featurable_slugs
-
-    featured_slugs = Static::Event.all
-      .select { |event| slug_candidates.include?(event.slug) }
-      .select(&:home_sort_date)
-      .sort_by(&:home_sort_date)
-      .reverse
-      .take(15)
-      .map(&:slug)
-
     @featured_events = Event.distinct
+      .not_meetup
+      .with_watchable_talks
+      .featurable
+      .where.not(home_sort_date: nil)
       .includes(:series, :keynote_speakers, :speakers)
-      .where(slug: featured_slugs)
-      .in_order_of(:slug, featured_slugs)
+      .order(home_sort_date: :desc)
+      .limit(15)
 
     respond_to do |format|
       format.html

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,27 +3,31 @@
 # Table name: events
 # Database name: primary
 #
-#  id               :integer          not null, primary key
-#  city             :string
-#  country_code     :string           indexed => [state_code]
-#  date             :date
-#  date_precision   :string           default("day"), not null
-#  end_date         :date
-#  geocode_metadata :json             not null
-#  kind             :string           default("event"), not null, indexed
-#  latitude         :decimal(10, 6)
-#  location         :string
-#  longitude        :decimal(10, 6)
-#  name             :string           default(""), not null, indexed
-#  slug             :string           default(""), not null, indexed
-#  start_date       :date
-#  state_code       :string           indexed => [country_code]
-#  talks_count      :integer          default(0), not null
-#  website          :string           default("")
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  canonical_id     :integer          indexed
-#  event_series_id  :integer          not null, indexed
+#  id                  :integer          not null, primary key
+#  banner_background   :string
+#  city                :string
+#  country_code        :string           indexed => [state_code]
+#  date                :date
+#  date_precision      :string           default("day"), not null
+#  end_date            :date
+#  featured_background :string
+#  featured_color      :string
+#  geocode_metadata    :json             not null
+#  home_sort_date      :date
+#  kind                :string           default("event"), not null, indexed
+#  latitude            :decimal(10, 6)
+#  location            :string
+#  longitude           :decimal(10, 6)
+#  name                :string           default(""), not null, indexed
+#  slug                :string           default(""), not null, indexed
+#  start_date          :date
+#  state_code          :string           indexed => [country_code]
+#  talks_count         :integer          default(0), not null
+#  website             :string           default("")
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  canonical_id        :integer          indexed
+#  event_series_id     :integer          not null, indexed
 #
 # Indexes
 #
@@ -106,6 +110,7 @@ class Event < ApplicationRecord
   scope :with_talks, -> { where.associated(:talks) }
   scope :with_watchable_talks, -> { where.associated(:watchable_talks) }
   scope :canonical, -> { where(canonical_id: nil) }
+  scope :featurable, -> { where.not(featured_background: nil).where.not(featured_color: nil) }
   scope :not_canonical, -> { where.not(canonical_id: nil) }
   scope :ft_search, ->(query) {
     joins(<<~SQL.squish)

--- a/app/models/static/event.rb
+++ b/app/models/static/event.rb
@@ -311,7 +311,11 @@ module Static
         location: location,
         start_date: start_date,
         end_date: end_date,
-        kind: kind
+        kind: kind,
+        featured_background: featured_background,
+        featured_color: featured_color,
+        banner_background: banner_background,
+        home_sort_date: home_sort_date(event_record: event)
       )
 
       if event.venue.exist?

--- a/app/views/page/featured.html.erb
+++ b/app/views/page/featured.html.erb
@@ -1,6 +1,5 @@
 <main class="container">
-  <% playlists = Static::Event.where.not(featured_background: nil) %>
-  <% events = Event.where(slug: playlists.map(&:slug)).order(date: :desc) %>
+  <% events = Event.featurable.order(date: :desc) %>
 
   <div>
     <% events.each do |event| %>

--- a/app/views/page/home.html.erb
+++ b/app/views/page/home.html.erb
@@ -4,12 +4,12 @@
 
 <% if @featured_events.any? %>
   <% content_for :head do %>
-    <meta name="theme-color" content="<%= @featured_events.first.static_metadata.featured_background %>" data-featured-theme-color>
+    <meta name="theme-color" content="<%= @featured_events.first.featured_background %>" data-featured-theme-color>
 
     <style>
       :root {
-        --featured-color: <%= @featured_events.first.static_metadata.featured_color %>;
-        --featured-background: <%= @featured_events.first.static_metadata.featured_background %>;
+        --featured-color: <%= @featured_events.first.featured_color %>;
+        --featured-background: <%= @featured_events.first.featured_background %>;
       }
 
       body.home-page .navbar {
@@ -91,8 +91,8 @@
             <% @featured_events.each_with_index do |event, index| %>
               <li
                 class="splide__slide"
-                data-featured-color="<%= event.static_metadata.featured_color %>"
-                data-featured-background="<%= event.static_metadata.featured_background %>">
+                data-featured-color="<%= event.featured_color %>"
+                data-featured-background="<%= event.featured_background %>">
                 <div class="<%= "hidden" if Current.user || index != 0 %>">
                   <%= render partial: "events/featured_home", locals: {event: event} %>
                 </div>

--- a/db/migrate/20260623000500_add_featured_fields_to_events.rb
+++ b/db/migrate/20260623000500_add_featured_fields_to_events.rb
@@ -1,0 +1,8 @@
+class AddFeaturedFieldsToEvents < ActiveRecord::Migration[8.2]
+  def change
+    add_column :events, :featured_background, :string
+    add_column :events, :featured_color, :string
+    add_column :events, :banner_background, :string
+    add_column :events, :home_sort_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_06_15_000903) do
+ActiveRecord::Schema[8.2].define(version: 2026_06_23_000500) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -198,6 +198,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_06_15_000903) do
   end
 
   create_table "events", force: :cascade do |t|
+    t.string "banner_background"
     t.integer "canonical_id"
     t.string "city"
     t.string "country_code"
@@ -206,7 +207,10 @@ ActiveRecord::Schema[8.2].define(version: 2026_06_15_000903) do
     t.string "date_precision", default: "day", null: false
     t.date "end_date"
     t.integer "event_series_id", null: false
+    t.string "featured_background"
+    t.string "featured_color"
     t.json "geocode_metadata", default: {}, null: false
+    t.date "home_sort_date"
     t.string "kind", default: "event", null: false
     t.decimal "latitude", precision: 10, scale: 6
     t.string "location"

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -4,27 +4,31 @@
 # Table name: events
 # Database name: primary
 #
-#  id               :integer          not null, primary key
-#  city             :string
-#  country_code     :string           indexed => [state_code]
-#  date             :date
-#  date_precision   :string           default("day"), not null
-#  end_date         :date
-#  geocode_metadata :json             not null
-#  kind             :string           default("event"), not null, indexed
-#  latitude         :decimal(10, 6)
-#  location         :string
-#  longitude        :decimal(10, 6)
-#  name             :string           default(""), not null, indexed
-#  slug             :string           default(""), not null, indexed
-#  start_date       :date
-#  state_code       :string           indexed => [country_code]
-#  talks_count      :integer          default(0), not null
-#  website          :string           default("")
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  canonical_id     :integer          indexed
-#  event_series_id  :integer          not null, indexed
+#  id                  :integer          not null, primary key
+#  banner_background   :string
+#  city                :string
+#  country_code        :string           indexed => [state_code]
+#  date                :date
+#  date_precision      :string           default("day"), not null
+#  end_date            :date
+#  featured_background :string
+#  featured_color      :string
+#  geocode_metadata    :json             not null
+#  home_sort_date      :date
+#  kind                :string           default("event"), not null, indexed
+#  latitude            :decimal(10, 6)
+#  location            :string
+#  longitude           :decimal(10, 6)
+#  name                :string           default(""), not null, indexed
+#  slug                :string           default(""), not null, indexed
+#  start_date          :date
+#  state_code          :string           indexed => [country_code]
+#  talks_count         :integer          default(0), not null
+#  website             :string           default("")
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  canonical_id        :integer          indexed
+#  event_series_id     :integer          not null, indexed
 #
 # Indexes
 #


### PR DESCRIPTION
### Description

Move `featured_background`, `featured_color`, `banner_background`, and `home_sort_date` from YAML-only (`Static::Event`) to the `events` database table. These fields are now synced during import and queried directly via SQL.

This eliminates the need to load and iterate all `Static::Event` YAML records on every home page and browse page request.
