### PR TITLE
Improve YouTube transcript fetching and add automated backfill

### DIFF
--- a/app/clients/youtube/transcript.rb
+++ b/app/clients/youtube/transcript.rb
@@ -1,11 +1,62 @@
 module YouTube
   class Transcript
+    Track = Data.define(:language_code, :is_generated, :translated, :snippets)
+
     def self.get(video_id, languages: ["en"])
       new.get(video_id, languages:)
     end
 
     def get(video_id, languages: ["en"])
       YoutubeRb::Transcript::YouTubeTranscriptApi.new.fetch(video_id, languages:)
+    rescue YoutubeRb::Transcript::CouldNotRetrieveTranscript
+      nil
+    end
+
+    def self.tracks(video_id, languages:)
+      new.tracks(video_id, languages:)
+    end
+
+    def tracks(video_id, languages:)
+      list = api.list(video_id)
+
+      languages.filter_map { |language| track_for(list, language) }.uniq(&:language_code)
+    rescue YoutubeRb::Transcript::CouldNotRetrieveTranscript
+      []
+    end
+
+    private
+
+    def api
+      YoutubeRb::Transcript::YouTubeTranscriptApi.new
+    end
+
+    def track_for(list, language)
+      transcript, translated = resolve(list, language)
+      return unless transcript
+
+      fetched = transcript.fetch
+
+      Track.new(
+        language_code: fetched.language_code,
+        is_generated: transcript.is_generated,
+        translated: translated,
+        snippets: fetched.snippets
+      )
+    rescue YoutubeRb::Transcript::CouldNotRetrieveTranscript
+      nil
+    end
+
+    def resolve(list, language)
+      native = native_transcript(list, language)
+      return [native, false] if native
+
+      source = list.find(&:translatable?)
+
+      source ? [source.translate(language), true] : [nil, nil]
+    end
+
+    def native_transcript(list, language)
+      list.find_transcript([language])
     rescue YoutubeRb::Transcript::CouldNotRetrieveTranscript
       nil
     end

--- a/app/helpers/talks_helper.rb
+++ b/app/helpers/talks_helper.rb
@@ -57,7 +57,14 @@ module TalksHelper
 
   def transcript_language_label(talk_transcript)
     name = Language.find(talk_transcript.language)&.english_name || talk_transcript.language.upcase
-    talk_transcript.auto_generated ? "#{name} (auto-generated)" : name
+
+    if talk_transcript.translated
+      "#{name} (auto-translated)"
+    elsif talk_transcript.auto_generated
+      "#{name} (auto-generated)"
+    else
+      name
+    end
   end
 
   def transcript_shows_hours?(cue_list)

--- a/app/jobs/recurring/transcript_backfill_job.rb
+++ b/app/jobs/recurring/transcript_backfill_job.rb
@@ -1,0 +1,13 @@
+class Recurring::TranscriptBackfillJob < ApplicationJob
+  queue_as :low
+
+  BATCH_SIZE = Integer(ENV.fetch("TRANSCRIPT_BACKFILL_BATCH_SIZE", 10))
+
+  def perform
+    return if ENV["SEED_SMOKE_TEST"]
+
+    Talk.pending_transcript.limit(BATCH_SIZE).each do |talk|
+      talk.youtube_transcript.fetch_and_store_later!
+    end
+  end
+end

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -30,6 +30,7 @@
 #  thumbnail_xl                  :string           default(""), not null
 #  thumbnail_xs                  :string           default(""), not null
 #  title                         :string           default(""), not null, indexed
+#  transcript_checked_at         :datetime
 #  video_availability_checked_at :datetime
 #  video_provider                :string           default("youtube"), not null, indexed => [date]
 #  video_unavailable_at          :datetime
@@ -123,6 +124,7 @@ class Talk < ApplicationRecord
   UNPUBLISHED_PROVIDERS = ["not_recorded", "scheduled", "not_published"]
   SUPPLEMENTARY_KINDS = ["trailer", "recap", "aftermovie"]
   NON_RECOMMENDABLE_KINDS = SUPPLEMENTARY_KINDS + ["intro", "outro", "trailer", "recap", "aftermovie"]
+  TRANSCRIPT_RECHECK_AFTER = 3.months
 
   KIND_LABELS = {
     "keynote" => "Keynote",
@@ -218,6 +220,7 @@ class Talk < ApplicationRecord
       ))
       .distinct
   }
+
   scope :with_raw_transcript, -> {
     joins(:talk_transcripts)
       .where(%(
@@ -226,6 +229,7 @@ class Talk < ApplicationRecord
       ))
       .distinct
   }
+
   scope :without_enhanced_transcript,
     -> {
       joins(:talk_transcripts)
@@ -236,6 +240,7 @@ class Talk < ApplicationRecord
         ))
         .distinct
     }
+
   scope :with_enhanced_transcript, -> {
     joins(:talk_transcripts)
       .where(%(
@@ -244,6 +249,14 @@ class Talk < ApplicationRecord
       ))
       .distinct
   }
+
+  scope :pending_transcript, -> {
+    youtube
+      .left_joins(:talk_transcripts)
+      .where(talk_transcripts: {id: nil})
+      .where("transcript_checked_at IS NULL OR transcript_checked_at < ?", TRANSCRIPT_RECHECK_AFTER.ago)
+  }
+
   scope :with_summary, -> { where("summary IS NOT NULL AND summary != ''") }
   scope :without_summary, -> { where("summary IS NULL OR summary = ''") }
   scope :with_duration, -> { where.not(duration_in_seconds: nil) }

--- a/app/models/talk/transcript.rb
+++ b/app/models/talk/transcript.rb
@@ -8,6 +8,7 @@
 #  enhanced_transcript :text
 #  language            :string           default("en"), not null, uniquely indexed => [talk_id]
 #  raw_transcript      :text
+#  translated          :boolean          default(FALSE), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  talk_id             :integer          not null, indexed, uniquely indexed => [language]

--- a/app/models/talk/youtube_transcript.rb
+++ b/app/models/talk/youtube_transcript.rb
@@ -1,5 +1,7 @@
 class Talk::YouTubeTranscript < ActiveRecord::AssociatedObject
-  performs :fetch_and_store!, retries: 3
+  performs :fetch_and_store!, retries: 3 do
+    limits_concurrency to: 1, key: "youtube_transcript"
+  end
 
   def available?
     talk.youtube? && talk.video_id.present?
@@ -14,7 +16,11 @@ class Talk::YouTubeTranscript < ActiveRecord::AssociatedObject
   def fetch_and_store!
     return unless available?
 
-    preferred_languages.each { |language| fetch_and_store_language!(language) }
+    YouTube::Transcript.tracks(talk.video_id, languages: preferred_languages).each do |track|
+      store_track(track)
+    end
+
+    talk.update_column(:transcript_checked_at, Time.current)
   end
 
   private
@@ -23,33 +29,33 @@ class Talk::YouTubeTranscript < ActiveRecord::AssociatedObject
     [talk.language, "en"].compact.uniq
   end
 
-  def fetch_and_store_language!(language)
-    youtube_transcript = YouTube::Transcript.get(talk.video_id, languages: [language])
-    return unless youtube_transcript.present?
-
-    raw = Talk::Transcript::CueList.from_youtube(youtube_transcript)
-    generated = youtube_transcript.is_generated
+  def store_track(track)
+    raw = Talk::Transcript::CueList.from_youtube(track)
     segments = talk.child_talks.where(video_provider: "parent")
 
     if segments.any?
-      segments.each { |child| store_slice(child, language, raw, generated) }
+      segments.each { |child| store_slice(child, track, raw) }
     else
-      store(talk, language, raw, generated)
+      store(talk, track, raw)
     end
   end
 
-  def store_slice(child, language, raw, generated)
+  def store_slice(child, track, raw)
     return unless child.start_seconds && child.end_seconds
 
     slice = raw.slice(child.start_seconds, child.end_seconds).presence
     return unless slice
 
-    store(child, language, slice, generated)
+    store(child, track, slice)
   end
 
-  def store(talk, language, raw, generated)
-    transcript = talk.talk_transcripts.find_or_initialize_by(language: language)
+  def store(talk, track, raw)
+    transcript = talk.talk_transcripts.find_or_initialize_by(language: track.language_code)
 
-    transcript.update!(raw_transcript: raw, auto_generated: generated)
+    transcript.update!(
+      raw_transcript: raw,
+      auto_generated: track.is_generated,
+      translated: track.translated
+    )
   end
 end

--- a/app/views/talks/_talk.html.erb
+++ b/app/views/talks/_talk.html.erb
@@ -286,10 +286,10 @@
         </article>
       </div>
 
-      <% if talk.transcript.present? %>
+      <% if talk.raw_transcript.present? %>
         <input type="radio" name="talk_tabs" role="tab" class="tab" aria-label="Transcript">
         <div role="tabpanel" class="tab-content !rounded-s-xl rounded-xl bg-base-200/50 p-6 mt-6 overflow-x-auto max-w-full">
-          <% transcripts = talk.talk_transcripts.select { |transcript| transcript.transcript.present? }.sort_by { |transcript| [(transcript.language == talk.language) ? 0 : 1, transcript.language] } %>
+          <% transcripts = talk.talk_transcripts.select { |transcript| transcript.raw_transcript.present? }.sort_by { |transcript| [(transcript.language == talk.language) ? 0 : 1, transcript.language] } %>
           <% default_language = (transcripts.any? { |transcript| transcript.language == talk.language }) ? talk.language : transcripts.first.language %>
 
           <%= tag.div data: {controller: "transcript", action: "video-player:timeupdate@window->transcript#timeUpdate"} do %>
@@ -315,7 +315,7 @@
 
             <% transcripts.each do |talk_transcript| %>
               <%= tag.div hidden: talk_transcript.language != default_language, class: "relative overflow-y-auto max-h-[32rem] pr-1", data: {language: talk_transcript.language, transcript_target: "panel", transcript_scroll: ""} do %>
-                <%= render partial: "talks/transcript", locals: {transcript: talk_transcript.transcript} %>
+                <%= render partial: "talks/transcript", locals: {transcript: talk_transcript.raw_transcript} %>
               <% end %>
             <% end %>
           <% end %>

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -22,3 +22,6 @@ clear_solid_queue_finished_jobs:
 mark_suspicious_users:
   class: Recurring::MarkSuspiciousUsersJob
   schedule: every 6 hours
+transcript_backfill_job:
+  class: Recurring::TranscriptBackfillJob
+  schedule: every 5 minutes

--- a/db/migrate/20260705120000_add_translated_to_talk_transcripts.rb
+++ b/db/migrate/20260705120000_add_translated_to_talk_transcripts.rb
@@ -1,0 +1,5 @@
+class AddTranslatedToTalkTranscripts < ActiveRecord::Migration[8.2]
+  def change
+    add_column :talk_transcripts, :translated, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20260705130000_add_transcript_checked_at_to_talks.rb
+++ b/db/migrate/20260705130000_add_transcript_checked_at_to_talks.rb
@@ -1,0 +1,5 @@
+class AddTranscriptCheckedAtToTalks < ActiveRecord::Migration[8.2]
+  def change
+    add_column :talks, :transcript_checked_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.2].define(version: 2026_07_04_120000) do
+ActiveRecord::Schema[8.2].define(version: 2026_07_05_130000) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -222,12 +222,12 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_04_120000) do
     t.string "featured_color"
     t.json "geocode_metadata", default: {}, null: false
     t.date "home_sort_date"
-    t.date "recordings_published_date"
     t.string "kind", default: "event", null: false
     t.decimal "latitude", precision: 10, scale: 6
     t.string "location"
     t.decimal "longitude", precision: 10, scale: 6
     t.string "name", default: "", null: false
+    t.date "recordings_published_date"
     t.string "slug", default: "", null: false
     t.date "start_date"
     t.string "state_code"
@@ -381,6 +381,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_04_120000) do
     t.string "language", default: "en", null: false
     t.text "raw_transcript"
     t.integer "talk_id", null: false
+    t.boolean "translated", default: false, null: false
     t.datetime "updated_at", null: false
     t.index ["talk_id", "language"], name: "index_talk_transcripts_on_talk_id_and_language", unique: true
     t.index ["talk_id"], name: "index_talk_transcripts_on_talk_id"
@@ -416,6 +417,7 @@ ActiveRecord::Schema[8.2].define(version: 2026_07_04_120000) do
     t.string "thumbnail_xl", default: "", null: false
     t.string "thumbnail_xs", default: "", null: false
     t.string "title", default: "", null: false
+    t.datetime "transcript_checked_at"
     t.datetime "updated_at", null: false
     t.datetime "video_availability_checked_at"
     t.string "video_id", default: "", null: false

--- a/test/fixtures/talk/transcripts.yml
+++ b/test/fixtures/talk/transcripts.yml
@@ -8,6 +8,7 @@
 #  enhanced_transcript :text
 #  language            :string           default("en"), not null, uniquely indexed => [talk_id]
 #  raw_transcript      :text
+#  translated          :boolean          default(FALSE), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  talk_id             :integer          not null, indexed, uniquely indexed => [language]

--- a/test/fixtures/talks.yml
+++ b/test/fixtures/talks.yml
@@ -30,6 +30,7 @@
 #  thumbnail_xl                  :string           default(""), not null
 #  thumbnail_xs                  :string           default(""), not null
 #  title                         :string           default(""), not null, indexed
+#  transcript_checked_at         :datetime
 #  video_availability_checked_at :datetime
 #  video_provider                :string           default("youtube"), not null, indexed => [date]
 #  video_unavailable_at          :datetime

--- a/test/jobs/recurring/transcript_backfill_job_test.rb
+++ b/test/jobs/recurring/transcript_backfill_job_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Recurring::TranscriptBackfillJobTest < ActiveJob::TestCase
+  test "enqueues a transcript fetch for youtube talks missing one" do
+    Talk.create!(title: "Backfill me", video_provider: "youtube", video_id: "backfill-vid", date: Date.today, static_id: "backfill-talk")
+
+    before = enqueued_jobs.size
+    Recurring::TranscriptBackfillJob.perform_now
+
+    assert_operator enqueued_jobs.size, :>, before
+  end
+
+  test "skips youtube talks checked within the recheck window" do
+    never = Talk.create!(title: "Never checked", video_provider: "youtube", video_id: "pt-never", date: Date.today, static_id: "pt-never")
+    recent = Talk.create!(title: "Checked today", video_provider: "youtube", video_id: "pt-recent", date: Date.today, static_id: "pt-recent", transcript_checked_at: Time.current)
+
+    ids = Talk.pending_transcript.ids
+
+    assert_includes ids, never.id
+    assert_not_includes ids, recent.id
+  end
+
+  test "enqueues nothing when every youtube talk already has a transcript" do
+    Talk.youtube.left_joins(:talk_transcripts).where(talk_transcripts: {id: nil}).find_each do |talk|
+      talk.talk_transcripts.create!(language: "en", raw_transcript: Talk::Transcript::CueList.new(cues: []))
+    end
+
+    assert_no_enqueued_jobs do
+      Recurring::TranscriptBackfillJob.perform_now
+    end
+  end
+end

--- a/test/models/talk/youtube_transcript_test.rb
+++ b/test/models/talk/youtube_transcript_test.rb
@@ -13,18 +13,6 @@ class Talk::YouTubeTranscriptTest < ActiveSupport::TestCase
     assert_nil Talk.new(video_provider: "vimeo", video_id: "123").youtube_transcript.fetch
   end
 
-  test "fetch_and_store! stores the fetched transcript" do
-    talk = Talk.create!(title: "T", video_provider: "youtube", video_id: "9LfmrkyP81M", date: Date.today, static_id: "yt-transcript-store")
-
-    VCR.use_cassette("youtube_video_transcript", match_requests_on: [:method]) do
-      talk.youtube_transcript.fetch_and_store!
-    end
-
-    assert talk.reload.talk_transcript.raw_transcript.present?
-    assert talk.transcript.cues.first.is_a?(Talk::Transcript::Cue)
-    assert_includes [true, false], talk.talk_transcript.auto_generated
-  end
-
   test "fetch requests the talk's language with an English fallback" do
     talk = Talk.new(video_provider: "youtube", video_id: "abc12345678", language: "ja")
     captured = nil
@@ -34,6 +22,18 @@ class Talk::YouTubeTranscriptTest < ActiveSupport::TestCase
     end
 
     assert_equal ["ja", "en"], captured
+  end
+
+  test "fetch_and_store! stores the fetched transcript" do
+    talk = Talk.create!(title: "T", video_provider: "youtube", video_id: "yt-store", date: Date.today, static_id: "yt-transcript-store")
+
+    YouTube::Transcript.stub(:tracks, [track([["hello world", 0, 5]], is_generated: true)]) do
+      talk.youtube_transcript.fetch_and_store!
+    end
+
+    assert talk.reload.talk_transcript.raw_transcript.present?
+    assert talk.transcript.cues.first.is_a?(Talk::Transcript::Cue)
+    assert_equal true, talk.talk_transcript.auto_generated
   end
 
   test "fetch_and_store! is a no-op for non-youtube videos" do
@@ -49,7 +49,7 @@ class Talk::YouTubeTranscriptTest < ActiveSupport::TestCase
     segment = Talk.create!(title: "A", video_provider: "parent", video_id: "lt-a", parent_talk: parent, start_seconds: 0, end_seconds: 100, date: Date.today, static_id: "lt-a")
     own_video_child = Talk.create!(title: "B", video_provider: "youtube", video_id: "lt-own", parent_talk: parent, date: Date.today, static_id: "lt-own")
 
-    YouTube::Transcript.stub(:get, fetched([["first talk", 30, 5]])) do
+    YouTube::Transcript.stub(:tracks, [track([["first talk", 30, 5]])]) do
       parent.youtube_transcript.fetch_and_store!
     end
 
@@ -62,22 +62,22 @@ class Talk::YouTubeTranscriptTest < ActiveSupport::TestCase
     parent = Talk.create!(title: "Lightning Talks", video_provider: "youtube", video_id: "lt-parent2", date: Date.today, static_id: "lt-parent2")
     segment = Talk.create!(title: "A", video_provider: "parent", video_id: "lt-a2", parent_talk: parent, start_seconds: 500, end_seconds: 600, date: Date.today, static_id: "lt-a2")
 
-    YouTube::Transcript.stub(:get, fetched([["intro", 30, 5]])) do
+    YouTube::Transcript.stub(:tracks, [track([["intro", 30, 5]])]) do
       parent.youtube_transcript.fetch_and_store!
     end
 
     assert_nil segment.reload.talk_transcript
   end
 
-  test "fetch_and_store! stores one transcript row per preferred language" do
+  test "fetch_and_store! stores one transcript row per returned language" do
     talk = Talk.create!(title: "Keynote", video_provider: "youtube", video_id: "ml-vid", date: Date.today, static_id: "ml-talk", language: "ja")
 
-    by_language = {
-      ["ja"] => fetched([["こんにちは", 0, 5]], is_generated: true),
-      ["en"] => fetched([["hello", 0, 5]], is_generated: false)
-    }
+    tracks = [
+      track([["こんにちは", 0, 5]], language_code: "ja", is_generated: true),
+      track([["hello", 0, 5]], language_code: "en", is_generated: false)
+    ]
 
-    YouTube::Transcript.stub(:get, ->(_video_id, languages:) { by_language[languages] }) do
+    YouTube::Transcript.stub(:tracks, tracks) do
       talk.youtube_transcript.fetch_and_store!
     end
 
@@ -86,18 +86,47 @@ class Talk::YouTubeTranscriptTest < ActiveSupport::TestCase
     assert_equal ["en", "ja"], talk.transcript_languages.sort
     assert_equal "こんにちは", talk.transcript(language: "ja").cues.first.text
     assert_equal "hello", talk.transcript(language: "en").cues.first.text
-    assert_equal true, talk.talk_transcript(language: "ja").auto_generated
-    assert_equal false, talk.talk_transcript(language: "en").auto_generated
+  end
+
+  test "fetch_and_store! flags auto-translated tracks and labels by the returned language" do
+    talk = Talk.create!(title: "JP Talk", video_provider: "youtube", video_id: "jp-vid", date: Date.today, static_id: "jp-talk", language: "ja")
+
+    tracks = [
+      track([["こんにちは", 0, 5]], language_code: "ja", is_generated: true, translated: false),
+      track([["hello", 0, 5]], language_code: "en", is_generated: true, translated: true)
+    ]
+
+    YouTube::Transcript.stub(:tracks, tracks) do
+      talk.youtube_transcript.fetch_and_store!
+    end
+
+    talk.reload
+
+    assert_equal false, talk.talk_transcript(language: "ja").translated
+    assert_equal true, talk.talk_transcript(language: "en").translated
+  end
+
+  test "fetch_and_store! records transcript_checked_at even when nothing is found" do
+    talk = Talk.create!(title: "No captions", video_provider: "youtube", video_id: "no-cap", date: Date.today, static_id: "no-cap-talk")
+
+    YouTube::Transcript.stub(:tracks, []) do
+      talk.youtube_transcript.fetch_and_store!
+    end
+
+    assert_nil talk.talk_transcript
+    assert_not_nil talk.reload.transcript_checked_at
   end
 
   private
 
-  def fetched(snippets, is_generated: false)
+  def track(snippets, language_code: "en", is_generated: false, translated: false)
     snippet = Struct.new(:text, :start, :duration)
 
-    Struct.new(:snippets, :is_generated).new(
-      snippets.map { |text, start, duration| snippet.new(text, start, duration) },
-      is_generated
+    YouTube::Transcript::Track.new(
+      language_code: language_code,
+      is_generated: is_generated,
+      translated: translated,
+      snippets: snippets.map { |text, start, duration| snippet.new(text, start, duration) }
     )
   end
 end


### PR DESCRIPTION
### Improve YouTube transcript fetching + backfill

The new synced-transcript UI surfaced a few correctness and quality problems in how we fetch and store transcripts. This pull request fixes language resolution, adds an automated backfill, and switches the UI to the faithful source.

### Correct language resolution

When we request a language, we now resolve a native track first and only fall back to an auto-translation when no native track exists, and we label each stored transcript by the language YouTube actually returned (`language_code`), not the one we asked for. 

Previously a request for Japanese could come back as an English translation and get mislabeled `ja`. A new `translated` flag marks machine-translated tracks so the UI can show `"auto-translated"` and we can prefer native tracks.

### Automated, throttled backfill

`Recurring::TranscriptBackfillJob` enqueues a small batch of fetches every few minutes, and the fetch job is concurrency-limited to 1 so requests are serialized. A new `transcript_checked_at` timestamp and `Talk.pending_transcript` scope record every attempt (including empty ones), so caption-less videos aren't retried forever and the backfill converges instead of running indefinitely.
