### PR TITLE
Only show Open CFPs in event header

### DIFF
--- a/app/views/events/_header.html.erb
+++ b/app/views/events/_header.html.erb
@@ -75,21 +75,13 @@
     <%= event.description %>
   </p>
 
-  <% event.cfps.each do |cfp| %>
+  <% event.cfps.open.each do |cfp| %>
     <% if event.start_date && event.start_date > Date.today && !event.static_metadata.cancelled? %>
       <div class="mt-6 p-4 bg-gray-100 rounded-lg max-w-[700px]">
         <h3 class="font-bold text-lg mb-2"><%= cfp.name.presence || "Call for Proposals" %></h3>
 
         <p class="text-[#636B74] mb-3">
-          <% if cfp.future? %>
-            The CFP opens on <%= cfp.formatted_open_date %><% if cfp.close_date.present? %> and closes on <%= cfp.formatted_close_date %><% end %>.
-          <% elsif cfp.open? %>
-            The CFP is currently open and closes on <%= cfp.formatted_close_date %>.
-          <% elsif cfp.closed? %>
-            The CFP closed on <%= cfp.formatted_close_date %>.
-          <% else %>
-            Call for Proposals information is available.
-          <% end %>
+          The CFP is currently open and closes on <%= cfp.formatted_close_date %>.
         </p>
 
         <% if cfp.close_date.blank? || cfp.open? %>

--- a/app/views/events/_header.html.erb
+++ b/app/views/events/_header.html.erb
@@ -75,20 +75,24 @@
     <%= event.description %>
   </p>
 
-  <% event.cfps.open.each do |cfp| %>
-    <% if event.start_date && event.start_date > Date.today && !event.static_metadata.cancelled? %>
+  <% if event.start_date.present? && event.start_date.future? && !event.static_metadata.cancelled? %>
+    <% event.cfps.open.each do |cfp| %>
       <div class="mt-6 p-4 bg-gray-100 rounded-lg max-w-[700px]">
-        <h3 class="font-bold text-lg mb-2"><%= cfp.name.presence || "Call for Proposals" %></h3>
+        <h3 class="font-bold text-lg mb-2">
+          <%= cfp.name.presence || "Call for Proposals" %>
+        </h3>
 
         <p class="text-[#636B74] mb-3">
-          The CFP is currently open and closes on <%= cfp.formatted_close_date %>.
+          <% if cfp.close_date.present? %>
+            The CFP is currently open and closes on <%= cfp.formatted_close_date %>.
+          <% else %>
+            The CFP is currently open.
+          <% end %>
         </p>
 
-        <% if cfp.close_date.blank? || cfp.open? %>
-          <%= external_link_to "Submit your proposal", cfp.link, class: "btn btn-primary btn-sm" %>
-        <% else %>
-          <%= external_link_to "View CFP details", cfp.link, class: "btn btn-secondary btn-sm" %>
-        <% end %>
+        <%= external_link_to "Submit your proposal",
+              cfp.link,
+              class: "btn btn-primary btn-sm" %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/events/_header.html.erb
+++ b/app/views/events/_header.html.erb
@@ -75,25 +75,25 @@
     <%= event.description %>
   </p>
 
-  <% if event.start_date.present? && event.start_date.future? && !event.static_metadata.cancelled? %>
-    <% event.cfps.open.each do |cfp| %>
-      <div class="mt-6 p-4 bg-gray-100 rounded-lg max-w-[700px]">
-        <h3 class="font-bold text-lg mb-2">
-          <%= cfp.name.presence || "Call for Proposals" %>
-        </h3>
+  <% event.cfps.each do |cfp| %>
+    <% next unless cfp.open? %>
 
-        <p class="text-[#636B74] mb-3">
-          <% if cfp.close_date.present? %>
-            The CFP is currently open and closes on <%= cfp.formatted_close_date %>.
-          <% else %>
-            The CFP is currently open.
-          <% end %>
-        </p>
+    <div class="mt-6 p-4 bg-gray-100 rounded-lg max-w-[700px]">
+      <h3 class="font-bold text-lg mb-2">
+        <%= cfp.name.presence || "Call for Proposals" %>
+      </h3>
 
-        <%= external_link_to "Submit your proposal",
-              cfp.link,
-              class: "btn btn-primary btn-sm" %>
-      </div>
-    <% end %>
+      <p class="text-[#636B74] mb-3">
+        <% if cfp.close_date.present? %>
+          The CFP is currently open and closes on <%= cfp.formatted_close_date %>.
+        <% else %>
+          The CFP is currently open.
+        <% end %>
+      </p>
+
+      <%= external_link_to "Submit your proposal",
+            cfp.link,
+            class: "btn btn-primary btn-sm" %>
+    </div>
   <% end %>
 </div>


### PR DESCRIPTION
## Description
Added open scope in event header partial
and remove the checks for future, open and closed 

## Screenshots
<img width="1137" height="561" alt="image" src="https://github.com/user-attachments/assets/db20edac-36d0-49c8-a622-239dfbd44161" />

## Testing Steps
goto events
looks for event which had future and closed cfps visible 
with this change it will now show only open cfps

## References
Closes https://github.com/rubyevents/rubyevents/issues/1858
