### PR TITLE
Upcoming event generator & RubyConf AU

### DIFF
--- a/data/rubyconf-au/rubyconf-au-2027/event.yml
+++ b/data/rubyconf-au/rubyconf-au-2027/event.yml
@@ -1,0 +1,16 @@
+# docs/ADDING_EVENTS.md
+---
+id: "rubyconf-au-2027"
+title: "RubyConf AU 2027"
+kind: "conference"
+start_date: "2027-12-31"
+end_date: "2027-12-31"
+year: 2027
+date_precision: "year"
+tickets_url: "" # TODO
+website: "" # TODO
+location: "Melbourne, VIC, AU"
+timezone: "Australia/Melbourne"
+coordinates:
+  latitude: -37.8142454
+  longitude: 144.9631732

--- a/data/rubyconf-au/rubyconf-au-2027/event.yml
+++ b/data/rubyconf-au/rubyconf-au-2027/event.yml
@@ -2,15 +2,15 @@
 ---
 id: "rubyconf-au-2027"
 title: "RubyConf AU 2027"
+location: "Melbourne, VIC, AU"
+timezone: "Australia/Melbourne"
 kind: "conference"
 start_date: "2027-12-31"
 end_date: "2027-12-31"
 year: 2027
 date_precision: "year"
-tickets_url: "" # TODO
 website: "" # TODO
-location: "Melbourne, VIC, AU"
-timezone: "Australia/Melbourne"
+tickets_url: "" # TODO
 coordinates:
   latitude: -37.8142454
   longitude: 144.9631732

--- a/lib/generators/event/USAGE
+++ b/lib/generators/event/USAGE
@@ -9,6 +9,7 @@ Example:
     This will create:
         /data/rubyconf/rubyconf-2026/event.yml
 
+  Create an event that has a venue.
     bin/rails generate event --event-series=tropicalrb --event=tropical-on-rails-2027 \
       --title="Tropical on Rails 2027" --start-date=2027-04-01 --end-date=2027-04-03 \
       --venue-name="Hotel Grande" --venue-address="R. Olimpíadas, 205 - Vila Olímpia, São Paulo - SP, 04551-000"
@@ -16,3 +17,11 @@ Example:
     This will create:
         /data/tropicalrb/tropical-on-rails-2027/event.yml
         /data/tropicalrb/tropical-on-rails-2027/venue.yml
+
+  Create an upcoming event that doesn't have a scheduled date yet - only a year.
+    bin/rails g event --event-series rubyconf-au --event rubyconf-au-2027 --title "RubyConf AU 2027" \
+      --kind "conference" --location "Melbourne, VIC, AU" --date-precision "year" --start-date "2027-12-31" \
+      --end-date "2027-12-31" --timezone "Australia/Melbourne"
+
+    This will create:
+        /data/rubyconf-au/rubyconf-au-2027/event.yml

--- a/lib/generators/event/event_generator.rb
+++ b/lib/generators/event/event_generator.rb
@@ -7,9 +7,17 @@ class EventGenerator < Generators::EventBase
   class_option :title, type: :string, desc: "Event name", group: "Fields", required: true
   class_option :description, type: :string, desc: "Event description", group: "Fields"
   class_option :kind, type: :string, enum: Event.kinds.keys, desc: "Event kind (e.g. conference, meetup, workshop)", default: "conference", group: "Fields"
+
+  # Dates
   class_option :start_date, type: :string, desc: "Start date (YYYY-MM-DD)", required: true, group: "Fields"
   class_option :end_date, type: :string, desc: "End date (YYYY-MM-DD)", required: true, group: "Fields"
+  class_option :announced_on, type: :string, desc: "Date when the event was announced (YYYY-MM-DD)", group: "Fields"
+  class_option :published_at, type: :string, desc: "Date when videos were published (YYYY-MM-DD)", group: "Fields"
+  class_option :date_precision, type: :string, enum: ["year", "month", "day"], desc: "Precision of the date (when exact dates are unknown)", group: "Fields"
+
+  # Websites
   class_option :tickets_url, type: :string, desc: "URL to purchase tickets (e.g., Tito, Eventbrite, Luma)", group: "Fields"
+  class_option :original_website, type: :string, desc: "Original/archived website URL", group: "Fields"
   class_option :website, type: :string, desc: "Event website URL", group: "Fields"
 
   # Flags

--- a/lib/generators/event/templates/event.yml.tt
+++ b/lib/generators/event/templates/event.yml.tt
@@ -7,11 +7,23 @@ kind: "<%= options[:kind] %>"
 description: |-
 <%= optimize_indentation(options[:description], 4) %>
 <%- end -%>
+<%- if options[:published_at] -%>
+published_at: "<%= options[:published_at] %>"
+<%- end -%>
+<%- if options[:announced_on] -%>
+announced_on: "<%= options[:announced_on] %>"
+<%- end -%>
 start_date: "<%= options[:start_date] %>"
 end_date: "<%= options[:end_date] %>"
 year: <%= @year %>
-tickets_url: "<%= options[:tickets_url] %>"<% " # TODO" if options[:tickets_url].blank? %>
-website: "<%= options[:website] %>"<% " # TODO" if options[:website].blank? %>
+<%- if options[:date_precision] -%>
+date_precision: "<%= options[:date_precision] %>"
+<%- end -%>
+tickets_url: "<%= options[:tickets_url] %>"<%= " # TODO" if options[:tickets_url].blank? %>
+website: "<%= options[:website] %>"<%= " # TODO" if options[:website].blank? %>
+<%- if options[:original_website] -%>
+original_website: "<%= options[:original_website] %>"
+<%- end -%>
 <%- if options[:last_edition] -%>
 last_edition: true
 <%- end -%>

--- a/lib/generators/event/templates/event.yml.tt
+++ b/lib/generators/event/templates/event.yml.tt
@@ -2,6 +2,12 @@
 ---
 id: "<%= options[:event] %>"
 title: "<%= options[:title] %>"
+<%- if @location -%>
+location: "<%= @location %>"
+<%- end -%>
+<%- if @timezone -%>
+timezone: "<%= @timezone %>"
+<%- end -%>
 kind: "<%= options[:kind] %>"
 <%- if options[:description] -%>
 description: |-
@@ -19,19 +25,13 @@ year: <%= @year %>
 <%- if options[:date_precision] -%>
 date_precision: "<%= options[:date_precision] %>"
 <%- end -%>
-tickets_url: "<%= options[:tickets_url] %>"<%= " # TODO" if options[:tickets_url].blank? %>
 website: "<%= options[:website] %>"<%= " # TODO" if options[:website].blank? %>
 <%- if options[:original_website] -%>
 original_website: "<%= options[:original_website] %>"
 <%- end -%>
+tickets_url: "<%= options[:tickets_url] %>"<%= " # TODO" if options[:tickets_url].blank? %>
 <%- if options[:last_edition] -%>
 last_edition: true
-<%- end -%>
-<%- if @location -%>
-location: "<%= @location %>"
-<%- end -%>
-<%- if @timezone -%>
-timezone: "<%= @timezone %>"
 <%- end -%>
 coordinates:<%- if options[:online] || @coordinates.nil? -%>
  false

--- a/test/lib/generators/event_generator_test.rb
+++ b/test/lib/generators/event_generator_test.rb
@@ -56,9 +56,13 @@ class EventGeneratorTest < Rails::Generators::TestCase
       "--description", "RubyConf 2027 description",
       "--start-date", "2027-11-15",
       "--end-date", "2027-11-17",
+      "--date-precision", "year",
+      "--announced-on", "2027-01-01",
+      "--published-at", "2027-12-01",
       "--kind", "retreat",
       "--tickets-url", "https://example.com/tickets",
       "--website", "https://example.com/rubyconf-2027",
+      "--original-website", "https://example.com/rubyconf-2027-archive",
       "--last-edition",
       "--timezone", "America/Chicago",
       "--online"]
@@ -71,10 +75,13 @@ class EventGeneratorTest < Rails::Generators::TestCase
       assert_match(/description: |-\s+RubyConf 2027 description/, content)
       assert_match(/start_date: "2027-11-15"/, content)
       assert_match(/end_date: "2027-11-17"/, content)
+      assert_match(/announced_on: "2027-01-01"/, content)
+      assert_match(/published_at: "2027-12-01"/, content)
       assert_match(/year: 2027/, content)
       assert_match(/kind: "retreat"/, content)
       assert_match(/tickets_url: "https:\/\/example.com\/tickets"/, content)
       assert_match(/website: "https:\/\/example.com\/rubyconf-2027"/, content)
+      assert_match(/original_website: "https:\/\/example.com\/rubyconf-2027-archive"/, content)
       assert_match(/timezone: "America\/Chicago"/, content)
       assert_match(/last_edition: true/, content)
       assert_match(/location: "online"/, content)


### PR DESCRIPTION
## Description
<!-- Please describe your changes. -->
Add new fields to event generator.
Add new RubyConf AU 2027 upcoming event.

## Screenshots
<!-- Add screenshots or GIFs if applicable. -->

<img width="1416" height="838" alt="Screenshot 2026-07-01 at 1 03 08 PM" src="https://github.com/user-attachments/assets/dd944c51-2303-4494-b3f1-1d6ffa8cc7c5" />
<img width="675" height="79" alt="Screenshot 2026-07-01 at 1 03 23 PM" src="https://github.com/user-attachments/assets/e4fe868a-fea0-433f-91cf-b862e56e4fbb" />
<img width="1415" height="836" alt="Screenshot 2026-07-01 at 1 04 11 PM" src="https://github.com/user-attachments/assets/b38e640f-c0e4-4ca0-8fef-773d6f8e278f" />


## Testing Steps
<!-- List steps to test your changes. -->
<!-- If this is a content PR, link to the affected pages -->

## References
<!-- Link to related issues, discussions, other PRs, or references you used to write the PR. -->
- closes #<!-- issue number -->
