### PR TITLE
Add RBQ 2026 Keynote recordings

### DIFF
--- a/data/rbqconf/rbqconf-2026/videos.yml
+++ b/data/rbqconf/rbqconf-2026/videos.yml
@@ -10,12 +10,15 @@
     - TODO # RBQ MC
 
 - id: "kinsey-durham-grace-rbqconf-2025"
-  title: "Keynote: Kinsey Durham Grace"
+  title: "Keynote: Building GitHub's Coding Agents, Wrangling Toddlers, & Untangling Fly Lines"
+  raw_title: "RBQ 2026 Opening Keynote Building GitHub's coding agents, wrangling toddlers, & untangling fly lines"
+  kind: "keynote"
   event_name: "RBQConf 2026"
   date: "2026-03-26"
+  published_at: "2026-07-01T13:07:52Z"
   announced_at: "2025-12-24"
-  video_provider: "scheduled"
-  video_id: "kinsey-durham-grace-rbqconf-2025"
+  video_provider: "youtube"
+  video_id: "_npmWR_Or80"
   description: ""
   speakers:
     - Kinsey Durham Grace
@@ -247,12 +250,15 @@
     - Cristian Planas
 
 - id: "nickolas-means-rbqconf-2025"
-  title: "Keynote: Nickolas Means"
+  title: "Keynote: 114 Miles to the Final Cut"
+  raw_title: "RBQ 2026 Closing Keynote - 114 Miles to the Final Cut"
+  kind: "keynote"
   event_name: "RBQConf 2026"
   date: "2026-03-27"
+  published_at: "2026-07-01T13:07:53Z"
   announced_at: "2025-12-24"
-  video_provider: "scheduled"
-  video_id: "nickolas-means-rbqconf-2025"
+  video_provider: "youtube"
+  video_id: "27vsZ7hl0RY"
   description: ""
   speakers:
     - Nickolas Means


### PR DESCRIPTION
<img width="2896" height="1760" alt="CleanShot 2026-07-01 at 20 58 07@2x" src="https://github.com/user-attachments/assets/260c52bb-6a33-46ce-9270-e201397fa317" />
