### PR TITLE
Give SF Ruby a Venue, and Kansai a tickets url

### DIFF
--- a/data/kansai-rubykaigi/kansai-rubykaigi-09/event.yml
+++ b/data/kansai-rubykaigi/kansai-rubykaigi-09/event.yml
@@ -11,6 +11,7 @@ website: "https://regional.rubykaigi.org/kansai09/"
 banner_background: "#FFFFFF"
 featured_background: "#FFFFFF"
 featured_color: "#041D4F"
+tickets_url: "https://ti.to/kansairubykaigi/09"
 coordinates:
   latitude: 35.01446057375976
   longitude: 135.85252085110668

--- a/data/kansai-rubykaigi/kansai-rubykaigi-09/event.yml
+++ b/data/kansai-rubykaigi/kansai-rubykaigi-09/event.yml
@@ -8,10 +8,10 @@ description: ""
 start_date: "2026-07-18"
 end_date: "2026-07-18"
 website: "https://regional.rubykaigi.org/kansai09/"
+tickets_url: "https://ti.to/kansairubykaigi/09"
 banner_background: "#FFFFFF"
 featured_background: "#FFFFFF"
 featured_color: "#041D4F"
-tickets_url: "https://ti.to/kansairubykaigi/09"
 coordinates:
   latitude: 35.01446057375976
   longitude: 135.85252085110668

--- a/data/sfruby/sfruby-2026/venue.yml
+++ b/data/sfruby/sfruby-2026/venue.yml
@@ -1,0 +1,21 @@
+# docs/ADDING_VENUES.md
+---
+name: "SF Jazz"
+url: "https://www.sfjazz.org"
+
+address:
+  street: "201 Franklin Street"
+  city: "San Francisco"
+  region: "California"
+  postal_code: "94102"
+  country: "United States"
+  country_code: "US"
+  display: "201 Franklin Street, San Francisco, CA 94102, United States"
+
+coordinates:
+  latitude: 37.7763779
+  longitude: -122.4215694
+
+maps:
+  google: "https://maps.app.goo.gl/kCRhiuYBew4nPHFz6"
+  openstreetmap: "https://www.openstreetmap.org/?mlat=37.7763779&mlon=-122.4215694&zoom=17"


### PR DESCRIPTION
## Description
<!-- Please describe your changes. -->
- Add SF Jazz as the venue for SF Ruby
- Add tickets url for Kansai Ruby

## Screenshots
<!-- Add screenshots or GIFs if applicable. -->
<img width="1509" height="552" alt="image" src="https://github.com/user-attachments/assets/8035cef8-9a7f-4cf6-a6b0-4acaf6840af4" />
<img width="1511" height="882" alt="image" src="https://github.com/user-attachments/assets/c9d1f245-1b18-445b-a834-b7067a5451a3" />

## Testing Steps
<!-- List steps to test your changes. -->
<!-- If this is a content PR, link to the affected pages -->
- /events/sfruby-2026/venue
- /events/kansai-rubykaigi-09/tickets

## References
<!-- Link to related issues, discussions, other PRs, or references you used to write the PR. -->
- closes #<!-- issue number -->
