### PR TITLE
Index Transcripts and make them searchable

### DIFF
--- a/app/controllers/spotlight/transcripts_controller.rb
+++ b/app/controllers/spotlight/transcripts_controller.rb
@@ -1,0 +1,32 @@
+class Spotlight::TranscriptsController < ApplicationController
+  include SpotlightSearch
+
+  LIMIT = 5
+
+  disable_analytics
+  skip_before_action :authenticate_user!
+
+  def index
+    @groups, @total_count = if search_query.present?
+      search_backend_class.search_transcript_passages(search_query, limit: LIMIT)
+    else
+      [[], nil]
+    end
+
+    respond_to do |format|
+      format.turbo_stream do
+        response.headers["X-Search-Backend"] = search_backend.to_s if Rails.env.development? && search_backend
+      end
+    end
+  end
+
+  private
+
+  helper_method :search_query
+  def search_query
+    params[:s]
+  end
+
+  helper_method :total_count
+  attr_reader :total_count
+end

--- a/app/controllers/transcript_searches_controller.rb
+++ b/app/controllers/transcript_searches_controller.rb
@@ -1,0 +1,28 @@
+class TranscriptSearchesController < ApplicationController
+  include SpotlightSearch
+
+  PER_PAGE = 20
+
+  skip_before_action :authenticate_user!
+
+  def index
+    @page = [params[:page].to_i, 1].max
+
+    @groups, @total_talks, @total_moments = if search_query.present?
+      search_backend_class.search_transcript_passages(search_query, limit: PER_PAGE, page: @page)
+    else
+      [[], 0, 0]
+    end
+
+    @total_talks = @total_talks.to_i
+    @total_moments = @total_moments.to_i
+    @pagy = Pagy.new(count: @total_talks, page: @page, limit: PER_PAGE) if @total_talks.positive?
+  end
+
+  private
+
+  helper_method :search_query
+  def search_query
+    params[:q].to_s.presence
+  end
+end

--- a/app/helpers/talks_helper.rb
+++ b/app/helpers/talks_helper.rb
@@ -55,6 +55,12 @@ module TalksHelper
     resource["url"]
   end
 
+  def talk_transcript_snippet(talk)
+    highlight = talk.highlight_result&.find { |result| result["field"] == "transcript_text" }
+
+    highlight && highlight["snippet"]
+  end
+
   def slides_external_link(slides_url)
     host = URI(slides_url).host
     link_to "See Slides on #{host}", sanitize_url(slides_url), target: "_blank", class: "btn btn-primary mt-6"

--- a/app/javascript/controllers/spotlight_search_controller.js
+++ b/app/javascript/controllers/spotlight_search_controller.js
@@ -7,7 +7,7 @@ import { get } from '@rails/request.js'
 export default class extends Controller {
   static targets = ['searchInput', 'form', 'searchResults', 'talksSearchResults',
     'speakersSearchResults', 'eventsSearchResults', 'topicsSearchResults', 'seriesSearchResults',
-    'organizationsSearchResults', 'locationsSearchResults', 'languagesSearchResults', 'kindsSearchResults', 'allSearchResults', 'searchQuery', 'loading', 'clear', 'searchBackendBadge', 'backendToggle', 'sqliteBadge', 'typesenseBadge']
+    'organizationsSearchResults', 'locationsSearchResults', 'languagesSearchResults', 'kindsSearchResults', 'transcriptsSearchResults', 'allSearchResults', 'searchQuery', 'loading', 'clear', 'searchBackendBadge', 'backendToggle', 'sqliteBadge', 'typesenseBadge']
 
   static debounces = ['search']
   static values = {
@@ -20,6 +20,7 @@ export default class extends Controller {
     urlSpotlightLocations: String,
     urlSpotlightLanguages: String,
     urlSpotlightKinds: String,
+    urlSpotlightTranscripts: String,
     mainResourcePath: String,
     defaultBackend: String
   }
@@ -143,6 +144,15 @@ export default class extends Controller {
       }
       this.kindsAbortController = new AbortController()
       searchPromises.push(this.#handleSearch(this.urlSpotlightKindsValue, query, this.kindsAbortController))
+    }
+
+    if (this.hasUrlSpotlightTranscriptsValue) {
+      if (this.transcriptsAbortController) {
+        this.transcriptsAbortController.abort()
+      }
+
+      this.transcriptsAbortController = new AbortController()
+      searchPromises.push(this.#handleSearch(this.urlSpotlightTranscriptsValue, query, this.transcriptsAbortController))
     }
 
     try {
@@ -299,6 +309,10 @@ export default class extends Controller {
       this.kindsAbortController.abort()
     }
 
+    if (this.transcriptsAbortController) {
+      this.transcriptsAbortController.abort()
+    }
+
     this.talksSearchResultsTarget.innerHTML = ''
     this.speakersSearchResultsTarget.innerHTML = ''
     this.eventsSearchResultsTarget.innerHTML = ''
@@ -331,6 +345,11 @@ export default class extends Controller {
     if (this.hasKindsSearchResultsTarget) {
       this.kindsSearchResultsTarget.innerHTML = ''
       this.kindsSearchResultsTarget.classList.add('hidden')
+    }
+
+    if (this.hasTranscriptsSearchResultsTarget) {
+      this.transcriptsSearchResultsTarget.innerHTML = ''
+      this.transcriptsSearchResultsTarget.classList.add('hidden')
     }
 
     this.allSearchResultsTarget.classList.add('hidden')

--- a/app/javascript/controllers/transcript_controller.js
+++ b/app/javascript/controllers/transcript_controller.js
@@ -6,6 +6,25 @@ export default class extends Controller {
   connect () {
     this.live = true
     this.currentCue = null
+    this.#openTabIfDeepLinked()
+  }
+
+  #openTabIfDeepLinked () {
+    const params = new URLSearchParams(window.location.search)
+    if (!params.has('t')) return
+
+    const tab = this.element.closest('[role="tabpanel"]')?.previousElementSibling
+
+    if (tab?.matches('input[type="radio"][role="tab"]')) {
+      tab.checked = true
+    }
+
+    const time = Number(params.get('t'))
+    if (Number.isNaN(time)) return
+
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      this.#activateCue(this.#cueAt(time), true)
+    }))
   }
 
   selectLanguage (event) {
@@ -52,6 +71,10 @@ export default class extends Controller {
     const time = event.detail.time
     if (time == null) return
 
+    this.#activateCue(this.#cueAt(time))
+  }
+
+  #cueAt (time) {
     let current = null
 
     for (const cue of this.visibleCues()) {
@@ -59,14 +82,18 @@ export default class extends Controller {
       else break
     }
 
-    if (current === this.currentCue) return
+    return current
+  }
+
+  #activateCue (cue, forceScroll = false) {
+    if (cue === this.currentCue) return
 
     this.clearHighlight()
-    this.currentCue = current
+    this.currentCue = cue
 
-    if (current) {
-      current.classList.add('bg-base-300', 'font-bold')
-      if (this.live) this.scrollToCue(current)
+    if (cue) {
+      cue.classList.add('bg-base-300', 'font-bold')
+      if (this.live || forceScroll) this.scrollToCue(cue)
     }
   }
 

--- a/app/javascript/controllers/video_player_controller.js
+++ b/app/javascript/controllers/video_player_controller.js
@@ -22,7 +22,7 @@ export default class extends Controller {
     watched: { default: false, type: Boolean }
   }
 
-  static targets = ['player', 'playerWrapper', 'watchedOverlay', 'resumeOverlay', 'playOverlay']
+  static targets = ['player', 'playerWrapper', 'watchedOverlay', 'resumeOverlay', 'playOverlay', 'playLabel']
   playbackRateOptions = [1, 1.25, 1.5, 1.75, 2]
 
   initialize () {
@@ -31,6 +31,28 @@ export default class extends Controller {
 
   connect () {
     this.init()
+    this.#showDeepLinkOnPlayButton()
+  }
+
+  #showDeepLinkOnPlayButton () {
+    if (!this.hasPlayLabelTarget) return
+
+    const value = new URLSearchParams(window.location.search).get('t')
+    if (!value) return
+
+    const seconds = Number(value)
+    if (Number.isNaN(seconds)) return
+
+    this.playLabelTarget.textContent = `Play from ${this.#formatTimestamp(seconds)}`
+  }
+
+  #formatTimestamp (totalSeconds) {
+    const seconds = Math.floor(totalSeconds)
+    const secs = String(seconds % 60).padStart(2, '0')
+    const mins = Math.floor(seconds / 60) % 60
+    const hours = Math.floor(seconds / 3600)
+
+    return hours > 0 ? `${hours}:${String(mins).padStart(2, '0')}:${secs}` : `${String(mins).padStart(2, '0')}:${secs}`
   }
 
   // methods
@@ -186,6 +208,12 @@ export default class extends Controller {
     if (this.pendingSeek != null) {
       this.player.seekTo(this.pendingSeek)
       this.pendingSeek = null
+    }
+
+    const urlTimestamp = new URLSearchParams(window.location.search).get('t')
+
+    if (urlTimestamp) {
+      this.player.seekTo(Number(urlTimestamp))
     }
 
     if (this.autoplay) {

--- a/app/models/search/backend/sqlite_fts.rb
+++ b/app/models/search/backend/sqlite_fts.rb
@@ -150,6 +150,10 @@ class Search::Backend::SQLiteFTS
       [[], 0]
     end
 
+    def search_transcript_passages(query, limit:, page: 1)
+      [[], 0, 0]
+    end
+
     def available?
       true
     end

--- a/app/models/search/backend/typesense.rb
+++ b/app/models/search/backend/typesense.rb
@@ -88,6 +88,12 @@ class Search::Backend::Typesense
       end
     end
 
+    def search_transcript_passages(query, limit:, page: 1)
+      perform_search(:transcript_passage, query) do
+        TranscriptPassageIndexer.search(query, limit: limit, page: page)
+      end
+    end
+
     def available?
       return false if Rails.env.test?
 

--- a/app/models/search/backend/typesense/indexer.rb
+++ b/app/models/search/backend/typesense/indexer.rb
@@ -33,6 +33,7 @@ class Search::Backend::Typesense
         reindex_languages
         reindex_locations
         reindex_kinds
+        reindex_transcript_passages
       end
 
       def reindex_talks
@@ -69,6 +70,10 @@ class Search::Backend::Typesense
 
       def reindex_kinds
         KindIndexer.reindex_all
+      end
+
+      def reindex_transcript_passages
+        TranscriptPassageIndexer.reindex_all
       end
 
       private

--- a/app/models/search/backend/typesense/transcript_passage_indexer.rb
+++ b/app/models/search/backend/typesense/transcript_passage_indexer.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+class Search::Backend::Typesense
+  class TranscriptPassageIndexer
+    COLLECTION_NAME = "transcript_passages"
+    IMPORT_BATCH_SIZE = 500
+
+    class << self
+      def collection_schema
+        {
+          "name" => COLLECTION_NAME,
+          "fields" => [
+            {"name" => "talk_id", "type" => "string", "facet" => true},
+            {"name" => "talk_slug", "type" => "string"},
+            {"name" => "talk_title", "type" => "string"},
+            {"name" => "speaker_names", "type" => "string", "optional" => true},
+            {"name" => "event_name", "type" => "string", "optional" => true},
+            {"name" => "thumbnail", "type" => "string", "optional" => true},
+            {"name" => "language", "type" => "string", "facet" => true},
+            {"name" => "start_seconds", "type" => "int32"},
+            {"name" => "end_seconds", "type" => "int32"},
+            {"name" => "text", "type" => "string"},
+            {"name" => "watchable", "type" => "bool", "facet" => true},
+            {"name" => "date_timestamp", "type" => "int64"}
+          ],
+          "default_sorting_field" => "date_timestamp",
+          "token_separators" => ["-", "_"]
+        }
+      end
+
+      def client
+        ::Typesense::Client.new(::Typesense.configuration)
+      end
+
+      def collection
+        client.collections[COLLECTION_NAME]
+      end
+
+      def ensure_collection!
+        collection.retrieve
+      rescue ::Typesense::Error::ObjectNotFound
+        client.collections.create(collection_schema)
+      end
+
+      def drop_collection!
+        collection.delete
+      rescue ::Typesense::Error::ObjectNotFound
+        # Collection doesn't exist, nothing to delete
+      end
+
+      def reindex_all
+        drop_collection!
+        ensure_collection!
+
+        count = 0
+        Talk.watchable.includes(:talk_transcripts, :speakers, event: :series).find_each.each_slice(IMPORT_BATCH_SIZE) do |talks|
+          documents = talks.flat_map { |talk| build_documents(talk) }
+          next if documents.empty?
+
+          collection.documents.import(documents, action: "upsert")
+          count += documents.size
+        end
+
+        Rails.logger.info "Typesense: Indexed #{count} transcript passages"
+        count
+      end
+
+      def index_talk(talk)
+        ensure_collection!
+        remove_talk(talk)
+
+        documents = build_documents(talk)
+        collection.documents.import(documents, action: "upsert") if documents.any?
+      end
+
+      def remove_talk(talk)
+        ensure_collection!
+        collection.documents.delete(filter_by: "talk_id:=#{talk.id}")
+      rescue ::Typesense::Error::ObjectNotFound
+        # Nothing indexed for this talk
+      end
+
+      def search(query, limit: 5, page: 1, moments_per_talk: 3)
+        return [[], 0, 0] if query.blank?
+
+        ensure_collection!
+
+        result = collection.documents.search(
+          q: query,
+          query_by: "text",
+          filter_by: "watchable:=true",
+          group_by: "talk_id",
+          group_limit: moments_per_talk,
+          per_page: limit,
+          page: page,
+          highlight_full_fields: "text",
+          highlight_affix_num_tokens: 8,
+          sort_by: "_text_match:desc"
+        )
+
+        groups = result["grouped_hits"].to_a.map { |group| build_group(group) }
+
+        [groups, result["found"], result["found_docs"]]
+      end
+
+      private
+
+      def build_documents(talk)
+        watchable = talk.published? || false
+        date_timestamp = talk.date&.to_time&.to_i || 0
+        speaker_names = talk.speakers.map(&:name).join(", ")
+
+        talk.talk_transcripts.flat_map do |transcript|
+          next [] unless transcript.raw_transcript&.present?
+
+          transcript.raw_transcript.passages.map do |passage|
+            {
+              id: "#{talk.id}-#{transcript.language}-#{passage.start_seconds}",
+              talk_id: talk.id.to_s,
+              talk_slug: talk.slug,
+              talk_title: talk.title,
+              speaker_names: speaker_names,
+              event_name: talk.event&.name.to_s,
+              thumbnail: talk.thumbnail_sm.to_s,
+              language: transcript.language,
+              start_seconds: passage.start_seconds,
+              end_seconds: passage.end_seconds,
+              text: passage.text,
+              watchable: watchable,
+              date_timestamp: date_timestamp
+            }
+          end
+        end
+      end
+
+      def build_group(group)
+        hits = group["hits"]
+        talk = hits.first["document"]
+
+        {
+          talk_id: talk["talk_id"],
+          talk_slug: talk["talk_slug"],
+          talk_title: talk["talk_title"],
+          speaker_names: talk["speaker_names"],
+          event_name: talk["event_name"],
+          thumbnail: talk["thumbnail"],
+          moments: hits.map { |hit| build_moment(hit) }.sort_by { |moment| moment[:start_seconds] }
+        }
+      end
+
+      def build_moment(hit)
+        document = hit["document"]
+        highlight = hit["highlights"].to_a.find { |entry| entry["field"] == "text" }
+
+        {
+          start_seconds: match_timestamp(document, highlight),
+          language: document["language"],
+          snippet: highlight&.dig("snippet") || document["text"]
+        }
+      end
+
+      def match_timestamp(document, highlight)
+        from = document["start_seconds"].to_i
+        full = highlight&.dig("value")
+        return from if full.blank?
+
+        words = full.split
+        index = words.index { |word| word.include?("<mark>") }
+        return from if index.nil? || words.empty?
+
+        to = document["end_seconds"].to_i
+
+        (from + (to - from) * (index.to_f / words.size)).round
+      end
+    end
+  end
+end

--- a/app/models/search/backend/typesense/transcript_passage_indexer.rb
+++ b/app/models/search/backend/typesense/transcript_passage_indexer.rb
@@ -95,7 +95,7 @@ class Search::Backend::Typesense
           page: page,
           highlight_full_fields: "text",
           highlight_affix_num_tokens: 8,
-          sort_by: "_text_match:desc"
+          sort_by: "_text_match:desc,date_timestamp:desc"
         )
 
         groups = result["grouped_hits"].to_a.map { |group| build_group(group) }

--- a/app/models/talk/transcript/cue.rb
+++ b/app/models/talk/transcript/cue.rb
@@ -23,6 +23,10 @@ class Talk::Transcript::Cue
     time_string_to_seconds(start_time)
   end
 
+  def end_time_in_seconds
+    time_string_to_seconds(end_time)
+  end
+
   def time_string_to_seconds(time_string)
     parts = time_string.split(":").map(&:to_f)
     hours = parts[0] * 3600

--- a/app/models/talk/transcript/cue_list.rb
+++ b/app/models/talk/transcript/cue_list.rb
@@ -1,6 +1,8 @@
 class Talk::Transcript::CueList < Data.define(:cues)
   include Enumerable
 
+  Passage = Data.define(:start_seconds, :end_seconds, :text)
+
   def to_text
     cues.map(&:text).join("\n\n")
   end
@@ -32,6 +34,32 @@ class Talk::Transcript::CueList < Data.define(:cues)
     self.class.new(cues: cues.select { |cue| cue.start_time_in_seconds.between?(from_seconds, to_seconds) })
   end
 
+  def deduplicated
+    self.class.new(cues: self.class.deduplicate_cues(cues))
+  end
+
+  def passages(window: 45)
+    groups = []
+
+    cues.each do |cue|
+      next if cue.text.blank?
+
+      if groups.empty? || (cue.start_time_in_seconds - groups.last.first.start_time_in_seconds) >= window
+        groups << [cue]
+      else
+        groups.last << cue
+      end
+    end
+
+    groups.map do |group|
+      Passage.new(
+        start_seconds: group.first.start_time_in_seconds,
+        end_seconds: group.last.end_time_in_seconds,
+        text: group.map(&:text).join(" ").squish
+      )
+    end
+  end
+
   class << self
     def from_youtube(youtube_transcript)
       cues = Array.wrap(youtube_transcript.snippets).map do |snippet|
@@ -42,7 +70,26 @@ class Talk::Transcript::CueList < Data.define(:cues)
         )
       end
 
-      new(cues:)
+      new(cues: deduplicate_cues(cues))
+    end
+
+    def deduplicate_cues(cues)
+      cues.each_with_object([]) do |cue, result|
+        text = result.empty? ? cue.text.to_s.strip : strip_overlap(result.last.text, cue.text)
+        next if text.blank?
+
+        result << Talk::Transcript::Cue.new(start_time: cue.start_time, end_time: cue.end_time, text: text)
+      end
+    end
+
+    def strip_overlap(previous, current)
+      previous_words = previous.to_s.split
+      current_words = current.to_s.split
+      limit = [previous_words.size, current_words.size].min
+
+      overlap = limit.downto(1).find { |n| previous_words.last(n) == current_words.first(n) } || 0
+
+      current_words.drop(overlap).join(" ")
     end
 
     def from_json(json)

--- a/app/views/shared/_spotlight_search.html.erb
+++ b/app/views/shared/_spotlight_search.html.erb
@@ -12,6 +12,7 @@
     data-spotlight-search-url-spotlight-locations-value="<%= spotlight_can_search_locations? ? spotlight_locations_path : nil %>"
     data-spotlight-search-url-spotlight-languages-value="<%= spotlight_can_search_languages? ? spotlight_languages_path : nil %>"
     data-spotlight-search-url-spotlight-kinds-value="<%= spotlight_kinds_path %>"
+    data-spotlight-search-url-spotlight-transcripts-value="<%= spotlight_transcripts_path %>"
     data-spotlight-search-main-resource-path-value="<%= spotlight_main_resource_path %>"
     data-spotlight-search-default-backend-value="<%= Search::Backend.default_backend_key %>">
     <div class="flex items-center gap-2 rounded-lg bg-white px-2 relative shrink-0">
@@ -127,6 +128,11 @@
         id="organizations_search_results"
         class="py-4 border-t hidden"
         data-spotlight-search-target="organizationsSearchResults"></div>
+
+      <div
+        id="transcripts_search_results"
+        class="py-4 border-t hidden"
+        data-spotlight-search-target="transcriptsSearchResults"></div>
     </div>
   </div>
 <% end %>

--- a/app/views/spotlight/transcripts/index.turbo_stream.erb
+++ b/app/views/spotlight/transcripts/index.turbo_stream.erb
@@ -1,0 +1,51 @@
+<%= turbo_stream.replace "transcripts_search_results" do %>
+  <div
+    id="transcripts_search_results"
+    class="<%= @groups.any? ? "py-4 border-t" : "hidden" %>"
+    data-spotlight-search-target="transcriptsSearchResults">
+    <% if @groups.any? %>
+      <div class="flex items-center flex-wrap gap-2 py-2">
+        <span class="text-sm font-medium text-gray-600">In Transcripts</span>
+
+        <% if total_count.present? && total_count.positive? %>
+          <span class="text-xs text-gray-400">(<%= total_count %> <%= "talk".pluralize(total_count) %>)</span>
+        <% end %>
+
+        <%= link_to "see all", transcript_search_path(q: search_query), class: "link text-sm text-gray-500", target: "_top" %>
+
+        <% if Rails.env.development? && search_backend == :typesense %>
+          <span class="badge badge-xs badge-primary">Typesense</span>
+        <% end %>
+      </div>
+
+      <div class="flex flex-col gap-3">
+        <% @groups.each do |group| %>
+          <div class="rounded-lg p-2 hover:bg-base-200/50">
+            <%= link_to talk_path(group[:talk_slug]), target: "_top", role: "option", class: "flex items-center gap-3 group" do %>
+              <% if group[:thumbnail].present? %>
+                <%= image_tag group[:thumbnail], loading: "lazy", class: "w-20 aspect-video object-cover rounded-md shrink-0" %>
+              <% end %>
+
+              <div class="min-w-0">
+                <div class="text-sm font-semibold line-clamp-1 group-hover:underline"><%= group[:talk_title] %></div>
+
+                <div class="text-xs text-gray-500 line-clamp-1">
+                  <%= group[:speaker_names] %><% if group[:event_name].present? %> &bull; <%= group[:event_name] %><% end %>
+                </div>
+              </div>
+            <% end %>
+
+            <div class="flex flex-col gap-0.5 mt-1.5 sm:ml-[5.75rem]">
+              <% group[:moments].each do |moment| %>
+                <%= link_to talk_path(group[:talk_slug], t: moment[:start_seconds]), target: "_top", role: "option", class: "flex items-baseline gap-2 rounded px-1.5 py-1 text-xs hover:bg-base-200" do %>
+                  <span class="font-mono tabular-nums text-primary shrink-0"><%= seconds_to_formatted_duration(moment[:start_seconds]) %></span>
+                  <span class="line-clamp-1 text-base-content/70 [&_mark]:bg-info/20 [&_mark]:text-info [&_mark]:rounded [&_mark]:px-0.5 [&_mark]:font-medium"><%= sanitize(moment[:snippet], tags: ["mark"]) %></span>
+                <% end %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/talks/_card_thumbnail.html.erb
+++ b/app/views/talks/_card_thumbnail.html.erb
@@ -90,6 +90,13 @@
         <% if speaker_text %><%= speaker_text %> • <% end %><%= talk.event&.name %>
       </div>
     </div>
+
+    <% if (snippet = talk_transcript_snippet(talk)) %>
+      <div class="flex gap-1.5 mt-1.5 text-xs text-base-content/60">
+        <%= fa("file-lines", size: nil, class: "h-3.5 w-3.5 fill-base-content/40 shrink-0 mt-0.5") %>
+        <span class="line-clamp-2 [&_mark]:bg-info/20 [&_mark]:text-info [&_mark]:rounded [&_mark]:px-0.5 [&_mark]:font-medium">…<%= sanitize(snippet, tags: ["mark"]) %>…</span>
+      </div>
+    <% end %>
   <% end %>
 
   <div data-hover-preview-target="preview" class="hidden">

--- a/app/views/talks/_video_player.html.erb
+++ b/app/views/talks/_video_player.html.erb
@@ -75,7 +75,7 @@
             </div>
 
             <div class="flex flex-col gap-1">
-              <div class="text-lg font-semibold">Play</div>
+              <div class="text-lg font-semibold" data-video-player-target="playLabel">Play</div>
               <% if talk.duration_in_seconds.present? %>
                 <div class="text-sm text-white/80"><%= seconds_to_formatted_duration(talk.duration_in_seconds) %></div>
               <% end %>

--- a/app/views/transcript_searches/index.html.erb
+++ b/app/views/transcript_searches/index.html.erb
@@ -1,0 +1,59 @@
+<div class="max-w-4xl mx-auto px-4 py-8">
+  <h1 class="text-2xl font-bold mb-1">Search transcripts</h1>
+  <p class="text-sm text-base-content/60 mb-6">Find the exact moment something was said, across every talk.</p>
+
+  <%= form_with url: transcript_search_path, method: :get,
+        data: {controller: "auto-submit", turbo_frame: "transcript_results", turbo_action: "advance"} do %>
+    <div class="flex items-center gap-2 rounded-lg bg-base-200 px-3 mb-8">
+      <%= fa("magnifying-glass", size: :md, style: :regular) %>
+      <%= text_field_tag :q, search_query, autofocus: true, autocomplete: "off",
+            placeholder: "e.g. hotwire, n+1, active record…",
+            class: "w-full p-3 bg-transparent outline-none text-lg" %>
+    </div>
+  <% end %>
+
+  <%= turbo_frame_tag "transcript_results" do %>
+    <% if search_query.present? %>
+    <% if @groups.any? %>
+      <p class="text-sm text-base-content/60 mb-4">
+        <%= number_with_delimiter(@total_moments) %> <%= "moment".pluralize(@total_moments) %>
+        across <%= number_with_delimiter(@total_talks) %> <%= "talk".pluralize(@total_talks) %>
+      </p>
+
+      <div class="flex flex-col gap-4">
+        <% @groups.each do |group| %>
+          <div class="flex gap-4 p-4 rounded-xl bg-base-200/40">
+            <% if group[:thumbnail].present? %>
+              <%= link_to talk_path(group[:talk_slug]), class: "shrink-0", data: {turbo_frame: "_top"} do %>
+                <%= image_tag group[:thumbnail], loading: "lazy", class: "w-32 sm:w-44 aspect-video object-cover rounded-lg" %>
+              <% end %>
+            <% end %>
+
+            <div class="flex-1 min-w-0">
+              <%= link_to group[:talk_title], talk_path(group[:talk_slug]), class: "font-semibold hover:underline line-clamp-1", data: {turbo_frame: "_top"} %>
+              <div class="text-sm text-base-content/60 line-clamp-1 mb-2">
+                <%= group[:speaker_names] %><% if group[:event_name].present? %> &bull; <%= group[:event_name] %><% end %>
+              </div>
+
+              <div class="flex flex-col gap-0.5">
+                <% group[:moments].each do |moment| %>
+                  <%= link_to talk_path(group[:talk_slug], t: moment[:start_seconds]), class: "flex items-baseline gap-2 rounded px-2 py-1 text-sm hover:bg-base-200", data: {turbo_frame: "_top"} do %>
+                    <span class="font-mono tabular-nums text-primary shrink-0"><%= seconds_to_formatted_duration(moment[:start_seconds]) %></span>
+                    <span class="text-base-content/70 [&_mark]:bg-info/20 [&_mark]:text-info [&_mark]:rounded [&_mark]:px-0.5 [&_mark]:font-medium">…<%= sanitize(moment[:snippet], tags: ["mark"]) %>…</span>
+                  <% end %>
+                <% end %>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </div>
+
+      <div class="mt-8 flex justify-center">
+        <%== pagy_nav(@pagy) if @pagy && @pagy.pages > 1 %>
+      </div>
+    <% else %>
+      <p class="text-base-content/60">No transcript matches for <strong><%= search_query %></strong>.</p>
+    <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -315,7 +315,10 @@ Rails.application.routes.draw do
     resources :locations, only: [:index]
     resources :languages, only: [:index]
     resources :kinds, only: [:index]
+    resources :transcripts, only: [:index]
   end
+
+  get "search/transcripts", to: "transcript_searches#index", as: :transcript_search
 
   resources :recommendations, only: [:index]
 

--- a/test/controllers/spotlight/transcripts_controller_test.rb
+++ b/test/controllers/spotlight/transcripts_controller_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class Spotlight::TranscriptsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index with turbo stream format" do
+    get spotlight_transcripts_url(format: :turbo_stream)
+    assert_response :success
+    assert_equal "text/vnd.turbo-stream.html", @response.media_type
+  end
+
+  test "should get index with a search query" do
+    get spotlight_transcripts_url(format: :turbo_stream, s: "rails")
+    assert_response :success
+    assert_equal "text/vnd.turbo-stream.html", @response.media_type
+  end
+
+  test "should not track analytics" do
+    assert_no_difference "Ahoy::Event.count" do
+      with_event_tracking do
+        get spotlight_transcripts_url(format: :turbo_stream)
+        assert_response :success
+      end
+    end
+  end
+end

--- a/test/controllers/transcript_searches_controller_test.rb
+++ b/test/controllers/transcript_searches_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class TranscriptSearchesControllerTest < ActionDispatch::IntegrationTest
+  test "renders the transcript search page without a query" do
+    get transcript_search_path
+    assert_response :success
+  end
+
+  test "renders the transcript search page with a query" do
+    get transcript_search_path(q: "rails")
+    assert_response :success
+  end
+end

--- a/test/models/talk/transcript/cue_list_test.rb
+++ b/test/models/talk/transcript/cue_list_test.rb
@@ -30,7 +30,42 @@ class Talk::Transcript::CueListTest < ActiveSupport::TestCase
     end
   end
 
+  test "passages groups cues into windowed chunks with start/end timestamps" do
+    cue_list = Talk::Transcript::CueList.new(cues: [cue(0), cue(20), cue(40), cue(100), cue(120)])
+
+    passages = cue_list.passages(window: 45)
+
+    assert_equal 2, passages.size
+    assert_equal 0, passages.first.start_seconds
+    assert_equal 45, passages.first.end_seconds
+    assert_equal "at 0 at 20 at 40", passages.first.text
+    assert_equal 100, passages.last.start_seconds
+    assert_equal "at 100 at 120", passages.last.text
+  end
+
+  test "deduplicated collapses rolling-caption repeats and tiny duplicate cues" do
+    cues = [
+      cue_with(0, "so there's been a"),
+      cue_with(1, "so there's been a"),               # tiny exact-duplicate boundary cue
+      cue_with(1, "so there's been a whole thing"),   # rolling: repeats previous tail + new words
+      cue_with(2, "whole thing"),                     # tiny duplicate of the tail
+      cue_with(2, "whole thing about rails")          # rolling
+    ]
+
+    result = Talk::Transcript::CueList.new(cues: cues).deduplicated.cues
+
+    assert_equal ["so there's been a", "whole thing", "about rails"], result.map(&:text)
+  end
+
   private
+
+  def cue_with(second, text)
+    Talk::Transcript::Cue.new(
+      start_time: Talk::Transcript::CueList.format_time(second * 1000),
+      end_time: Talk::Transcript::CueList.format_time((second + 1) * 1000),
+      text: text
+    )
+  end
 
   def cue(second)
     Talk::Transcript::Cue.new(


### PR DESCRIPTION
### Description

This pull request adds full-text search over talk transcripts so you can find the exact moment something was said and jump straight to it in the video.

  - Indexes transcripts as timestamped passages in a dedicated Typesense collection, searchable grouped by talk.
  - Surfaces results in two places: an `"In Transcripts"` section in the spotlight (`⌘K`), and a standalone `/search/transcripts` page with search-as-you-type and pagination.
  - Each result is a jumpable moment, clicking it opens the talk at `?t=`, which seeks the video, opens the Transcript tab, scrolls to the line, and labels the play button `"Play from 12:04"`. Match time is interpolated from the term's position in the passage, so it lands on the word, not the passage start.
  - Collapses YouTube's rolling-caption duplication when importing transcripts, and shows a highlighted transcript snippet on regular search hits too.


### Screenshots

<b>Search Results</b>

<img width="1818" height="1064" alt="CleanShot 2026-07-07 at 00 15 20@2x" src="https://github.com/user-attachments/assets/edeb3d5b-781d-4a79-8da2-3f9beec43667" />

<b>Search Transcripts page</b>

<img width="2448" height="1782" alt="CleanShot 2026-07-07 at 00 15 08@2x" src="https://github.com/user-attachments/assets/0b25aff2-0c88-41ba-9777-b8a51e876085" />

<b>Play From timestamp on talks show page</b>


<img width="1912" height="1688" alt="CleanShot 2026-07-07 at 00 17 26@2x" src="https://github.com/user-attachments/assets/1e9c8eff-e419-4b17-9412-4f2e45b314a1" />
