### PR TITLE
Add language understanding preferences for talk recommendations

### DIFF
--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -364,17 +364,12 @@ class BrowseController < ApplicationController
   def load_language_rows
     return @language_rows = [] unless Current.user
 
+    understood_languages = Current.user.languages.understood - ["en"]
+    return @language_rows = [] unless understood_languages.any?
+
     watched_talk_ids = Current.user.watched_talks.pluck(:talk_id)
-    return @language_rows = [] unless watched_talk_ids.any?
 
-    watched_languages = Talk.where(id: watched_talk_ids)
-      .where.not(language: ["en", nil])
-      .distinct
-      .pluck(:language)
-
-    return @language_rows = [] unless watched_languages.any?
-
-    @language_rows = watched_languages.map do |lang_code|
+    @language_rows = understood_languages.map do |lang_code|
       language_name = Language.by_code(lang_code)
       talks = Talk.watchable
         .where(language: lang_code)

--- a/app/controllers/language_preferences_controller.rb
+++ b/app/controllers/language_preferences_controller.rb
@@ -1,0 +1,18 @@
+class LanguagePreferencesController < ApplicationController
+  ANSWERS = %w[understands does_not_understand unset].freeze
+
+  # PATCH /language_preference
+  def update
+    code = params[:language_code].to_s
+    answer = params[:answer].to_s
+
+    if code.present? && ANSWERS.include?(answer)
+      Current.user.languages.set(code, answer)
+    end
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_back fallback_location: root_path }
+    end
+  end
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -130,7 +130,7 @@ class ProfilesController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(
+    permitted = params.require(:user).permit(
       :github_handle,
       :twitter,
       :bsky,
@@ -143,8 +143,19 @@ class ProfilesController < ApplicationController
       :pronouns_type,
       :pronouns,
       :slug,
-      spoken_languages: []
+      language_preferences: {}
     )
+
+    if permitted.key?(:language_preferences)
+      permitted[:language_preferences] = permitted[:language_preferences].to_h.filter_map { |code, answer|
+        case answer
+        when "understands" then [code, {"understands" => true}]
+        when "does_not_understand" then [code, {"understands" => false}]
+        end
+      }.to_h
+    end
+
+    permitted
   end
 
   def set_favorite_user

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -142,20 +142,25 @@ class ProfilesController < ApplicationController
       :speakerdeck,
       :pronouns_type,
       :pronouns,
-      :slug,
-      language_preferences: {}
+      :slug
     )
 
-    if permitted.key?(:language_preferences)
-      permitted[:language_preferences] = permitted[:language_preferences].to_h.filter_map { |code, answer|
-        case answer
-        when "understands" then [code, {"understands" => true}]
-        when "does_not_understand" then [code, {"understands" => false}]
-        end
-      }.to_h
-    end
+    permitted[:language_preferences] = language_preferences_param if params[:user]&.key?(:language_preferences)
 
     permitted
+  end
+
+  def language_preferences_param
+    raw = params.require(:user).fetch(:language_preferences, {}).to_unsafe_h
+
+    raw.each_with_object({}) do |(code, answer), result|
+      next unless Language.by_code(code)
+
+      case answer
+      when "understands" then result[code] = {"understands" => true}
+      when "does_not_understand" then result[code] = {"understands" => false}
+      end
+    end
   end
 
   def set_favorite_user

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -4,6 +4,22 @@ class Language
   ALL_ENGLISH_NAMES = ISO_639::ISO_639_1.map { |language| language.english_name.split(";").first }.freeze
   ALL_LANGUAGES = ALL_ALPHA2_CODES.zip(ALL_ENGLISH_NAMES).to_h.freeze
 
+  UNDERSTANDS_CONFIRMATIONS = {
+    "en" => "Yes, I understand English",
+    "ja" => "はい、日本語がわかります",
+    "zh" => "是的，我听得懂中文",
+    "pt" => "Sim, eu entendo português",
+    "es" => "Sí, entiendo español",
+    "fr" => "Oui, je comprends le français",
+    "it" => "Sì, capisco l'italiano",
+    "de" => "Ja, ich verstehe Deutsch",
+    "ru" => "Да, я понимаю русский",
+    "tr" => "Evet, Türkçe anlıyorum",
+    "pl" => "Tak, rozumiem polski",
+    "bg" => "Да, разбирам български",
+    "ro" => "Da, înțeleg română"
+  }.freeze
+
   def self.find(term)
     ISO_639
       .search(term)
@@ -51,6 +67,10 @@ class Language
 
   def self.native_name(code)
     LanguageHelper::NATIVE_NAMES[code]
+  end
+
+  def self.understands_confirmation(code)
+    UNDERSTANDS_CONFIRMATIONS[code] || "Yes, I understand #{by_code(code) || code}"
   end
 
   def self.emoji_flag(code)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,7 @@
 #  geocode_metadata     :json             not null
 #  github_handle        :string
 #  github_metadata      :json             not null
+#  language_preferences :json             not null
 #  latitude             :decimal(10, 6)
 #  linkedin             :string           default(""), not null
 #  location             :string           default("")
@@ -28,7 +29,6 @@
 #  settings             :json             not null
 #  slug                 :string           default(""), not null, uniquely indexed
 #  speakerdeck          :string           default(""), not null
-#  spoken_languages     :json             not null
 #  state_code           :string
 #  suspicion_cleared_at :datetime
 #  suspicion_marked_at  :datetime
@@ -151,6 +151,7 @@ class User < ApplicationRecord
 
   has_object :profiles
   has_object :favorite_statuses
+  has_object :languages
   has_object :talk_recommender
   has_object :watched_talk_seeder
   has_object :speakerdeck_feed

--- a/app/models/user/languages.rb
+++ b/app/models/user/languages.rb
@@ -1,0 +1,95 @@
+class User::Languages < ActiveRecord::AssociatedObject
+  # Each language maps to a hash of dimensions, e.g. {"understands" => true}.
+  # Only "understands" is used so far; nesting means "speaks" (etc.) can be added
+  # later without a migration.
+  DIMENSIONS = %w[understands].freeze
+
+  extension do
+    validate do
+      valid = language_preferences.all? do |_code, entry|
+        entry.is_a?(Hash) &&
+          (entry.keys - User::Languages::DIMENSIONS).empty? &&
+          entry.values.all? { |value| [true, false].include?(value) }
+      end
+
+      errors.add(:language_preferences, "has an invalid shape") unless valid
+    end
+  end
+
+  def understands?(code)
+    dimension(code, "understands") == true
+  end
+
+  def does_not_understand?(code)
+    dimension(code, "understands") == false
+  end
+
+  def set?(code)
+    preferences.key?(code.to_s)
+  end
+
+  def understood
+    codes_where("understands", true)
+  end
+
+  def not_understood
+    codes_where("understands", false)
+  end
+
+  def set(code, answer)
+    value = case answer.to_s
+    when "understands" then true
+    when "does_not_understand" then false
+    when "unset" then nil
+    else raise ArgumentError, "unknown language preference answer: #{answer}"
+    end
+
+    entry = (preferences[code.to_s] || {}).dup
+    value.nil? ? entry.delete("understands") : entry["understands"] = value
+
+    updated = preferences.merge(code.to_s => entry)
+    updated.delete(code.to_s) if entry.empty?
+
+    user.update(language_preferences: updated)
+  end
+
+  def pending_prompts
+    watched_languages
+      .select { |code| dimension(code, "understands").nil? }
+      .sort_by { |code| -watched_counts[code].to_i }
+  end
+
+  def pending_prompt
+    pending_prompts.first
+  end
+
+  def watched_count(code)
+    user.watched_talks.joins(:talk).where(talks: {language: code.to_s}).count
+  end
+
+  def watched_counts
+    user.watched_talks.joins(:talk).group("talks.language").count
+  end
+
+  private
+
+  def dimension(code, name)
+    preferences.dig(code.to_s, name)
+  end
+
+  def codes_where(name, value)
+    preferences.select { |_, entry| entry[name] == value }.keys
+  end
+
+  def preferences
+    user.language_preferences
+  end
+
+  def watched_languages
+    user.watched_talks
+      .joins(:talk)
+      .where.not(talks: {language: nil})
+      .distinct
+      .pluck("talks.language")
+  end
+end

--- a/app/views/language_preferences/update.turbo_stream.erb
+++ b/app/views/language_preferences/update.turbo_stream.erb
@@ -1,3 +1,3 @@
 <%= turbo_stream.replace "language-prompt" do %>
-  <%= render "shared/language_prompt" %>
+  <%= render "shared/language_prompt", just_completed: true %>
 <% end %>

--- a/app/views/language_preferences/update.turbo_stream.erb
+++ b/app/views/language_preferences/update.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "language-prompt" do %>
+  <%= render "shared/language_prompt" %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,6 +38,7 @@
   <body data-controller="preserve-scroll" class="<%= yield(:body_class) %>">
     <div class="hotwire-native:hidden">
       <%= render "shared/navbar" %>
+      <%= render "shared/language_prompt" %>
     </div>
 
     <div class="min-h-screen">

--- a/app/views/profiles/_form.html.erb
+++ b/app/views/profiles/_form.html.erb
@@ -15,22 +15,6 @@
       <%= form.text_field :location, class: "input input-bordered w-full" %>
     </div>
 
-    <div class="col-span-2">
-      <%= form.label :spoken_languages, "Languages I speak" %>
-
-      <div class="grid grid-cols-2 md:grid-cols-3 gap-2 mt-2 max-h-60 overflow-y-auto border rounded-lg p-3">
-        <% Language.used.each do |code, name| %>
-          <label class="flex items-center gap-2">
-            <%= check_box_tag "user[spoken_languages][]",
-                  code,
-                  user.spoken_languages.include?(code) %>
-
-            <%= name %>
-          </label>
-        <% end %>
-      </div>
-    </div>
-
     <div>
       <%= form.label :github_handle, "GitHub" %>
       <%= form.text_field :github_handle, class: "input input-bordered w-full" %>
@@ -72,6 +56,64 @@
     <div>
       <%= form.label :website %>
       <%= form.text_field :website, class: "input input-bordered w-full" %>
+    </div>
+
+    <div class="col-span-2">
+      <%= form.label :languages, "Languages" %>
+      <p class="text-sm text-base-content/60 mb-2">This helps us recommend talks in languages you understand.</p>
+
+      <% watched_counts = user.languages.watched_counts %>
+      <% grouped_languages = Language.used.group_by do |code, _name|
+           if user.languages.understands?(code)
+             :understands
+           elsif watched_counts[code].to_i > 0
+             :watched
+           else
+             :other
+           end
+         end %>
+
+      <div class="flex flex-col gap-4 mt-2 max-h-72 overflow-y-auto border rounded-lg p-3">
+        <% [[:understands, "Languages you understand"], [:watched, "Languages you watched talks in"], [:other, "Other languages"]].each do |group, heading| %>
+          <% languages = grouped_languages[group] %>
+          <% next if languages.blank? %>
+
+          <div>
+            <h4 class="text-xs font-semibold text-base-content/50 uppercase tracking-wider mb-1"><%= heading %> (<%= languages.size %>)</h4>
+
+            <div class="flex flex-col gap-1">
+              <% languages.each do |code, name| %>
+                <% current = if user.languages.understands?(code)
+                     "understands"
+                   else
+                     (user.languages.does_not_understand?(code) ? "does_not_understand" : "unset")
+                   end %>
+                <div class="flex flex-wrap items-center justify-between gap-2 py-1">
+                  <span class="flex items-center gap-2">
+                    <span><%= Language.emoji_flag(code) %> <%= name %></span>
+                    <% if (watched = watched_counts[code].to_i) > 0 %>
+                      <span class="text-xs text-base-content/50">You've watched <%= pluralize(watched, "talk") %></span>
+                    <% end %>
+                  </span>
+
+                  <div class="join">
+                    <% [["understands", "Understand"], ["does_not_understand", "Don't understand"]].each do |value, label| %>
+                      <%= tag.input(
+                            type: "radio",
+                            name: "user[language_preferences][#{code}]",
+                            value: value,
+                            class: "join-item btn btn-sm",
+                            "aria-label": label,
+                            checked: current == value
+                          ) %>
+                    <% end %>
+                  </div>
+                </div>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
     </div>
   </div>
 

--- a/app/views/profiles/_header_content.html.erb
+++ b/app/views/profiles/_header_content.html.erb
@@ -3,6 +3,18 @@
 <div id="<%= dom_id(user, :header_content) %>" class="flex flex-col lg:flex-row gap-8 items-center lg:justify-right text-center lg:text-left mb-6 lg:mb-0">
   <div class="relative w-fit">
     <%= ui_avatar(user, size_class: "size-24 md:size-36", size: :lg) %>
+
+    <% understood_languages = user.languages.understood %>
+
+    <% if understood_languages.any? %>
+      <div class="flex justify-center gap-1.5">
+        <% understood_languages.each do |code| %>
+          <%= ui_tooltip("Understands #{Language.by_code(code) || code}") do %>
+            <span class="text-lg leading-none"><%= Language.emoji_flag(code) %></span>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
   </div>
 
   <div class="flex-col flex gap-2 title justify-center items-center lg:items-start">

--- a/app/views/shared/_language_prompt.html.erb
+++ b/app/views/shared/_language_prompt.html.erb
@@ -1,36 +1,41 @@
 <div id="language-prompt">
-  <% pending_codes = Current.user ? Current.user.languages.pending_prompts : [] %>
+  <% code = Current.user&.languages&.pending_prompt %>
 
-  <% if pending_codes.any? %>
-    <% watched_counts = Current.user.languages.watched_counts %>
+  <% if code %>
+    <% language_name = Language.by_code(code) || code.upcase %>
+    <% watched_count = Current.user.languages.watched_count(code) %>
 
     <div class="bg-base-200 border-y border-base-300">
-      <div class="container py-3">
-        <div class="flex flex-col divide-y divide-base-300">
-          <% pending_codes.each do |code| %>
-          <% language_name = Language.by_code(code) || code.upcase %>
-          <div class="flex flex-wrap items-center justify-between gap-3 py-2 first:pt-0 last:pb-0">
-            <p class="text-sm">
-              <span class="mr-1"><%= Language.emoji_flag(code) %></span>
-              You've watched <strong><%= pluralize(watched_counts[code].to_i, "talk") %></strong> in <strong><%= language_name %></strong>. Do you understand it?
-            </p>
+      <div class="container py-3 flex flex-wrap items-center justify-between gap-3">
+        <p class="text-sm">
+          <span class="mr-1"><%= Language.emoji_flag(code) %></span>
+          You've watched <strong><%= pluralize(watched_count, "talk") %></strong> in <strong><%= language_name %></strong>. Do you understand it?
+          <span class="text-base-content/60">We'll use this to recommend talks.</span>
+        </p>
 
-            <div class="flex items-center gap-2">
-              <%= button_to Language.understands_confirmation(code),
-                    language_preference_path(language_code: code, answer: "understands"),
-                    method: :patch,
-                    class: "btn btn-sm btn-primary" %>
+        <div class="flex flex-col sm:flex-row items-stretch sm:items-center gap-2 w-full sm:w-auto">
+          <%= button_to Language.understands_confirmation(code),
+                language_preference_path(language_code: code, answer: "understands"),
+                method: :patch,
+                class: "btn btn-sm btn-primary w-full sm:w-auto" %>
 
-              <%= button_to "No, I don't understand #{language_name}",
-                    language_preference_path(language_code: code, answer: "does_not_understand"),
-                    method: :patch,
-                    class: "btn btn-sm btn-outline" %>
-            </div>
-          </div>
-          <% end %>
+          <%= button_to "No, I don't understand #{language_name}",
+                language_preference_path(language_code: code, answer: "does_not_understand"),
+                method: :patch,
+                class: "btn btn-sm btn-outline w-full sm:w-auto" %>
         </div>
+      </div>
+    </div>
+  <% elsif local_assigns[:just_completed] %>
+    <div class="bg-base-200 border-y border-base-300">
+      <div class="container py-3 flex flex-wrap items-center justify-between gap-3">
+        <p class="text-sm">
+          Thanks for the information! You can always update your language preferences in your profile.
+        </p>
 
-        <p class="text-sm text-base-content/60 mt-2">We'll use this to recommend talks.</p>
+        <%= ui_button url: edit_profile_path(Current.user), kind: :neutral, size: :sm, data: {turbo_frame: "modal"} do %>
+          Update language preferences
+        <% end %>
       </div>
     </div>
   <% end %>

--- a/app/views/shared/_language_prompt.html.erb
+++ b/app/views/shared/_language_prompt.html.erb
@@ -1,0 +1,37 @@
+<div id="language-prompt">
+  <% pending_codes = Current.user ? Current.user.languages.pending_prompts : [] %>
+
+  <% if pending_codes.any? %>
+    <% watched_counts = Current.user.languages.watched_counts %>
+
+    <div class="bg-base-200 border-y border-base-300">
+      <div class="container py-3">
+        <div class="flex flex-col divide-y divide-base-300">
+          <% pending_codes.each do |code| %>
+          <% language_name = Language.by_code(code) || code.upcase %>
+          <div class="flex flex-wrap items-center justify-between gap-3 py-2 first:pt-0 last:pb-0">
+            <p class="text-sm">
+              <span class="mr-1"><%= Language.emoji_flag(code) %></span>
+              You've watched <strong><%= pluralize(watched_counts[code].to_i, "talk") %></strong> in <strong><%= language_name %></strong>. Do you understand it?
+            </p>
+
+            <div class="flex items-center gap-2">
+              <%= button_to Language.understands_confirmation(code),
+                    language_preference_path(language_code: code, answer: "understands"),
+                    method: :patch,
+                    class: "btn btn-sm btn-primary" %>
+
+              <%= button_to "No, I don't understand #{language_name}",
+                    language_preference_path(language_code: code, answer: "does_not_understand"),
+                    method: :patch,
+                    class: "btn btn-sm btn-outline" %>
+            </div>
+          </div>
+          <% end %>
+        </div>
+
+        <p class="text-sm text-base-content/60 mt-2">We'll use this to recommend talks.</p>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -241,6 +241,8 @@ Rails.application.routes.draw do
 
   resources :favorite_users, only: [:index, :create, :destroy, :update]
 
+  resource :language_preference, only: [:update]
+
   resources :events, param: :slug, only: [:index, :show] do
     resources :event_participations, only: [:create, :destroy]
 

--- a/db/migrate/20260702130000_consolidate_language_preferences_on_users.rb
+++ b/db/migrate/20260702130000_consolidate_language_preferences_on_users.rb
@@ -1,0 +1,6 @@
+class ConsolidateLanguagePreferencesOnUsers < ActiveRecord::Migration[8.2]
+  def change
+    add_column :users, :language_preferences, :json, default: {}, null: false
+    remove_column :users, :spoken_languages, :json, default: [], null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_07_02_093844) do
+ActiveRecord::Schema[8.2].define(version: 2026_07_02_130000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -479,6 +479,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_02_093844) do
     t.json "geocode_metadata", default: {}, null: false
     t.string "github_handle"
     t.json "github_metadata", default: {}, null: false
+    t.json "language_preferences", default: {}, null: false
     t.decimal "latitude", precision: 10, scale: 6
     t.string "linkedin", default: "", null: false
     t.string "location", default: ""
@@ -492,7 +493,6 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_02_093844) do
     t.json "settings", default: {}, null: false
     t.string "slug", default: "", null: false
     t.string "speakerdeck", default: "", null: false
-    t.json "spoken_languages", default: [], null: false
     t.string "state_code"
     t.datetime "suspicion_cleared_at"
     t.datetime "suspicion_marked_at"

--- a/test/controllers/browse_controller_test.rb
+++ b/test/controllers/browse_controller_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class BrowseControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+  end
+
+  test "language rows are empty without spoken languages" do
+    sign_in_as @user
+
+    get browse_url("language_rows")
+
+    assert_response :success
+    assert_no_match "More Talks in", response.body
+  end
+
+  test "language rows recommend talks in the user's spoken languages" do
+    @user.update!(language_preferences: {"pt" => {"understands" => true}})
+    sign_in_as @user
+
+    get browse_url("language_rows")
+
+    assert_response :success
+    assert_match "More Talks in", response.body
+  end
+end

--- a/test/controllers/language_preferences_controller_test.rb
+++ b/test/controllers/language_preferences_controller_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+
+class LanguagePreferencesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:one)
+  end
+
+  test "requires authentication" do
+    patch language_preference_url(language_code: "ja", answer: "understands")
+    assert_response :redirect
+  end
+
+  test "records that the user understands a language" do
+    sign_in_as @user
+
+    patch language_preference_url(language_code: "ja", answer: "understands")
+
+    assert_response :redirect
+    assert_includes @user.reload.languages.understood, "ja"
+    assert_not_includes @user.languages.not_understood, "ja"
+  end
+
+  test "records that the user does not understand a language" do
+    sign_in_as @user
+
+    patch language_preference_url(language_code: "pt", answer: "does_not_understand")
+
+    assert_response :redirect
+    assert_includes @user.reload.languages.not_understood, "pt"
+    assert_not_includes @user.languages.understood, "pt"
+  end
+
+  test "ignores an invalid answer" do
+    sign_in_as @user
+
+    patch language_preference_url(language_code: "ja", answer: "maybe")
+
+    assert_empty @user.reload.languages.understood
+    assert_empty @user.languages.not_understood
+  end
+
+  test "responds to turbo stream by replacing the banner" do
+    sign_in_as @user
+
+    patch language_preference_url(language_code: "ja", answer: "understands"), headers: {"Accept" => "text/vnd.turbo-stream.html"}
+
+    assert_response :success
+    assert_match "language-prompt", response.body
+  end
+end

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -124,16 +124,26 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to profile_url(canonical_user)
   end
 
-  test "owner can update their spoken languages" do
+  test "owner can set language preferences via the tri-state form" do
     sign_in_as @user
 
     patch profile_url(@user), params: {
       user: {
-        spoken_languages: ["en", "ja"]
+        language_preferences: {
+          "ja" => "understands",
+          "pt" => "does_not_understand",
+          "de" => "unset"
+        }
       }
     }
 
     assert_redirected_to profile_url(@user)
-    assert_equal ["en", "ja"], @user.reload.spoken_languages
+
+    @user.reload
+
+    assert_equal ["ja"], @user.languages.understood
+    assert_equal ["pt"], @user.languages.not_understood
+    assert_not @user.language_preferences.key?("de")
+    assert_equal({"understands" => true}, @user.language_preferences["ja"])
   end
 end

--- a/test/fixtures/talks.yml
+++ b/test/fixtures/talks.yml
@@ -124,6 +124,7 @@ non_english_talk_one:
   description: Non English talk description
   slug: non-english-talk-title
   kind: "talk"
+  language: pt
   video_provider: mp4
   external_player: true
   date: "2025-05-20"

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -15,6 +15,7 @@
 #  geocode_metadata     :json             not null
 #  github_handle        :string
 #  github_metadata      :json             not null
+#  language_preferences :json             not null
 #  latitude             :decimal(10, 6)
 #  linkedin             :string           default(""), not null
 #  location             :string           default("")
@@ -28,7 +29,6 @@
 #  settings             :json             not null
 #  slug                 :string           default(""), not null, uniquely indexed
 #  speakerdeck          :string           default(""), not null
-#  spoken_languages     :json             not null
 #  state_code           :string
 #  suspicion_cleared_at :datetime
 #  suspicion_marked_at  :datetime

--- a/test/models/language_test.rb
+++ b/test/models/language_test.rb
@@ -61,7 +61,7 @@ class LanguageTest < ActiveSupport::TestCase
     talk.save
 
     assert_equal 3, Language.used.length
-    assert_equal ["en", "es", "pt"], Language.used.keys
+    assert_equal ["en", "pt", "es"], Language.used.keys
   end
 
   test "find_by_code" do

--- a/test/models/language_test.rb
+++ b/test/models/language_test.rb
@@ -53,15 +53,15 @@ class LanguageTest < ActiveSupport::TestCase
   end
 
   test "used" do
-    assert_equal 1, Language.used.length
-    assert_equal ["en"], Language.used.keys
+    assert_equal 2, Language.used.length
+    assert_equal ["en", "pt"], Language.used.keys
 
     talk = talks(:two)
     talk.language = "Spanish"
     talk.save
 
-    assert_equal 2, Language.used.length
-    assert_equal ["en", "es"], Language.used.keys
+    assert_equal 3, Language.used.length
+    assert_equal ["en", "es", "pt"], Language.used.keys
   end
 
   test "find_by_code" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -670,4 +670,65 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 2, user.event_participations.where(event: event).count
     assert_equal [event], user.participated_events.where(id: event.id).to_a
   end
+
+  test "understands? and does_not_understand? reflect the stored preferences" do
+    user = users(:one)
+    user.update!(language_preferences: {"ja" => {"understands" => true}, "pt" => {"understands" => false}})
+
+    assert user.languages.understands?("ja")
+    assert user.languages.understands?(:ja)
+    assert_not user.languages.understands?("pt")
+    assert user.languages.does_not_understand?("pt")
+    assert_not user.languages.does_not_understand?("ja")
+  end
+
+  test "set moves a code between understood and not understood" do
+    user = users(:one)
+
+    user.languages.set("ja", :understands)
+    assert_equal ["ja"], user.reload.languages.understood
+
+    user.languages.set("ja", :does_not_understand)
+    assert_equal [], user.reload.languages.understood
+    assert_equal ["ja"], user.languages.not_understood
+
+    user.languages.set("ja", :unset)
+    assert_equal [], user.reload.languages.understood
+    assert_equal [], user.languages.not_understood
+    assert_empty user.language_preferences
+  end
+
+  test "language preferences reject an invalid shape" do
+    user = users(:one)
+    user.language_preferences = {"ja" => "maybe"}
+
+    assert_not user.valid?
+    assert user.errors[:language_preferences].any?
+  end
+
+  test "pending_prompt includes English so we don't assume everyone understands it" do
+    user = users(:one)
+    english_talk = Talk.find_by(language: "en")
+    user.watched_talks.find_or_create_by!(talk: english_talk) { |wt| wt.watched = true }
+
+    assert_includes user.languages.pending_prompts, "en"
+
+    user.languages.set("en", :does_not_understand)
+    assert_not_includes user.reload.languages.pending_prompts, "en"
+  end
+
+  test "pending_prompt returns a watched language without a preference" do
+    user = users(:one)
+    talk = talks(:non_english_talk_one)
+    assert_equal "pt", talk.language
+
+    user.languages.set("en", :understands)
+    assert_nil user.reload.languages.pending_prompt
+
+    user.watched_talks.create!(talk: talk, watched: true)
+    assert_equal "pt", user.languages.pending_prompt
+
+    user.languages.set("pt", :does_not_understand)
+    assert_nil user.reload.languages.pending_prompt
+  end
 end


### PR DESCRIPTION
## Description

Let users record which languages they understand so recommendations can surface non-English talks they can actually follow.

This pull request store preferences in a single `language_preferences` JSON column, shaped as `{ "ja": { "understands": true } }` and encapsulated in a `User::Languages` associated object (nesting leaves room for a future `"speaks"` dimension without a migration)

We rename the earlier `spoken_languages` column from #1826  into `language_preferences` to account for both `understood` and `not understood` so we can remember if a user said that they don't speak a language.

Additionally, we show a site-wide "Do you understand it?" banner prompting users about languages they've watched talks in (English included since not all Rubyists are comfortable with english)

The language preferences can also be managed in the profile edit form section.

## Screenshots

<img width="2730" height="842" alt="CleanShot 2026-07-02 at 17 20 55@2x" src="https://github.com/user-attachments/assets/786fb40a-604f-460d-95b8-8e0e7c91f891" />

<img width="2676" height="852" alt="CleanShot 2026-07-02 at 17 21 04@2x" src="https://github.com/user-attachments/assets/46bafe35-3f76-4fcc-9c51-e2df29be2017" />


<img width="1304" height="752" alt="CleanShot 2026-07-02 at 16 59 45@2x" src="https://github.com/user-attachments/assets/5545f023-9c28-4c1d-a40d-be224db97001" />


## Testing Steps

* Mark talk as watched
* Banner shows up
* Click "Yes, I understand" or "No, I don't understand"
* Go to profile
* Click "Edit Profile"
* See Updated Language Preferences

## References

Follow up on #1826  and #1852 