### PR TITLE
Add Languages to profile

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -142,7 +142,8 @@ class ProfilesController < ApplicationController
       :speakerdeck,
       :pronouns_type,
       :pronouns,
-      :slug
+      :slug,
+      spoken_languages: []
     )
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -19,7 +19,7 @@
 #  location            :string
 #  longitude           :decimal(10, 6)
 #  name                :string           default(""), not null, indexed
-#  slug                :string           default(""), not null, indexed
+#  slug                :string           default(""), not null, uniquely indexed
 #  start_date          :date
 #  state_code          :string           indexed => [country_code]
 #  talks_count         :integer          default(0), not null
@@ -36,7 +36,7 @@
 #  index_events_on_event_series_id              (event_series_id)
 #  index_events_on_kind                         (kind)
 #  index_events_on_name                         (name)
-#  index_events_on_slug                         (slug)
+#  index_events_on_slug                         (slug) UNIQUE
 #
 # Foreign Keys
 #

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -19,7 +19,7 @@
 #  location            :string
 #  longitude           :decimal(10, 6)
 #  name                :string           default(""), not null, indexed
-#  slug                :string           default(""), not null, uniquely indexed
+#  slug                :string           default(""), not null, indexed
 #  start_date          :date
 #  state_code          :string           indexed => [country_code]
 #  talks_count         :integer          default(0), not null
@@ -36,7 +36,7 @@
 #  index_events_on_event_series_id              (event_series_id)
 #  index_events_on_kind                         (kind)
 #  index_events_on_name                         (name)
-#  index_events_on_slug                         (slug) UNIQUE
+#  index_events_on_slug                         (slug)
 #
 # Foreign Keys
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,7 @@
 #  settings             :json             not null
 #  slug                 :string           default(""), not null, uniquely indexed
 #  speakerdeck          :string           default(""), not null
+#  spoken_languages     :json             not null
 #  state_code           :string
 #  suspicion_cleared_at :datetime
 #  suspicion_marked_at  :datetime

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -15,6 +15,22 @@
       <%= form.text_field :location, class: "input input-bordered w-full" %>
     </div>
 
+    <div class="col-span-2">
+      <%= form.label :spoken_languages, "Languages I speak" %>
+
+      <div class="grid grid-cols-2 md:grid-cols-3 gap-2 mt-2 max-h-60 overflow-y-auto border rounded-lg p-3">
+        <% Language.used.each do |code, name| %>
+          <label class="flex items-center gap-2">
+            <%= check_box_tag "user[spoken_languages][]",
+                  code,
+                  user.spoken_languages.include?(code) %>
+
+            <%= name %>
+          </label>
+        <% end %>
+      </div>
+    </div>
+
     <div>
       <%= form.label :github_handle, "GitHub" %>
       <%= form.text_field :github_handle, class: "input input-bordered w-full" %>

--- a/db/migrate/20260702093844_add_spoken_languages_to_users.rb
+++ b/db/migrate/20260702093844_add_spoken_languages_to_users.rb
@@ -1,0 +1,5 @@
+class AddSpokenLanguagesToUsers < ActiveRecord::Migration[8.2]
+  def change
+    add_column :users, :spoken_languages, :json, default: [], null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_06_25_000000) do
+ActiveRecord::Schema[8.2].define(version: 2026_07_02_093844) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -492,6 +492,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_06_25_000000) do
     t.json "settings", default: {}, null: false
     t.string "slug", default: "", null: false
     t.string "speakerdeck", default: "", null: false
+    t.json "spoken_languages", default: [], null: false
     t.string "state_code"
     t.datetime "suspicion_cleared_at"
     t.datetime "suspicion_marked_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -238,7 +238,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_02_093844) do
     t.index ["event_series_id"], name: "index_events_on_event_series_id"
     t.index ["kind"], name: "index_events_on_kind"
     t.index ["name"], name: "index_events_on_name"
-    t.index ["slug"], name: "index_events_on_slug"
+    t.index ["slug"], name: "index_events_on_slug", unique: true
   end
 
   create_table "favorite_users", force: :cascade do |t|

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -123,4 +123,17 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
     get profile_url("duplicate-controller")
     assert_redirected_to profile_url(canonical_user)
   end
+
+  test "owner can update their spoken languages" do
+    sign_in_as @user
+
+    patch profile_url(@user), params: {
+      user: {
+        spoken_languages: ["en", "ja"]
+      }
+    }
+
+    assert_redirected_to profile_url(@user)
+    assert_equal ["en", "ja"], @user.reload.spoken_languages
+  end
 end

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -20,7 +20,7 @@
 #  location            :string
 #  longitude           :decimal(10, 6)
 #  name                :string           default(""), not null, indexed
-#  slug                :string           default(""), not null, indexed
+#  slug                :string           default(""), not null, uniquely indexed
 #  start_date          :date
 #  state_code          :string           indexed => [country_code]
 #  talks_count         :integer          default(0), not null
@@ -37,7 +37,7 @@
 #  index_events_on_event_series_id              (event_series_id)
 #  index_events_on_kind                         (kind)
 #  index_events_on_name                         (name)
-#  index_events_on_slug                         (slug)
+#  index_events_on_slug                         (slug) UNIQUE
 #
 # Foreign Keys
 #

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -28,6 +28,7 @@
 #  settings             :json             not null
 #  slug                 :string           default(""), not null, uniquely indexed
 #  speakerdeck          :string           default(""), not null
+#  spoken_languages     :json             not null
 #  state_code           :string
 #  suspicion_cleared_at :datetime
 #  suspicion_marked_at  :datetime


### PR DESCRIPTION
## Description
Added a column in users table: spoken language
Added in strong params 
Added multi select option in profile

## Screenshots
<img width="1105" height="329" alt="Screenshot from 2026-07-02 15-14-02" src="https://github.com/user-attachments/assets/8c088ee4-4623-4716-b6df-14d0d485f8cf" />

<img width="1257" height="145" alt="Screenshot from 2026-07-02 15-13-44" src="https://github.com/user-attachments/assets/8631b2a1-98b6-4bc7-8667-a8502b9097b0" />

## Testing Steps
Sign in
goto profile
system should show an option to choose languages

## References
Closes https://github.com/rubyevents/rubyevents/issues/1826
