### PR TITLE
Add hover previews to home page talk cards

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,13 +2,18 @@ class ApplicationController < ActionController::Base
   include Authenticable
   include Metadata
   include Analytics
+  include WatchedTalks
 
   prepend_before_action :redirect_to_ruby_events
 
-  helper_method :default_watch_list
+  helper_method :default_watch_list, :user_favorite_talks_ids
 
   def default_watch_list
     @default_watch_list ||= Current.user&.default_watch_list
+  end
+
+  def user_favorite_talks_ids
+    @user_favorite_talks_ids ||= default_watch_list&.talks&.ids || []
   end
 
   private

--- a/app/controllers/watch_list_talks_controller.rb
+++ b/app/controllers/watch_list_talks_controller.rb
@@ -4,17 +4,24 @@ class WatchListTalksController < ApplicationController
 
   def create
     @talk = Talk.find(params[:talk_id])
-    @watch_list.talks << @talk
-    redirect_back fallback_location: @watch_list
+    @watch_list.talks << @talk unless @watch_list.talk_ids.include?(@talk.id)
+    respond_to_toggle
   end
 
   def destroy
-    @talk = @watch_list.talks.find(params[:id])
-    WatchListTalk.find_by(talk_id: @talk.id, watch_list_id: @watch_list.id).destroy
-    redirect_back fallback_location: @watch_list
+    @watch_list.watch_list_talks.find_by(talk_id: params[:id])&.destroy
+    respond_to_toggle
   end
 
   private
+
+  def respond_to_toggle
+    if request.format.turbo_stream?
+      redirect_back fallback_location: @watch_list
+    else
+      head :no_content
+    end
+  end
 
   def set_watch_list
     @watch_list = Current.user.watch_lists.find(params[:watch_list_id])

--- a/app/helpers/language_helper.rb
+++ b/app/helpers/language_helper.rb
@@ -17,7 +17,7 @@ module LanguageHelper
     "czech" => "🇨🇿",
     "danish" => "🇩🇰",
     "dutch" => "🇳🇱",
-    "english" => "",
+    "english" => "🇬🇧",
     "esperanto" => "🏳️",
     "estonian" => "🇪🇪",
     "fijian" => "🇫🇯",

--- a/app/helpers/talks_helper.rb
+++ b/app/helpers/talks_helper.rb
@@ -3,6 +3,18 @@ module TalksHelper
     Duration.seconds_to_formatted_duration(seconds, raise: false)
   end
 
+  def talk_watch_status(talk)
+    if talk.scheduled? || talk.parent_talk&.scheduled?
+      {label: "Scheduled", icon: "clock"}
+    elsif talk.not_recorded? || talk.parent_talk&.not_recorded?
+      {label: "Not Recorded", icon: "video-slash"}
+    elsif talk.not_published? || talk.parent_talk&.not_published?
+      {label: "Not Published", icon: "upload"}
+    elsif talk.video_unavailable?
+      {label: "Unavailable", icon: "video-slash"}
+    end
+  end
+
   def ordering_title
     case order_by_key
     when "date_desc"

--- a/app/javascript/controllers/bookmark_controller.js
+++ b/app/javascript/controllers/bookmark_controller.js
@@ -1,0 +1,47 @@
+import { Controller } from '@hotwired/stimulus'
+import { post, destroy } from '@rails/request.js'
+
+export default class extends Controller {
+  static targets = ['solid', 'regular', 'message']
+
+  static values = {
+    bookmarked: Boolean,
+    addUrl: String,
+    removeUrl: String
+  }
+
+  toggle (event) {
+    event.preventDefault()
+
+    const wasBookmarked = this.bookmarkedValue
+    this.#render(!wasBookmarked)
+    this.#showMessage(wasBookmarked ? 'Removed from bookmarks' : 'Added to bookmarks')
+
+    const url = wasBookmarked ? this.removeUrlValue : this.addUrlValue
+    const request = wasBookmarked ? destroy(url) : post(url)
+
+    request.catch(() => this.#render(wasBookmarked))
+  }
+
+  #render (bookmarked) {
+    this.bookmarkedValue = bookmarked
+    this.solidTarget.classList.toggle('hidden', !bookmarked)
+    this.regularTarget.classList.toggle('hidden', bookmarked)
+  }
+
+  #showMessage (text) {
+    if (!this.hasMessageTarget) return
+
+    const message = this.messageTarget
+    message.textContent = text
+    message.classList.remove('hidden')
+
+    requestAnimationFrame(() => message.classList.remove('opacity-0', '-translate-y-1'))
+
+    clearTimeout(this.messageTimer)
+    this.messageTimer = setTimeout(() => {
+      message.classList.add('opacity-0', '-translate-y-1')
+      message.addEventListener('transitionend', () => message.classList.add('hidden'), { once: true })
+    }, 1600)
+  }
+}

--- a/app/javascript/controllers/hover_preview_controller.js
+++ b/app/javascript/controllers/hover_preview_controller.js
@@ -1,20 +1,35 @@
 import { Controller } from '@hotwired/stimulus'
+import { useMatchMedia } from 'stimulus-use'
 
 export default class extends Controller {
   static targets = ['card', 'preview']
   static values = { delay: { type: Number, default: 350 } }
 
   connect () {
+    useMatchMedia(this, {
+      mediaQueries: { hoverable: '(min-width: 1024px) and (hover: hover) and (prefers-reduced-motion: no-preference)' }
+    })
     this.onScroll = () => this.hide(true)
+    this.onBeforeCache = () => this.hide(true)
+    document.addEventListener('turbo:before-cache', this.onBeforeCache)
   }
 
   disconnect () {
     this.#clearTimers()
     this.#detachScroll()
+    document.removeEventListener('turbo:before-cache', this.onBeforeCache)
+  }
+
+  isHoverable () {
+    this.hoverable = true
+  }
+
+  notHoverable () {
+    this.hoverable = false
   }
 
   enter () {
-    if (!this.#enabled) return
+    if (!this.hoverable) return
 
     clearTimeout(this.hideTimer)
     clearTimeout(this.cleanupTimer)
@@ -97,10 +112,6 @@ export default class extends Controller {
     preview.style.transition = ''
     preview.style.transform = ''
     preview.style.opacity = ''
-  }
-
-  get #enabled () {
-    return window.matchMedia('(min-width: 1024px) and (hover: hover)').matches
   }
 
   #detachScroll () {

--- a/app/javascript/controllers/hover_preview_controller.js
+++ b/app/javascript/controllers/hover_preview_controller.js
@@ -1,0 +1,115 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static targets = ['card', 'preview']
+  static values = { delay: { type: Number, default: 350 } }
+
+  connect () {
+    this.onScroll = () => this.hide(true)
+  }
+
+  disconnect () {
+    this.#clearTimers()
+    this.#detachScroll()
+  }
+
+  enter () {
+    if (!this.#enabled) return
+
+    clearTimeout(this.hideTimer)
+    clearTimeout(this.cleanupTimer)
+    this.showTimer = setTimeout(() => this.show(), this.delayValue)
+  }
+
+  leave () {
+    clearTimeout(this.showTimer)
+    this.hideTimer = setTimeout(() => this.hide(), 80)
+  }
+
+  show () {
+    if (!this.hasPreviewTarget) return
+
+    const preview = this.previewTarget
+    preview.classList.remove('hidden')
+    preview.style.opacity = '1'
+
+    const fromCard = this.#layout()
+    preview.style.transition = 'none'
+    preview.style.transform = fromCard
+
+    preview.getBoundingClientRect()
+
+    preview.style.transition = 'transform 220ms cubic-bezier(0.22, 1, 0.36, 1)'
+    preview.style.transform = 'none'
+
+    window.addEventListener('scroll', this.onScroll, { passive: true, capture: true })
+  }
+
+  hide (immediate = false) {
+    if (!this.hasPreviewTarget) return
+
+    const preview = this.previewTarget
+    this.#detachScroll()
+
+    if (immediate || preview.classList.contains('hidden')) {
+      this.#reset()
+      return
+    }
+
+    preview.style.transition = 'transform 160ms ease-in, opacity 160ms ease-in'
+    preview.style.transform = this.#layout()
+    preview.style.opacity = '0'
+
+    clearTimeout(this.cleanupTimer)
+    this.cleanupTimer = setTimeout(() => this.#reset(), 160)
+  }
+
+  #layout () {
+    const card = this.cardTarget.getBoundingClientRect()
+    const preview = this.previewTarget
+    const scale = 1.3
+    const width = Math.round(card.width * scale)
+
+    let left = card.left - (width - card.width) / 2
+    left = Math.max(8, Math.min(left, window.innerWidth - width - 8))
+
+    preview.style.position = 'fixed'
+    preview.style.width = `${width}px`
+    preview.style.left = `${Math.round(left)}px`
+    preview.style.zIndex = '50'
+    preview.style.transformOrigin = 'top left'
+
+    const height = preview.offsetHeight
+    let top = card.top - (card.height * (scale - 1)) / 2
+    top = Math.min(top, window.innerHeight - height - 8)
+    top = Math.max(8, top)
+    preview.style.top = `${Math.round(top)}px`
+
+    const s = card.width / width
+    const tx = card.left - left
+    const ty = card.top - top
+    return `translate(${tx}px, ${ty}px) scale(${s})`
+  }
+
+  #reset () {
+    const preview = this.previewTarget
+    preview.classList.add('hidden')
+    preview.style.transition = ''
+    preview.style.transform = ''
+    preview.style.opacity = ''
+  }
+
+  get #enabled () {
+    return window.matchMedia('(min-width: 1024px) and (hover: hover)').matches
+  }
+
+  #detachScroll () {
+    window.removeEventListener('scroll', this.onScroll, { capture: true })
+  }
+
+  #clearTimers () {
+    clearTimeout(this.showTimer)
+    clearTimeout(this.hideTimer)
+    clearTimeout(this.cleanupTimer)
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -7,18 +7,23 @@ import { application } from "./application"
 import AutoClickController from "./auto-click_controller"
 application.register("auto-click", AutoClickController)
 
-import CollapsibleController from "./collapsible_controller"
-application.register("collapsible", CollapsibleController)
-application.register("collapsible-feedback", CollapsibleController)
-
 import AutoSubmitController from "./auto_submit_controller"
 application.register("auto-submit", AutoSubmitController)
+
+import BookmarkController from "./bookmark_controller"
+application.register("bookmark", BookmarkController)
 
 import Bridge__ButtonController from "./bridge/button_controller"
 application.register("bridge--button", Bridge__ButtonController)
 
 import Bridge__OauthController from "./bridge/oauth_controller"
 application.register("bridge--oauth", Bridge__OauthController)
+
+import CollapsibleController from "./collapsible_controller"
+application.register("collapsible", CollapsibleController)
+
+import ContentRowController from "./content_row_controller"
+application.register("content-row", ContentRowController)
 
 import CopyToClipboardController from "./copy_to_clipboard_controller"
 application.register("copy-to-clipboard", CopyToClipboardController)
@@ -28,9 +33,6 @@ application.register("dropdown", DropdownController)
 
 import EventController from "./event_controller"
 application.register("event", EventController)
-
-import HoverCardController from "./hover_card_controller"
-application.register("hover-card", HoverCardController)
 
 import EventListController from "./event_list_controller"
 application.register("event-list", EventListController)
@@ -43,6 +45,9 @@ application.register("events-view-switcher", EventsViewSwitcherController)
 
 import GeolocationController from "./geolocation_controller"
 application.register("geolocation", GeolocationController)
+
+import HoverCardController from "./hover_card_controller"
+application.register("hover-card", HoverCardController)
 
 import HoverPreviewController from "./hover_preview_controller"
 application.register("hover-preview", HoverPreviewController)
@@ -61,9 +66,6 @@ application.register("preserve-scroll", PreserveScrollController)
 
 import PronounsSelectController from "./pronouns_select_controller"
 application.register("pronouns-select", PronounsSelectController)
-
-import ContentRowController from "./content_row_controller"
-application.register("content-row", ContentRowController)
 
 import ScrollController from "./scroll_controller"
 application.register("scroll", ScrollController)

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -44,6 +44,9 @@ application.register("events-view-switcher", EventsViewSwitcherController)
 import GeolocationController from "./geolocation_controller"
 application.register("geolocation", GeolocationController)
 
+import HoverPreviewController from "./hover_preview_controller"
+application.register("hover-preview", HoverPreviewController)
+
 import LazyLoadingController from "./lazy_loading_controller"
 application.register("lazy-loading", LazyLoadingController)
 

--- a/app/views/browse/_content_row.html.erb
+++ b/app/views/browse/_content_row.html.erb
@@ -37,14 +37,13 @@
           data-action="scroll->content-row#handleScroll">
           <div class="flex gap-4 sm:pb-2" data-content-row-target="track">
             <% talks.each do |talk| %>
-              <% watched_talk = watched_talks.find { |wt| wt.talk_id == talk.id } if watched_talks.present? %>
+              <% watched_talk = (watched_talks.presence || user_watched_talks).find { |wt| wt.talk_id == talk.id } %>
+
               <div class="snap-start shrink-0 w-[200px] sm:w-[300px] lg:w-[320px]"
                    data-controller="hover-preview"
                    data-action="mouseenter->hover-preview#enter mouseleave->hover-preview#leave">
                 <div data-hover-preview-target="card">
-                  <%= render "talks/card_thumbnail",
-                        talk: talk,
-                        watched_talk: watched_talk %>
+                  <%= render "talks/card_thumbnail", talk: talk, watched_talk: watched_talk %>
                 </div>
 
                 <div data-hover-preview-target="preview" class="hidden">

--- a/app/views/browse/_content_row.html.erb
+++ b/app/views/browse/_content_row.html.erb
@@ -38,10 +38,18 @@
           <div class="flex gap-4 sm:pb-2" data-content-row-target="track">
             <% talks.each do |talk| %>
               <% watched_talk = watched_talks.find { |wt| wt.talk_id == talk.id } if watched_talks.present? %>
-              <div class="snap-start shrink-0 w-[200px] sm:w-[300px] lg:w-[320px]">
-                <%= render "talks/card_thumbnail",
-                      talk: talk,
-                      watched_talk: watched_talk %>
+              <div class="snap-start shrink-0 w-[200px] sm:w-[300px] lg:w-[320px]"
+                   data-controller="hover-preview"
+                   data-action="mouseenter->hover-preview#enter mouseleave->hover-preview#leave">
+                <div data-hover-preview-target="card">
+                  <%= render "talks/card_thumbnail",
+                        talk: talk,
+                        watched_talk: watched_talk %>
+                </div>
+
+                <div data-hover-preview-target="preview" class="hidden">
+                  <%= render "talks/card_preview", talk: talk %>
+                </div>
               </div>
             <% end %>
           </div>

--- a/app/views/talks/_card_preview.html.erb
+++ b/app/views/talks/_card_preview.html.erb
@@ -1,0 +1,103 @@
+<%# locals: (talk:) %>
+
+<div class="rounded-xl overflow-hidden bg-base-100 shadow-2xl ring-1 ring-black/10">
+  <%= link_to talk_path(talk), class: "block aspect-video overflow-hidden relative", data: {turbo_frame: "_top"} do %>
+    <%= image_tag talk.thumbnail_lg,
+          loading: "lazy",
+          alt: talk.title,
+          class: class_names("w-full h-full", talk.thumbnail_classes.presence || "object-cover") %>
+  <% end %>
+
+  <div class="p-3.5 flex flex-col gap-3">
+    <div class="flex items-center gap-2.5">
+      <% if talk.speakers.present? %>
+        <div class="avatar-group -space-x-3 shrink-0 [&_.avatar]:border-2">
+          <% talk.speakers.first(3).each do |speaker| %>
+            <%= render Ui::AvatarComponent.new(speaker, size: :sm, linked: true) %>
+          <% end %>
+        </div>
+      <% end %>
+      <%= link_to talk.title, talk_path(talk), class: "text-base font-bold leading-snug line-clamp-2 hover:underline", data: {turbo_frame: "_top"} %>
+    </div>
+
+    <% if talk.speakers.present? %>
+      <div class="flex items-center gap-2 text-sm font-medium">
+        <%= fa("microphone", size: nil, class: "h-3.5 w-3.5 fill-base-content/40 shrink-0") %>
+        <span class="line-clamp-1">
+          <%= safe_join(talk.speakers.map { |speaker| link_to(speaker.name, profile_path(speaker), class: "hover:underline", data: {turbo_frame: "_top"}) }, ", ") %>
+        </span>
+      </div>
+    <% end %>
+
+    <div class="flex flex-wrap items-center gap-1.5 text-xs font-medium text-base-content/70">
+      <% if talk.kind.present? && talk.kind != "talk" %>
+        <span class="inline-flex items-center px-2 py-1 rounded-md bg-base-200/80">
+          <%= Talk::KIND_LABELS[talk.kind] || talk.kind.titleize %>
+        </span>
+      <% end %>
+
+      <% if talk.event&.name.present? %>
+        <%= link_to event_path(talk.event), class: "inline-flex items-center gap-1.5 max-w-[60%] px-2 py-1 rounded-md bg-base-200/80 hover:bg-base-200", data: {turbo_frame: "_top"} do %>
+          <% if talk.event.avatar_image_path.present? %>
+            <%= image_tag image_path(talk.event.avatar_image_path), class: "size-4 rounded shrink-0 ring-1 ring-black/5", alt: talk.event.name, loading: "lazy" %>
+          <% end %>
+          <span class="truncate"><%= talk.event.name %></span>
+        <% end %>
+      <% end %>
+
+      <% if talk.date.present? %>
+        <span class="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-base-200/80">
+          <%= fa("calendar", size: nil, class: "h-3 w-3 fill-base-content/50") %>
+          <%= talk.date.strftime("%b %-d, %Y") %>
+        </span>
+      <% end %>
+
+      <% if talk.duration_in_seconds.present? %>
+        <span class="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-base-200/80">
+          <%= fa("clock", size: nil, class: "h-3 w-3 fill-base-content/50") %>
+          <%= seconds_to_formatted_duration(talk.duration_in_seconds) %>
+        </span>
+      <% end %>
+
+      <% if talk.language.present? %>
+        <%= link_to talks_path(language: talk.language), class: "inline-flex items-center gap-1 px-2 py-1 rounded-md bg-base-200/80 hover:bg-base-200", data: {turbo_frame: "_top"} do %>
+          <%= Language.emoji_flag(talk.language) %> <%= talk.language_name %>
+        <% end %>
+      <% end %>
+
+      <% if talk.slides_url.present? %>
+        <%= link_to talk.slides_url, target: "_blank", rel: "noopener", class: "inline-flex items-center gap-1 px-2 py-1 rounded-md bg-primary/10 text-primary hover:bg-primary/20" do %>
+          <%= fa("presentation-screen", size: nil, class: "h-3 w-3 fill-current") %>
+          Slides
+        <% end %>
+      <% end %>
+    </div>
+
+    <% sections = talk.child_talks.order(:start_seconds).to_a %>
+    <% if sections.any? %>
+      <div class="flex flex-col gap-1.5 pt-1">
+        <div class="text-[11px] font-semibold uppercase tracking-wide text-base-content/40">
+          <%= pluralize(sections.size, "section") %>
+        </div>
+        <div class="grid grid-cols-2 gap-x-3 gap-y-0.5">
+          <% sections.first(8).each_with_index do |section, index| %>
+            <%= link_to talk_path(section), class: "flex items-center gap-1.5 text-xs rounded px-1 -mx-1 py-0.5 hover:bg-base-200/60 min-w-0", data: {turbo_frame: "_top"} do %>
+              <span class="text-base-content/40 tabular-nums shrink-0"><%= index + 1 %>.</span>
+              <% if section.speakers.first %>
+                <%= render Ui::AvatarComponent.new(section.speakers.first, size: :xs) %>
+              <% end %>
+              <span class="min-w-0 truncate text-base-content/80"><%= section.title %></span>
+            <% end %>
+          <% end %>
+        </div>
+        <% if sections.size > 8 %>
+          <div class="text-xs text-base-content/50">+<%= sections.size - 8 %> more</div>
+        <% end %>
+      </div>
+    <% elsif talk.description.present? %>
+      <p class="text-xs leading-relaxed text-base-content/60 line-clamp-3 pt-1">
+        <%= talk.description %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/talks/_card_preview.html.erb
+++ b/app/views/talks/_card_preview.html.erb
@@ -1,12 +1,53 @@
 <%# locals: (talk:) %>
 
 <div class="rounded-xl overflow-hidden bg-base-100 shadow-2xl ring-1 ring-black/10">
-  <%= link_to talk_path(talk), class: "block aspect-video overflow-hidden relative", data: {turbo_frame: "_top"} do %>
-    <%= image_tag talk.thumbnail_lg,
-          loading: "lazy",
-          alt: talk.title,
-          class: class_names("w-full h-full", talk.thumbnail_classes.presence || "object-cover") %>
-  <% end %>
+  <% watched_talk = user_watched_talks.find { |wt| wt.talk_id == talk.id } %>
+  <div class="relative aspect-video overflow-hidden">
+    <%= link_to talk_path(talk), class: "block w-full h-full", data: {turbo_frame: "_top"} do %>
+      <%= image_tag talk.thumbnail_lg,
+            loading: "lazy",
+            alt: talk.title,
+            class: class_names("w-full h-full", talk.thumbnail_classes.presence || "object-cover") %>
+    <% end %>
+
+    <% if default_watch_list %>
+      <% bookmarked = user_favorite_talks_ids.include?(talk.id) %>
+      <div class="absolute top-2 right-2 z-10"
+           data-controller="bookmark"
+           data-bookmark-bookmarked-value="<%= bookmarked %>"
+           data-bookmark-add-url-value="<%= watch_list_talks_path(default_watch_list, talk_id: talk.id) %>"
+           data-bookmark-remove-url-value="<%= watch_list_talk_path(default_watch_list, talk.id) %>">
+        <div data-bookmark-target="message" class="hidden absolute top-full right-0 mt-2 whitespace-nowrap rounded-md bg-black/80 px-2 py-1 text-xs font-medium text-white shadow-lg pointer-events-none opacity-0 -translate-y-1 transition duration-200"></div>
+
+        <button type="button" class="flex items-center justify-center size-8 rounded-full bg-black/50 backdrop-blur-sm hover:bg-black/70 transition-colors" data-action="bookmark#toggle" aria-label="Toggle bookmark">
+          <span data-bookmark-target="solid" class="<%= "hidden" unless bookmarked %>">
+            <%= fa("bookmark", style: :solid, size: :sm, class: "fill-current text-white") %>
+          </span>
+          <span data-bookmark-target="regular" class="<%= "hidden" if bookmarked %>">
+            <%= fa("bookmark", style: :regular, size: :sm, class: "fill-current text-white") %>
+          </span>
+        </button>
+      </div>
+    <% end %>
+
+    <% if watched_talk&.watched? %>
+      <div class="absolute top-2 left-2 z-10 inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-black/60 backdrop-blur-sm text-white text-xs font-medium">
+        <%= fa("circle-check", size: nil, class: "h-3 w-3 fill-current text-green-400") %>
+        Watched
+      </div>
+    <% elsif watched_talk&.in_progress? && talk.duration_in_seconds.present? && watched_talk.progress_seconds.present? %>
+      <% remaining_minutes = ((talk.duration_in_seconds - watched_talk.progress_seconds) / 60.0).ceil %>
+      <div class="absolute bottom-2 left-2 z-10 px-1.5 py-0.5 rounded bg-black/70 backdrop-blur-sm text-white text-xs font-medium">
+        <%= remaining_minutes %> min left
+      </div>
+    <% end %>
+
+    <% if watched_talk&.in_progress? %>
+      <div class="absolute bottom-0 inset-x-0 h-1 bg-white/30 z-10">
+        <div class="h-full bg-primary" style="width: <%= watched_talk.progress_percentage %>%"></div>
+      </div>
+    <% end %>
+  </div>
 
   <div class="p-3.5 flex flex-col gap-3">
     <div class="flex items-center gap-2.5">
@@ -30,12 +71,6 @@
     <% end %>
 
     <div class="flex flex-wrap items-center gap-1.5 text-xs font-medium text-base-content/70">
-      <% if talk.kind.present? && talk.kind != "talk" %>
-        <span class="inline-flex items-center px-2 py-1 rounded-md bg-base-200/80">
-          <%= Talk::KIND_LABELS[talk.kind] || talk.kind.titleize %>
-        </span>
-      <% end %>
-
       <% if talk.event&.name.present? %>
         <%= link_to event_path(talk.event), class: "inline-flex items-center gap-1.5 max-w-[60%] px-2 py-1 rounded-md bg-base-200/80 hover:bg-base-200", data: {turbo_frame: "_top"} do %>
           <% if talk.event.avatar_image_path.present? %>
@@ -59,6 +94,12 @@
         </span>
       <% end %>
 
+      <% if talk.kind.present? && talk.kind != "talk" %>
+        <span class="inline-flex items-center px-2 py-1 rounded-md bg-base-200/80">
+          <%= Talk::KIND_LABELS[talk.kind] || talk.kind.titleize %>
+        </span>
+      <% end %>
+
       <% if talk.language.present? %>
         <%= link_to talks_path(language: talk.language), class: "inline-flex items-center gap-1 px-2 py-1 rounded-md bg-base-200/80 hover:bg-base-200", data: {turbo_frame: "_top"} do %>
           <%= Language.emoji_flag(talk.language) %> <%= talk.language_name %>
@@ -70,6 +111,13 @@
           <%= fa("presentation-screen", size: nil, class: "h-3 w-3 fill-current") %>
           Slides
         <% end %>
+      <% end %>
+
+      <% if (status = talk_watch_status(talk)) %>
+        <span class="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-base-200/80">
+          <%= fa(status[:icon], size: nil, class: "h-3 w-3 fill-base-content/50") %>
+          <%= status[:label] %>
+        </span>
       <% end %>
     </div>
 

--- a/app/views/talks/_card_thumbnail.html.erb
+++ b/app/views/talks/_card_thumbnail.html.erb
@@ -16,7 +16,11 @@
           srcset: ["#{talk.thumbnail_lg} 2x"],
           loading: "lazy",
           alt: talk.title,
-          class: class_names("w-full h-full rounded-xl sm:group-hover:scale-105 transition-transform duration-300", talk.thumbnail_classes.presence || "object-cover")
+          class: class_names(
+            "w-full h-full rounded-xl sm:group-hover:scale-105 transition duration-300",
+            talk.thumbnail_classes.presence || "object-cover",
+            "opacity-50 sm:group-hover:opacity-100": watched_talk&.watched?
+          )
         ) %>
 
     <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent rounded-xl hidden sm:block"></div>
@@ -27,7 +31,12 @@
       </div>
     <% end %>
 
-    <% if talk.duration_in_seconds.present? %>
+    <% if watched_talk&.watched? %>
+      <div class="absolute top-2 right-2 z-20 inline-flex items-center gap-1 px-1.5 py-0.5 bg-black/70 backdrop-blur-sm rounded text-white text-xs font-medium">
+        <%= fa("circle-check", size: nil, class: "h-3 w-3 fill-green-400") %>
+        Watched
+      </div>
+    <% elsif talk.duration_in_seconds.present? %>
       <div class="absolute top-2 right-2 z-20 px-1.5 py-0.5 bg-black/70 backdrop-blur-sm rounded text-white text-xs font-medium">
         <% if watched_talk&.in_progress? && watched_talk.progress_seconds.present? %>
           <% remaining_seconds = talk.duration_in_seconds - watched_talk.progress_seconds %>
@@ -37,40 +46,17 @@
           <%= seconds_to_formatted_duration(talk.duration_in_seconds) %>
         <% end %>
       </div>
+    <% elsif (status = talk_watch_status(talk)) %>
+      <div class="absolute top-2 right-2 z-20 inline-flex items-center gap-1 px-1.5 py-0.5 bg-black/70 backdrop-blur-sm rounded text-white text-xs font-medium">
+        <%= fa(status[:icon], size: nil, class: "h-3 w-3 fill-white") %>
+        <%= status[:label] %>
+      </div>
     <% end %>
 
     <% if talk.published? && talk.video_available? %>
       <div class="absolute inset-0 bottom-6 z-10 hidden sm:group-hover:flex items-center justify-center opacity-0 sm:group-hover:opacity-100 transition-opacity duration-200">
         <div class="p-2 bg-white/20 backdrop-blur-sm rounded-full sm:group-hover:bg-white/30 sm:group-hover:scale-110 transition-all duration-200">
           <%= fa("play", size: :sm, class: "fill-white") %>
-        </div>
-      </div>
-    <% elsif talk.scheduled? || talk.parent_talk&.scheduled? %>
-      <div class="absolute inset-0 bottom-6 z-10 hidden sm:group-hover:flex items-center justify-center opacity-0 sm:group-hover:opacity-100 transition-opacity duration-200">
-        <div class="flex items-center gap-2 px-3 py-1.5 bg-black/60 backdrop-blur-sm rounded-full">
-          <%= fa("clock", size: :sm, class: "fill-white") %>
-          <span class="text-white text-xs font-medium">Scheduled</span>
-        </div>
-      </div>
-    <% elsif talk.not_recorded? || talk.parent_talk&.not_recorded? %>
-      <div class="absolute inset-0 bottom-6 z-10 hidden sm:group-hover:flex items-center justify-center opacity-0 sm:group-hover:opacity-100 transition-opacity duration-200">
-        <div class="flex items-center gap-2 px-3 py-1.5 bg-black/60 backdrop-blur-sm rounded-full">
-          <%= fa("video-slash", size: :sm, class: "fill-white") %>
-          <span class="text-white text-xs font-medium">Not recorded</span>
-        </div>
-      </div>
-    <% elsif talk.not_published? || talk.parent_talk&.not_published? %>
-      <div class="absolute inset-0 bottom-6 z-10 hidden sm:group-hover:flex items-center justify-center opacity-0 sm:group-hover:opacity-100 transition-opacity duration-200">
-        <div class="flex items-center gap-2 px-3 py-1.5 bg-black/60 backdrop-blur-sm rounded-full">
-          <%= fa("upload", size: :sm, class: "fill-white") %>
-          <span class="text-white text-xs font-medium">Not published</span>
-        </div>
-      </div>
-    <% elsif talk.video_unavailable? %>
-      <div class="absolute inset-0 bottom-6 z-10 hidden sm:group-hover:flex items-center justify-center opacity-0 sm:group-hover:opacity-100 transition-opacity duration-200">
-        <div class="flex items-center gap-2 px-3 py-1.5 bg-black/60 backdrop-blur-sm rounded-full">
-          <%= fa("video-slash", size: :sm, class: "fill-white") %>
-          <span class="text-white text-xs font-medium">Unavailable</span>
         </div>
       </div>
     <% end %>

--- a/test/controllers/watch_list_talks_controller_test.rb
+++ b/test/controllers/watch_list_talks_controller_test.rb
@@ -8,23 +8,40 @@ class WatchListTalksControllerTest < ActionDispatch::IntegrationTest
     sign_in_as @user
   end
 
-  test "should add talk to watch_list" do
+  test "should add talk to watch_list and redirect for turbo submissions" do
     assert_difference("WatchListTalk.count") do
-      post watch_list_talks_url(@watch_list), params: {talk_id: @talk.id}
+      post watch_list_talks_url(@watch_list), params: {talk_id: @talk.id}, as: :turbo_stream
     end
 
     assert_redirected_to watch_list_url(@watch_list)
     assert_includes @watch_list.talks, @talk
   end
 
-  test "should remove talk from watch_list" do
+  test "should remove talk from watch_list and redirect for turbo submissions" do
     WatchListTalk.create!(watch_list: @watch_list, talk: @talk)
 
     assert_difference("WatchListTalk.count", -1) do
-      delete watch_list_talk_url(@watch_list, @talk.id)
+      delete watch_list_talk_url(@watch_list, @talk.id), as: :turbo_stream
     end
 
     assert_redirected_to watch_list_url(@watch_list)
     assert_not_includes @watch_list.talks, @talk
+  end
+
+  test "should ack with no content for xhr (request.js) toggles" do
+    assert_difference("WatchListTalk.count") do
+      post watch_list_talks_url(@watch_list), params: {talk_id: @talk.id}, xhr: true
+    end
+
+    assert_response :no_content
+    assert_includes @watch_list.talks, @talk
+  end
+
+  test "remove is idempotent when the talk is not bookmarked" do
+    assert_no_difference("WatchListTalk.count") do
+      delete watch_list_talk_url(@watch_list, @talk.id), xhr: true
+    end
+
+    assert_response :no_content
   end
 end


### PR DESCRIPTION
### Description

Hovering a talk card in a content row now expands a Netflix-style preview that grows out of the card (FLIP `transform` on a fixed-position element, so it escapes the row's `overflow-x` clipping).

The preview shows the full details: speaker avatar(s) + names, talk kind, event (with logo), date, duration, language, a slides link, and the description. And, for lightning talks, a two-column list of their sections. Speakers, event, language, slides, and sections all link out.

Hover/desktop only (gated via `matchMedia "(min-width: 1024px) and (hover: hover)");` touch and small screens are unaffected.

### Screenshots

<img width="3324" height="1510" alt="CleanShot 2026-06-23 at 22 38 34@2x" src="https://github.com/user-attachments/assets/5ec95476-50cd-4a15-a64d-6f87d37400b8" />



https://github.com/user-attachments/assets/36dd4c2f-885d-45f6-ac12-bd6b71a1f94c

