### PR TITLE
Fix tag filtering for non-string tags

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -8,7 +8,7 @@ class Announcement
     end
 
     def by_tag(tag)
-      Collection.new(select { |a| a.tags.any? { |tag_value| tag_value.to_s.casecmp?(tag) }})
+      Collection.new(select { |a| a.tags.any? { |tag_value| tag_value.to_s.casecmp?(tag) } })
     end
 
     def all_tags

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -8,7 +8,7 @@ class Announcement
     end
 
     def by_tag(tag)
-      Collection.new(select { |a| a.tags.map(&:downcase).include?(tag.downcase) })
+      Collection.new(select { |a| a.tags.any? { |tag_value| tag_value.to_s.casecmp?(tag) }})
     end
 
     def all_tags


### PR DESCRIPTION
## Description
Updated Announcement::Collection#by_tag to safely compare tags of different types.
Converted each tag to a string before performing a case-insensitive comparison using casecmp?.
Prevents NoMethodError when tags contain non-string values such as integers while preserving existing filtering behavior.

## Screenshots
<img width="1259" height="506" alt="image" src="https://github.com/user-attachments/assets/e77cafbf-d6f3-4533-91d5-530f7876cc75" />

## Testing Steps
https://www.rubyevents.org/announcements

## References
https://github.com/rubyevents/rubyevents/issues/1836
