### PR TITLE
Add slides URLs for three talks

### DIFF
--- a/data/blastoffrails/blastoffrails-2026/videos.yml
+++ b/data/blastoffrails/blastoffrails-2026/videos.yml
@@ -43,6 +43,7 @@
   event_name: "Blastoff Rails 2026"
   date: "2026-06-11"
   published_at: "2026-06-26T15:00:26Z"
+  slides_url: "https://docs.google.com/presentation/d/110taCda3T4oDAgg3JjE5T_4KMoubzuh6MD8-SwtY_8M/edit?usp=sharing"
   video_provider: "youtube"
   video_id: "lJD-0s7dQQc"
   description: |-

--- a/data/railsconf/railsconf-2025/videos.yml
+++ b/data/railsconf/railsconf-2025/videos.yml
@@ -330,6 +330,7 @@
   date: "2025-07-08"
   published_at: "2025-07-24T12:28:43Z"
   track: "Breakout 1 - Independence"
+  slides_url: "https://docs.google.com/presentation/d/1NZKbXAkYu_ynXfJ_u7avd-Viz9COX4a9yT9pQv1f4iw/edit?usp=sharing"
   video_provider: "youtube"
   video_id: "ozayFBNKO2M"
   description: |-

--- a/data/tropicalrb/tropical-on-rails-2026/videos.yml
+++ b/data/tropicalrb/tropical-on-rails-2026/videos.yml
@@ -431,6 +431,7 @@
   published_at: "2026-05-28T03:00:13Z"
   announced_at: "2026-01-28"
   language: "English"
+  slides_url: "https://docs.google.com/presentation/d/1v7JH0cK1HCn2yWQR81TnMnBMHwhPo6fgFfl5DgvjMJ0/edit?usp=sharing"
   video_provider: "youtube"
   video_id: "c6l6Anm_Ijo"
   description: |-


### PR DESCRIPTION
Adds `slides_url` for three talks:

- **Blastoff Rails 2026** — Rubyists can make games too!
- **Tropical on Rails 2026** — Production Data Doesn't Have to Be Scary
- **RailsConf 2025** — Ruby Internals: A Guide For Rails Developers