### PR TITLE
Add Google Slides embed support for talk slides

### DIFF
--- a/app/helpers/talks_helper.rb
+++ b/app/helpers/talks_helper.rb
@@ -55,6 +55,31 @@ module TalksHelper
     resource["url"]
   end
 
+  def slides_external_link(slides_url)
+    host = URI(slides_url).host
+    link_to "See Slides on #{host}", sanitize_url(slides_url), target: "_blank", class: "btn btn-primary mt-6"
+  rescue URI::InvalidURIError
+    nil
+  end
+
+  def google_slides_embed_url(slides_url)
+    return nil if slides_url.blank?
+
+    uri = URI(slides_url)
+    return nil unless uri.host == "docs.google.com"
+    return nil unless uri.path.start_with?("/presentation/")
+
+    parts = uri.path.split("/").reject(&:empty?)
+    if %w[edit view pub embed].include?(parts.last)
+      parts[-1] = "embed"
+    else
+      parts << "embed"
+    end
+    "https://docs.google.com/#{parts.join("/")}"
+  rescue URI::InvalidURIError
+    nil
+  end
+
   def transcript_language_label(talk_transcript)
     name = Language.find(talk_transcript.language)&.english_name || talk_transcript.language.upcase
 

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -73,6 +73,9 @@ application.register("scroll", ScrollController)
 import ScrollIntoViewController from "./scroll_into_view_controller"
 application.register("scroll-into-view", ScrollIntoViewController)
 
+import SlidesEmbedController from "./slides_embed_controller"
+application.register("slides-embed", SlidesEmbedController)
+
 import SplideController from "./splide_controller"
 application.register("splide", SplideController)
 

--- a/app/javascript/controllers/slides_embed_controller.js
+++ b/app/javascript/controllers/slides_embed_controller.js
@@ -1,0 +1,24 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class extends Controller {
+  static targets = ['iframe', 'loading']
+
+  connect () {
+    this.fallbackTimeout = setTimeout(() => this.onTimeout(), 15000)
+  }
+
+  disconnect () {
+    clearTimeout(this.fallbackTimeout)
+  }
+
+  loaded () {
+    clearTimeout(this.fallbackTimeout)
+    this.loadingTarget.hidden = true
+    this.iframeTarget.hidden = false
+  }
+
+  onTimeout () {
+    this.loadingTarget.hidden = true
+    this.iframeTarget.hidden = true
+  }
+}

--- a/app/views/talks/slides/show.html.erb
+++ b/app/views/talks/slides/show.html.erb
@@ -13,9 +13,35 @@
         <div class="responsive-iframe-container">
           <%= sanitize oembed_json.dig("html"), tags: ["iframe"], attributes: ["id", "class", "src", "width", "height", "style", "frameborder", "allowtransparency", "allowfullscreen"] %>
         </div>
+
+        <%= slides_external_link(@talk.slides_url) %>
+
+      <% elsif (embed_url = google_slides_embed_url(@talk.slides_url)) %>
+        <div data-controller="slides-embed">
+          <div data-slides-embed-target="loading"
+               class="w-full rounded bg-base-300 animate-pulse aspect-video">
+          </div>
+
+          <div class="responsive-iframe-container">
+            <iframe src="<%= embed_url %>"
+                    title="<%= @talk.title %>"
+                    frameborder="0"
+                    hidden
+                    data-slides-embed-target="iframe"
+                    data-action="load->slides-embed#loaded"
+                    allowfullscreen
+                    mozallowfullscreen
+                    webkitallowfullscreen
+                    class="aspect-video">
+            </iframe>
+          </div>
+
+          <%= slides_external_link(@talk.slides_url) %>
+        </div>
+
+      <% else %>
+        <%= slides_external_link(@talk.slides_url) %>
       <% end %>
     <% end %>
-
-    <a class="btn btn-primary mt-6" href="<%= sanitize(@talk.slides_url) %>" target="_blank">See Slides on <%= uri.host %></a>
   <% end %>
 <% end %>

--- a/test/helpers/talks_helper_test.rb
+++ b/test/helpers/talks_helper_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TalksHelperTest < ActionView::TestCase
+  test "google_slides_embed_url converts edit URL to embed URL" do
+    url = "https://docs.google.com/presentation/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/edit"
+    assert_equal "https://docs.google.com/presentation/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/embed",
+      google_slides_embed_url(url)
+  end
+
+  test "google_slides_embed_url converts view URL to embed URL" do
+    url = "https://docs.google.com/presentation/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/view"
+    assert_equal "https://docs.google.com/presentation/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/embed",
+      google_slides_embed_url(url)
+  end
+
+  test "google_slides_embed_url converts published URL to embed URL" do
+    url = "https://docs.google.com/presentation/d/e/2PACX-1vSomePublishedId/pub"
+    assert_equal "https://docs.google.com/presentation/d/e/2PACX-1vSomePublishedId/embed",
+      google_slides_embed_url(url)
+  end
+
+  test "google_slides_embed_url handles bare presentation ID without action segment" do
+    url = "https://docs.google.com/presentation/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms"
+    assert_equal "https://docs.google.com/presentation/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/embed",
+      google_slides_embed_url(url)
+  end
+
+  test "google_slides_embed_url is idempotent on already-embed URL" do
+    url = "https://docs.google.com/presentation/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/embed"
+    assert_equal url, google_slides_embed_url(url)
+  end
+
+  test "google_slides_embed_url strips query string" do
+    url = "https://docs.google.com/presentation/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/edit?usp=sharing"
+    assert_equal "https://docs.google.com/presentation/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/embed",
+      google_slides_embed_url(url)
+  end
+
+  test "google_slides_embed_url strips URL fragment" do
+    url = "https://docs.google.com/presentation/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/edit#slide=id.p"
+    assert_equal "https://docs.google.com/presentation/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/embed",
+      google_slides_embed_url(url)
+  end
+
+  test "google_slides_embed_url returns nil for nil input" do
+    assert_nil google_slides_embed_url(nil)
+  end
+
+  test "google_slides_embed_url returns nil for non-Google URLs" do
+    assert_nil google_slides_embed_url("https://speakerdeck.com/someone/talk")
+  end
+
+  test "google_slides_embed_url returns nil for other Google Docs types" do
+    assert_nil google_slides_embed_url("https://docs.google.com/document/d/someDocId/edit")
+  end
+
+  test "google_slides_embed_url returns nil for invalid URLs" do
+    assert_nil google_slides_embed_url("not a url")
+  end
+end


### PR DESCRIPTION
## Description

Google Slides embed support for the talk slides page, matching the existing SpeakerDeck pattern.

`google_slides_embed_url` normalizes any Google Slides URL (edit, view, pub, bare ID) to the `/embed` form. Non-Google Slides URLs return nil, leaving the plain-link fallback untouched.

The new `slides-embed` Stimulus controller shows a daisyUI skeleton while the iframe loads. When the `load` event fires, the skeleton hides and the iframe appears. If `load` never fires within 15 seconds, both hide and the fallback button stays visible.

`slides_external_link` was extracted from the view to avoid repeating the anchor tag across all three branches (SpeakerDeck, Google Slides, fallback).

## Screenshots

<img width="1146" height="898" title="Demo for /talks/rubyists-can-make-games-too" alt="Demo for /talks/rubyists-can-make-games-too" src="https://github.com/user-attachments/assets/361a6d43-31c9-4512-94bf-7663c550c95a" />

## Testing steps

1. Navigate to a talk with a Google Slides URL as slides_url and click the Slides tab.
2. Verify the skeleton shows briefly, then the iframe appears.
3. To test the timeout: temporarily set an invalid Google Slides URL. The skeleton should hide after 15 seconds and leave only the button.


## References

- Closes #1856 