### PR TITLE
Add RubyKaigi 2016 schedule, venue, sponsors, CFP and enrich talks

### DIFF
--- a/data/rubykaigi/rubykaigi-2016/cfp.yml
+++ b/data/rubykaigi/rubykaigi-2016/cfp.yml
@@ -1,0 +1,4 @@
+---
+- name: "Call for Presentations"
+  link: "https://cfp.rubykaigi.org/events/2016"
+  close_date: "2016-06-12"

--- a/data/rubykaigi/rubykaigi-2016/event.yml
+++ b/data/rubykaigi/rubykaigi-2016/event.yml
@@ -14,5 +14,5 @@ banner_background: "#C22700"
 featured_background: "#C22700"
 featured_color: "#FFFFFF"
 coordinates:
-  latitude: 35.011564
-  longitude: 135.7681489
+  latitude: 35.0610839
+  longitude: 135.7831473

--- a/data/rubykaigi/rubykaigi-2016/schedule.yml
+++ b/data/rubykaigi/rubykaigi-2016/schedule.yml
@@ -1,0 +1,174 @@
+---
+# https://rubykaigi.org/2016/schedule
+days:
+  - name: "Day 1"
+    date: "2016-09-08"
+    grid:
+      - start_time: "08:30"
+        end_time: "10:00"
+        slots: 1
+        items:
+          - "Door Open"
+
+      - start_time: "10:00"
+        end_time: "10:10"
+        slots: 1
+        items:
+          - "Opening"
+
+      - start_time: "10:10"
+        end_time: "11:10"
+        slots: 1
+
+      - start_time: "11:20"
+        end_time: "12:00"
+        slots: 2
+
+      - start_time: "12:00"
+        end_time: "13:30"
+        slots: 1
+        items:
+          - "Lunch Break"
+
+      - start_time: "13:30"
+        end_time: "14:10"
+        slots: 2
+
+      - start_time: "14:20"
+        end_time: "15:00"
+        slots: 2
+
+      - start_time: "15:00"
+        end_time: "15:30"
+        slots: 1
+        items:
+          - "Afternoon Break"
+
+      - start_time: "15:30"
+        end_time: "16:10"
+        slots: 2
+
+      - start_time: "16:20"
+        end_time: "17:00"
+        slots: 2
+
+      - start_time: "17:10"
+        end_time: "17:50"
+        slots: 2
+
+  - name: "Day 2"
+    date: "2016-09-09"
+    grid:
+      - start_time: "08:30"
+        end_time: "09:20"
+        slots: 1
+        items:
+          - "Door Open"
+
+      - start_time: "09:20"
+        end_time: "10:20"
+        slots: 1
+
+      - start_time: "10:30"
+        end_time: "11:10"
+        slots: 2
+
+      - start_time: "11:20"
+        end_time: "12:00"
+        slots: 2
+
+      - start_time: "12:00"
+        end_time: "13:30"
+        slots: 1
+        items:
+          - "Lunch Break"
+
+      - start_time: "13:30"
+        end_time: "14:10"
+        slots: 2
+
+      - start_time: "14:20"
+        end_time: "15:00"
+        slots: 2
+
+      - start_time: "15:00"
+        end_time: "15:30"
+        slots: 1
+        items:
+          - "Afternoon Break"
+
+      - start_time: "15:30"
+        end_time: "16:10"
+        slots: 2
+
+      - start_time: "16:20"
+        end_time: "17:00"
+        slots: 2
+
+      - start_time: "17:10"
+        end_time: "17:50"
+        slots: 2
+
+  - name: "Day 3"
+    date: "2016-09-10"
+    grid:
+      - start_time: "08:30"
+        end_time: "09:20"
+        slots: 1
+        items:
+          - "Door Open"
+
+      - start_time: "09:20"
+        end_time: "10:20"
+        slots: 1
+
+      - start_time: "10:30"
+        end_time: "11:10"
+        slots: 2
+
+      - start_time: "11:20"
+        end_time: "12:00"
+        slots: 2
+
+      - start_time: "12:00"
+        end_time: "13:30"
+        slots: 1
+        items:
+          - "Lunch Break"
+
+      - start_time: "13:30"
+        end_time: "14:10"
+        slots: 2
+
+      - start_time: "14:20"
+        end_time: "15:00"
+        slots: 2
+
+      - start_time: "15:00"
+        end_time: "15:30"
+        slots: 1
+        items:
+          - "Afternoon Break"
+
+      - start_time: "15:30"
+        end_time: "16:10"
+        slots: 2
+
+      - start_time: "16:20"
+        end_time: "17:20"
+        slots: 1
+
+      - start_time: "17:30"
+        end_time: "18:00"
+        slots: 1
+        items:
+          - "Closing"
+
+tracks:
+  - name: "Main Hall"
+    color: "#C22700"
+    text_color: "#FFFFFF"
+
+  - name: "Room D"
+    color: "#F5A623"
+    text_color: "#444444"

--- a/data/rubykaigi/rubykaigi-2016/sponsors.yml
+++ b/data/rubykaigi/rubykaigi-2016/sponsors.yml
@@ -1,0 +1,243 @@
+---
+- tiers:
+    - name: "Ruby Sponsors"
+      description: |-
+        Sponsors under the Ruby Sponsors tier
+      level: 1
+      sponsors:
+        - name: "Money Forward, Inc."
+          website: "https://moneyforward.com/"
+          slug: "MoneyForwardInc"
+
+        - name: "Speee, Inc."
+          website: "http://www.speee.jp/"
+          slug: "SpeeeInc"
+
+        - name: "PIXTA Inc."
+          website: "https://pixta.jp/"
+          slug: "PIXTAInc"
+
+        - name: "Cookpad Inc."
+          website: "http://cookpad.com/"
+          slug: "CookpadInc"
+
+    - name: "Name Badge Sponsor"
+      description: |-
+        Sponsors under the Name Badge Sponsor tier
+      level: 2
+      sponsors:
+        - name: "Eight"
+          website: "https://8card.net/"
+          slug: "Eight"
+
+    - name: "Platinum Sponsors"
+      description: |-
+        Sponsors under the Platinum Sponsors tier
+      level: 3
+      sponsors:
+        - name: "Tabelog"
+          website: "http://tabelog.com/"
+          slug: "Tabelog"
+
+        - name: "Happy Elements K.K."
+          website: "http://www.happyelements.co.jp/"
+          slug: "HappyElementsKK"
+
+        - name: "Akatsuki Inc."
+          website: "http://aktsk.jp/"
+          slug: "AkatsukiInc"
+
+        - name: "GitHub, Inc."
+          website: "https://github.com/"
+          slug: "github"
+
+    - name: "Drinkup Sponsor"
+      description: |-
+        Sponsors under the Drinkup Sponsor tier
+      level: 4
+      sponsors:
+        - name: "Misoca Inc."
+          website: "https://info.misoca.jp/"
+          slug: "MisocaInc"
+
+        - name: "Agileware Inc."
+          website: "http://agileware.jp/"
+          slug: "AgilewareInc"
+
+    - name: "Bento Sponsor"
+      description: |-
+        Sponsors under the Bento Sponsor tier
+      level: 5
+      sponsors:
+        - name: "Eiwa System Management, Inc."
+          website: "http://agile.esm.co.jp/"
+          slug: "EiwaSystemManagementInc"
+
+        - name: "Aiming Inc."
+          website: "http://aiming-inc.com/"
+          slug: "Aiming"
+
+    - name: "Nursery Sponsor"
+      description: |-
+        Sponsors under the Nursery Sponsor tier
+      level: 6
+      sponsors:
+        - name: "Everyleaf Corporation"
+          website: "https://everyleaf.com/"
+          slug: "EveryleafCorporation"
+
+    - name: "Gold Sponsors"
+      description: |-
+        Sponsors under the Gold Sponsors tier
+      level: 7
+      sponsors:
+        - name: "Bit Journey, Inc."
+          website: "https://bitjourney.com/"
+          slug: "BitJourneyInc"
+
+        - name: "Opt, Inc."
+          website: "http://www.opt.ne.jp/"
+          slug: "OptInc"
+
+        - name: "Recruit Marketing Partners Co., Ltd."
+          website: "http://www.recruit-mp.co.jp/"
+          slug: "RecruitMarketingPartnersCoLtd"
+
+        - name: "Kaizen Platform, Inc."
+          website: "https://kaizenplatform.com/"
+          slug: "KaizenPlatformInc"
+
+        - name: "GMO Pepabo, Inc."
+          website: "https://pepabo.com/"
+          slug: "GMOPepaboInc"
+
+        - name: "RAKSUL Inc."
+          website: "https://raksul.com/"
+          slug: "RAKSULInc"
+
+        - name: "Nintendo Co., Ltd."
+          website: "https://www.nintendo.co.jp/"
+          slug: "NintendoCoLtd"
+
+        - name: "Google"
+          website: "https://cloud.google.com/ruby"
+          slug: "Google"
+
+        - name: "PR TIMES, Inc."
+          website: "http://prtimes.co.jp/"
+          slug: "PRTIMESInc"
+
+        - name: "esa LLC"
+          website: "https://esa.io/"
+          slug: "esaLLC"
+
+        - name: "M3, Inc."
+          website: "https://corporate.m3.com/"
+          slug: "M3Inc"
+
+        - name: "MediWeb, Inc."
+          website: "http://www.mediweb.jp/"
+          slug: "MediWebInc"
+
+        - name: "Synergy Marketing, Inc."
+          website: "http://www.techscore.com/"
+          slug: "SynergyMarketingInc"
+
+        - name: "SMS Co., Ltd."
+          website: "http://www.bm-sms.co.jp/"
+          slug: "SMSCoLtd"
+
+    - name: "Mobile Application Sponsor"
+      description: |-
+        Sponsors under the Mobile Application Sponsor tier
+      level: 8
+      sponsors:
+        - name: "EL Passion"
+          website: "http://www.elpassion.com/"
+          slug: "ELPassion"
+
+    - name: "RubyKaraoke Sponsor"
+      description: |-
+        Sponsors under the RubyKaraoke Sponsor tier
+      level: 9
+      sponsors:
+        - name: "Drecom Co., Ltd."
+          website: "http://www.drecom.co.jp/"
+          slug: "DrecomCoLtd"
+
+    - name: "Silver Sponsors"
+      description: |-
+        Sponsors under the Silver Sponsors tier
+      level: 10
+      sponsors:
+        - name: "Elastic"
+          website: "https://www.elastic.co/"
+          slug: "Elastic"
+
+        - name: "ClearCode Inc."
+          website: "https://www.clear-code.com/"
+          slug: "ClearCodeInc"
+
+        - name: "ookami, Inc."
+          website: "http://www.playerapp.tokyo/ookamiinc"
+          slug: "ookamiInc"
+
+        - name: "Gaiax Co. Ltd."
+          website: "http://www.gaiax.co.jp/"
+          slug: "GaiaxCoLtd"
+
+        - name: "PORT INC."
+          website: "https://www.theport.jp/"
+          slug: "PORTInc"
+
+        - name: "Ruby Development Inc."
+          website: "https://www.ruby-dev.jp/"
+          slug: "RubyDevelopmentInc"
+
+        - name: "Splout Ltd."
+          website: "https://splout.co.jp/"
+          slug: "SploutLtd"
+
+        - name: "Goodpatch, Inc."
+          website: "http://goodpatch.com/"
+          slug: "GoodpatchInc"
+
+        - name: "Toreta, Inc."
+          website: "https://toreta.in/jp/"
+          slug: "ToretaInc"
+
+        - name: "spice life, Inc."
+          website: "http://spicelife.jp/"
+          slug: "spicelifeInc"
+
+        - name: "SideCI"
+          website: "https://sideci.com/"
+          slug: "SideCI"
+
+        - name: "Livesense Inc."
+          website: "http://www.livesense.co.jp/"
+          slug: "LivesenseInc"
+
+        - name: "Clinical Platform"
+          website: "https://clinical-platform.com/"
+          slug: "ClinicalPlatform"
+
+        - name: "Kyoto University Micro Computer Club"
+          website: "http://kmc.jp/"
+          slug: "KyotoUniversityMicroComputerClub"
+
+        - name: "e-Agency Co., Ltd."
+          website: "http://www.e-agency.co.jp/"
+          slug: "eAgencyCoLtd"
+
+        - name: "Vareal Co., Ltd."
+          website: "https://www.vareal.co.jp/"
+          slug: "VarealCoLtd"
+
+        - name: "BENIC SOLUTION CORP."
+          website: "http://www.benic.co.jp/"
+          slug: "BENICSOLUTIONCORP"
+
+        - name: "Wantedly, Inc."
+          website: "http://site.wantedly.com/"
+          slug: "WantedlyInc"

--- a/data/rubykaigi/rubykaigi-2016/venue.yml
+++ b/data/rubykaigi/rubykaigi-2016/venue.yml
@@ -1,0 +1,23 @@
+---
+# https://rubykaigi.org/2016/venue
+name: "Kyoto International Conference Center"
+url: "https://www.icckyoto.or.jp/en/"
+
+address:
+  street: "Takaragaike"
+  city: "Sakyo-ku"
+  region: "Kyoto"
+  postal_code: "606-0001"
+  country: "Japan"
+  country_code: "JP"
+  display: "Takaragaike, Sakyo-ku, Kyoto 606-0001, Japan"
+
+coordinates:
+  latitude: 35.0610839
+  longitude: 135.7831473
+
+maps:
+  google: "https://www.google.com/maps/place/Kyoto+International+Conference+Center/@35.0610839,135.7831473,17z"
+
+nearby:
+  public_transport: "Directly connected to Kokusaikaikan Station (Exit 4-2), the terminus of the Karasuma Subway Line; about 20 minutes from Kyoto Station. About 75 minutes from Kansai International Airport via the Haruka Express to Kyoto Station, or 2 hours 15 minutes by Shinkansen from Tokyo Station to Kyoto Station."

--- a/data/rubykaigi/rubykaigi-2016/videos.yml
+++ b/data/rubykaigi/rubykaigi-2016/videos.yml
@@ -1,70 +1,30 @@
-# TODO: talks running order
-# TODO: talk dates
-# TODO: conference website
-# TODO: schedule website
 ---
-- id: "petr-chalupa-rubykaigi-2016"
-  title: "Who reordered my code?!"
-  raw_title: "[EN] Who reordered my code?! / Petr Chalupa"
+
+## Day 1 - 2016-09-08
+
+- id: "yukihiro-matz-matsumoto-rubykaigi-2016"
+  title: "Keynote: Ruby 3 Typing"
+  raw_title: '[JA][Keynote] Ruby3 Typing / Yukihiro "Matz" Matsumoto'
+  kind: "keynote"
   event_name: "RubyKaigi 2016"
   date: "2016-09-08"
   published_at: "2016-09-20T03:56:50Z"
-  language: "English"
-  slides_url: "https://speakerdeck.com/pitr_ch/who-reordered-my-code"
+  language: "Japanese"
+  track: "Main Hall"
   video_provider: "youtube"
-  video_id: "3FS1xnCEMq0"
+  video_id: "2Ag8l-wq5qk"
   description: |-
-    https://rubykaigi.org/2016/presentations/pitr_ch.html
+    https://rubykaigi.org/2016/presentations/yukihiro_matz.html
 
-    There is a hidden problem waiting as Ruby becomes 3x faster and starts to support parallel computation - reordering by JIT compilers and CPUs.
-    In this talk, we’ll start by trying to optimize a few simple Ruby snippets. We’ll play the role of a JIT and a CPU and order operations as the rules of the system allow. Then we add a second thread to the snippets and watch it as it breaks horribly.
-    In the second part, we’ll fix the unwanted reorderings by introducing a memory model to Ruby. We’ll discuss in detail how it fixes the snippets and how it can be used to write faster code for parallel execution.
+    Static typing is very popular among recent languages, e.g. TypeScript, Flow, Go, Swift, etc. Even Python has introduced type annotation. How about Ruby?
 
-    Petr Chalupa / @pitr_ch
-    He is a core maintainer of concurrent-ruby, where he has contributed concurrent abstractions and a synchronisation layer, providing volatile and atomic instance variables. He is part of the team working on JRuby+Truffle Ruby implementation at Oracle Labs. He is a happy Ruby user for 10 years.
+    Can Ruby statically typed? Has dynamic typing become obsolete?
+    I will show you the answer. You will see the future of the type system in Ruby3.
+
+    Yukihiro "Matz" Matsumoto @yukihiro_matz
+    The Creator of Ruby
   speakers:
-    - Petr Chalupa
-
-- id: "kevin-menard-rubykaigi-2016"
-  title: "A Tale of Two String Representations"
-  raw_title: "[EN] A Tale of Two String Representations / Kevin Menard"
-  event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
-  published_at: "2016-09-20T03:56:50Z"
-  language: "English"
-  slides_url: "https://speakerdeck.com/nirvdrum/a-tale-of-two-string-representations"
-  video_provider: "youtube"
-  video_id: "UQnxukip368"
-  description: |-
-    https://rubykaigi.org/2016/presentations/nirvdrum.html
-
-    Strings are used pervasively in Ruby. If we can make them faster, we can make many apps faster.
-    In this talk, I will be introducing ropes: an immutable tree-based data structure for implementing strings. While an old idea, ropes provide a new way of looking at string performance and mutability in Ruby. I will describe how we replaced a byte array-oriented string representation with a rope-based one in JRuby+Truffle. Then we’ll look at how moving to ropes affects common string operations, its immediate performance impact, and how ropes can have cascading performance implications for apps.
-
-    Kevin Menard @nirvdrum
-    Kevin is a researcher at Oracle Labs where he works as part of a team developing a high performance Ruby implementation in conjunction with the JRuby team. He’s been involved with the Ruby community since 2008 and has been doing open source in some capacity since 1999. In his spare time he’s a father of two and enjoys playing drums.
-  speakers:
-    - Kevin Menard
-
-- id: "martin-j-drst-rubykaigi-2016"
-  title: "Ups and Downs of Ruby Internationalization"
-  raw_title: "[EN] Ups and Downs of Ruby Internationalization / Martin J. Dürst"
-  event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
-  published_at: "2016-09-20T03:56:49Z"
-  language: "English"
-  slides_url: "http://www.sw.it.aoyama.ac.jp/2016/pub/RubyKaigi/"
-  video_provider: "youtube"
-  video_id: "vfJp4mkf0EQ"
-  description: |-
-    https://rubykaigi.org/2016/presentations/duerst.html
-
-    Currently many of Ruby's String methods, such as upcase and downcase, are limited to ASCII and ignore the rest of the world. This is finally going to change in Ruby 2.4, where this functionality will be extended to cover full Unicode. You will get to know what will change, how your programs may be affected, and how these changes are implemented behind the scenes. We will also look at the overall state of internationalization functionality in Ruby, and potential future directions.
-
-    Martin J. Dürst @duerst
-    Martin is a Professor of Computer Science at Aoyama Gakuin University in Japan. He has been one of the main drivers of Internationalization (I18N) and the use of Unicode on the Web and the Internet. He published the first proposals for DNS I18N and NFC character normalization, and is the main author of the W3C Character Model and the IRI specification (RFC 3987). Since 2007, he and his students have contributed to the implementation of Ruby, mostly in the area of I18N.
-  speakers:
-    - Martin J. Dürst
+    - "Yukihiro \"Matz\" Matsumoto"
 
 - id: "masatoshi-seki-rubykaigi-2016"
   title: "dRuby in the last century."
@@ -73,6 +33,7 @@
   date: "2016-09-08"
   published_at: "2016-09-20T03:56:50Z"
   language: "Japanese"
+  track: "Main Hall"
   slides_url: "https://speakerdeck.com/m_seki/druby2016"
   video_provider: "youtube"
   video_id: "Z7wTY3xZ7G0"
@@ -101,6 +62,73 @@
   speakers:
     - Masatoshi SEKI
 
+- id: "lin-yu-hsiang-rubykaigi-2016"
+  title: "ErRuby: Ruby on Erlang/OTP"
+  raw_title: "[EN] ErRuby: Ruby on Erlang/OTP / Lin Yu Hsiang"
+  event_name: "RubyKaigi 2016"
+  date: "2016-09-08"
+  published_at: "2016-09-20T13:59:09Z"
+  language: "English"
+  track: "Room D"
+  slides_url: "https://speakerdeck.com/johnlinvc/erruby-ruby-on-erlang"
+  video_provider: "youtube"
+  video_id: "Yl7F3wyEMlQ"
+  description: |-
+    https://rubykaigi.org/2016/presentations/johnlinvc.html
+
+    Concurrency will be an important feature for future Ruby, and Erlang programming language is famous for its concurrency features such as Actor model, Lightweight process and ability to build fault tolerant distributed systems such as the telecom.
+
+    ErRuby, an Ruby interpreter on Erlang/OTP, tries to bring Ruby to the concurrent world. ErRuby use Actor and process to create an Object-Oriented realm in immutable Erlang universe. I'll talk about how to implement key Ruby features in a functional way and demonstrate experimental concurrency features of ErRuby.
+
+    ErRuby is at github.com/johnlinvc/erruby
+  speakers:
+    - Lin Yu Hsiang
+
+- id: "petr-chalupa-rubykaigi-2016"
+  title: "Who reordered my code?!"
+  raw_title: "[EN] Who reordered my code?! / Petr Chalupa"
+  event_name: "RubyKaigi 2016"
+  date: "2016-09-08"
+  published_at: "2016-09-20T03:56:50Z"
+  language: "English"
+  track: "Main Hall"
+  slides_url: "https://speakerdeck.com/pitr_ch/who-reordered-my-code"
+  video_provider: "youtube"
+  video_id: "3FS1xnCEMq0"
+  description: |-
+    https://rubykaigi.org/2016/presentations/pitr_ch.html
+
+    There is a hidden problem waiting as Ruby becomes 3x faster and starts to support parallel computation - reordering by JIT compilers and CPUs.
+    In this talk, we’ll start by trying to optimize a few simple Ruby snippets. We’ll play the role of a JIT and a CPU and order operations as the rules of the system allow. Then we add a second thread to the snippets and watch it as it breaks horribly.
+    In the second part, we’ll fix the unwanted reorderings by introducing a memory model to Ruby. We’ll discuss in detail how it fixes the snippets and how it can be used to write faster code for parallel execution.
+
+    Petr Chalupa / @pitr_ch
+    He is a core maintainer of concurrent-ruby, where he has contributed concurrent abstractions and a synchronisation layer, providing volatile and atomic instance variables. He is part of the team working on JRuby+Truffle Ruby implementation at Oracle Labs. He is a happy Ruby user for 10 years.
+  speakers:
+    - Petr Chalupa
+
+- id: "uchio-kondo-rubykaigi-2016"
+  title: "Welcome to haconiwa - the (m)Ruby on Container"
+  raw_title: "[EN] Welcome to haconiwa - the (m)Ruby on Container / Uchio KONDO"
+  kind: "talk"
+  event_name: "RubyKaigi 2016"
+  date: "2016-09-08"
+  published_at: "2016-09-20T13:52:22Z"
+  language: "English"
+  track: "Room D"
+  slides_url: "https://speakerdeck.com/udzura/mruby-on-container"
+  video_provider: "youtube"
+  video_id: "ZKMC5uFlo9s"
+  description: |-
+    https://rubykaigi.org/2016/presentations/udzura.html
+
+    In the current tech scene, many developers use so-called Container-based virtualization such as Docker or LXC.
+
+    Uchio KONDO, @udzura
+    An 8 y.o. Rubyist, Hashicorp freak, DevOps enthusiast, system programming novice. One of the writers of books "Perfect Ruby" / "Perfect Ruby on Rails" (both in Japanese). He lives in Fukuoka - the "coast" city of "west" Japan, works at GMO Pepabo, Inc. as SRE/R&D/Dev Productivity Engineer, and holds Fukuoka.rb local meetup. He also is a organizer of RailsGirls Fukuoka #1.
+  speakers:
+    - Uchio KONDO
+
 - id: "koichi-sasada-rubykaigi-2016"
   title: "A proposal of new concurrency model for Ruby 3"
   raw_title: "[EN] A proposal of new concurrency model for Ruby 3 / Koichi Sasada"
@@ -108,6 +136,7 @@
   date: "2016-09-08"
   published_at: "2016-09-20T03:56:50Z"
   language: "English"
+  track: "Main Hall"
   slides_url: "http://www.atdot.net/~ko1/activities/2016_rubykaigi.pdf"
   video_provider: "youtube"
   video_id: "WIrYh14H9kA"
@@ -135,28 +164,82 @@
   speakers:
     - Koichi Sasada
 
-- id: "yukihiro-matz-matsumoto-rubykaigi-2016"
-  title: "Keynote: Ruby 3 Typing"
-  raw_title: '[JA][Keynote] Ruby3 Typing / Yukihiro "Matz" Matsumoto'
-  kind: "keynote"
+- id: "elct9620-rubykaigi-2016"
+  title: "Play with GLSL on OpenFrameworks"
+  raw_title: "[EN] Play with GLSL on OpenFrameworks"
+  event_name: "RubyKaigi 2016"
+  date: "2016-09-08"
+  published_at: "2016-09-21T19:03:23Z"
+  language: "English"
+  track: "Room D"
+  slides_url: "https://speakerdeck.com/elct9620/play-glsl-on-mruby-with-openframeworks"
+  video_provider: "youtube"
+  video_id: "C2t05Y3dOFQ"
+  description: |-
+    https://rubykaigi.org/2016/presentations/elct9620.html
+
+    Learning GLSL (OpenGL Shader Language) is a little harder to me, but if I can create shader like Unreal Engine 4's material design tool? Let's play with Shader on OpenFrameworks.
+    I using mruby and OpenFrameworks to create a scriptable GLSL generator to create shader. By the power of Ruby DSL, the shader generate becomes very fun and simplely.
+
+    蒼時弦也, @elct9620
+    A Web Developer focus on Interaction Design, and love Game, Animation and Comic. Current working on develop game and website.
+  speakers:
+    - elct9620
+
+- id: "kevin-menard-rubykaigi-2016"
+  title: "A Tale of Two String Representations"
+  raw_title: "[EN] A Tale of Two String Representations / Kevin Menard"
   event_name: "RubyKaigi 2016"
   date: "2016-09-08"
   published_at: "2016-09-20T03:56:50Z"
-  language: "Japanese"
+  language: "English"
+  track: "Main Hall"
+  slides_url: "https://speakerdeck.com/nirvdrum/a-tale-of-two-string-representations"
   video_provider: "youtube"
-  video_id: "2Ag8l-wq5qk"
+  video_id: "UQnxukip368"
   description: |-
-    https://rubykaigi.org/2016/presentations/yukihiro_matz.html
+    https://rubykaigi.org/2016/presentations/nirvdrum.html
 
-    Static typing is very popular among recent languages, e.g. TypeScript, Flow, Go, Swift, etc. Even Python has introduced type annotation. How about Ruby?
+    Strings are used pervasively in Ruby. If we can make them faster, we can make many apps faster.
+    In this talk, I will be introducing ropes: an immutable tree-based data structure for implementing strings. While an old idea, ropes provide a new way of looking at string performance and mutability in Ruby. I will describe how we replaced a byte array-oriented string representation with a rope-based one in JRuby+Truffle. Then we’ll look at how moving to ropes affects common string operations, its immediate performance impact, and how ropes can have cascading performance implications for apps.
 
-    Can Ruby statically typed? Has dynamic typing become obsolete?
-    I will show you the answer. You will see the future of the type system in Ruby3.
-
-    Yukihiro "Matz" Matsumoto @yukihiro_matz
-    The Creator of Ruby
+    Kevin Menard @nirvdrum
+    Kevin is a researcher at Oracle Labs where he works as part of a team developing a high performance Ruby implementation in conjunction with the JRuby team. He’s been involved with the Ruby community since 2008 and has been doing open source in some capacity since 1999. In his spare time he’s a father of two and enjoys playing drums.
   speakers:
-    - "Yukihiro \"Matz\" Matsumoto"
+    - Kevin Menard
+
+- id: "yoh-osaki-rubykaigi-2016"
+  title: "Isomorphic web programming in Ruby"
+  raw_title: "[JA] Isomorphic web programming in Ruby / Yoh Osaki"
+  event_name: "RubyKaigi 2016"
+  date: "2016-09-08"
+  published_at: "2016-09-20T03:56:46Z"
+  language: "Japanese"
+  track: "Room D"
+  slides_url: "http://rubykaigi.youchan.org/"
+  video_provider: "youtube"
+  video_id: "gKDs4V5D_k0"
+  description: |-
+    https://rubykaigi.org/2016/presentations/youchan.html
+
+    Last year at RubyKaigi, I introduced Hyalite, a virtual DOM implemented in Ruby.
+
+    Hyalite allows Rubyists to write front and back-end code in Ruby, an approach that has proven to provide many benefits. Using a single language across an application stack is sometimes referred to as isomorphic programming.
+
+    This talk introduces a new framework for isomorphic programming with the Opal: Menilite.
+
+    Menilite shares model code between the server side and the client side by marshalling objects and storing them in the database automatically.
+
+    As a result, code duplication is reduced and APIs are no longer a necessity.
+
+    Isomorphic programming can significantly accelerate your progress on a project; I sincerely hope you find it helpful in developing web applications.
+
+    Menilite aims to expand the playing field for the Ruby language, a language optimized for developer happiness. I'm sure you will agree that we will find even more happiness by bringing Ruby to the front-end as well.
+
+    Yoh Osaki, @youchan
+    Software engineer at Ubiregi inc. Author of Hyalite which is react like virtual DOM library. Member of Asakusa.rb, Chidoriashi.rb
+  speakers:
+    - Yoh Osaki
 
 - id: "tanaka-akira-rubykaigi-2016"
   title: "Unifying Fixnum and Bignum into Integer"
@@ -165,6 +248,7 @@
   date: "2016-09-08"
   published_at: "2016-09-20T03:56:49Z"
   language: "Japanese"
+  track: "Main Hall"
   slides_url: "http://www.a-k-r.org/pub/2016-09-08-rubykaigi-unified-integer.pdf"
   video_provider: "youtube"
   video_id: "-k_ZhC5Lkgg"
@@ -187,13 +271,109 @@
   speakers:
     - Tanaka Akira
 
+- id: "ritta-narita-rubykaigi-2016"
+  title: "How to create multiprocess server on Windows with Ruby"
+  raw_title: "[EN] How to create multiprocess server on Windows with Ruby / Ritta Narita"
+  event_name: "RubyKaigi 2016"
+  date: "2016-09-08"
+  published_at: "2016-09-20T13:57:09Z"
+  language: "English"
+  track: "Room D"
+  slides_url: "http://www.slideshare.net/RittaNarita/how-to-create-multiprocess-server-on-windows-with-ruby-rubykaigi2016-ritta-narita"
+  video_provider: "youtube"
+  video_id: "h3Vg6B-mg6o"
+  description: |-
+    https://rubykaigi.org/2016/presentations/narittan.html
+
+    Unicorn is the most used multiprocess server framework implemented in ruby. But it doesn't work on Windows unfortunately.
+
+    Serverengine is a robust multiprocess server implemented in ruby and it works on windows now. This is the first multiprocess server with ruby which can work on windows.
+    I'll talk about what only ruby can do and my original effort for realizing a robust multiprocess server for restricted environment.
+
+    And in the end, I'll introduce real demos on windows.
+
+    Ritta Narita, @narittan
+    Ritta graduated from university last September and now is working at Treasure Data.Inc. And he is maintainer of serverengine.
+  speakers:
+    - Ritta Narita
+
+- id: "martin-j-drst-rubykaigi-2016"
+  title: "Ups and Downs of Ruby Internationalization"
+  raw_title: "[EN] Ups and Downs of Ruby Internationalization / Martin J. Dürst"
+  event_name: "RubyKaigi 2016"
+  date: "2016-09-08"
+  published_at: "2016-09-20T03:56:49Z"
+  language: "English"
+  track: "Main Hall"
+  slides_url: "http://www.sw.it.aoyama.ac.jp/2016/pub/RubyKaigi/"
+  video_provider: "youtube"
+  video_id: "vfJp4mkf0EQ"
+  description: |-
+    https://rubykaigi.org/2016/presentations/duerst.html
+
+    Currently many of Ruby's String methods, such as upcase and downcase, are limited to ASCII and ignore the rest of the world. This is finally going to change in Ruby 2.4, where this functionality will be extended to cover full Unicode. You will get to know what will change, how your programs may be affected, and how these changes are implemented behind the scenes. We will also look at the overall state of internationalization functionality in Ruby, and potential future directions.
+
+    Martin J. Dürst @duerst
+    Martin is a Professor of Computer Science at Aoyama Gakuin University in Japan. He has been one of the main drivers of Internationalization (I18N) and the use of Unicode on the Web and the Internet. He published the first proposals for DNS I18N and NFC character normalization, and is the main author of the W3C Character Model and the IRI specification (RFC 3987). Since 2007, he and his students have contributed to the implementation of Ruby, mostly in the area of I18N.
+  speakers:
+    - Martin J. Dürst
+
+- id: "takashi-kokubun-rubykaigi-2016"
+  title: "Scalable job queue system built with Docker"
+  raw_title: "[JA] Scalable job queue system built with Docker / Takashi Kokubun"
+  event_name: "RubyKaigi 2016"
+  date: "2016-09-08"
+  published_at: "2016-09-20T13:54:11Z"
+  language: "Japanese"
+  track: "Room D"
+  slides_url: "https://speakerdeck.com/k0kubun/scalable-job-queue-system-built-with-docker"
+  video_provider: "youtube"
+  video_id: "MO2Zs0q6T9Y"
+  description: |-
+    https://rubykaigi.org/2016/presentations/k0kubun.html
+
+    While job queue system has been indispensable to execute a task asynchronously for a long time, we have some problems in typical job queue systems built with Ruby. Have you ever suffered from job queue system's availability, scalability or operation cost? Don't you want to implement a job with another language which is suitable for the job?
+    We built a new job queue system using Docker this year. In this talk, you'll know how these problems can be solved with the system constructed with Ruby.
+
+    Takashi Kokubun, @k0kubun
+    A software engineer working to improve developer's productivity at Cookpad Inc.
+  speakers:
+    - Takashi Kokubun
+
+## Day 2 - 2016-09-09
+
+- id: "justin-searls-rubykaigi-2016"
+  title: "Fearlessly Refactoring Legacy Ruby"
+  raw_title: "[EN] Fearlessly Refactoring Legacy Ruby / Justin Searls"
+  kind: "keynote"
+  event_name: "RubyKaigi 2016"
+  date: "2016-09-09"
+  published_at: "2016-09-20T03:56:49Z"
+  language: "English"
+  track: "Main Hall"
+  slides_url: "https://speakerdeck.com/searls/surgical-refactors"
+  video_provider: "youtube"
+  video_id: "lQvDd9GPSB4"
+  description: |-
+    https://rubykaigi.org/2016/presentations/searls.html
+
+    Until recently, we didn't talk much about "legacy Ruby". But today, so many companies rely on Ruby that legacy code is inevitable.
+    When code is hard-to-understand, we fear our changes may silently break something. This fear erodes the courage to improve code's design, making future change even harder.
+    If we combine proven refactoring techniques with Ruby's flexibility, we can safely add features while gradually improving our design. This talk will draw on code analysis, testing, and object-oriented design to equip attendees with a process for refactoring legacy code without fear.
+
+    Justin Searls @searls
+    Nobody knows bad code like Justin Searls—he writes bad code effortlessly. And it's given him the chance to study why the industry has gotten so good at making bad software. He co-founded Test Double, an agency focused on fixing what's broken in software.
+  speakers:
+    - Justin Searls
+
 - id: "kouhei-sutou-rubykaigi-2016"
   title: "How to create bindings 2016"
   raw_title: "[JA] How to create bindings 2016 / Kouhei Sutou"
   event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
+  date: "2016-09-09"
   published_at: "2016-09-20T03:56:49Z"
   language: "Japanese"
+  track: "Main Hall"
   slides_url: "https://slide.rabbit-shocker.org/authors/kou/rubykaigi-2016/"
   video_provider: "youtube"
   video_id: "Iw0ha41Ty6I"
@@ -210,13 +390,122 @@
   speakers:
     - Kouhei Sutou
 
+- id: "colby-swandale-rubykaigi-2016"
+  title: "Writing A Gameboy Emulator in Ruby"
+  raw_title: "[EN] Writing A Gameboy Emulator in Ruby / Colby Swandale"
+  event_name: "RubyKaigi 2016"
+  date: "2016-09-09"
+  published_at: "2016-09-21T04:00:06Z"
+  language: "English"
+  track: "Room D"
+  slides_url: "https://speakerdeck.com/colby/making-a-gameboy-emulator-in-ruby"
+  video_provider: "youtube"
+  video_id: "_mHdUhVQOb8"
+  description: |-
+    https://rubykaigi.org/2016/presentations/0xColby.html
+
+    Released in 1989 the Gameboy was the first handheld console of the Gameboy series to be released by Nintendo. It featured games such as Pokemon Red & Blue, Tetris, Super Mario Land and went on to sell 64 million units worldwide.
+    My talk will be discussing what components make up a Gameboy, such as the CPU, RAM, Graphics and Game Cartridge. How each component works individually and how they work together to let trainers catch em all. Then how to replicate the behavior of the Gameboy in code to eventually make an emulator.
+
+    Colby Swandale, @0xColby
+    Working in Melbourne at Marketplacer. I enjoy working on Ruby on Rails projects, low level computing and encryption.
+  speakers:
+    - Colby Swandale
+
+- id: "aja-hammerly-rubykaigi-2016"
+  title: "Exploring Big Data with rubygems.org Download Data"
+  raw_title: "[EN] Exploring Big Data with rubygems.org Download Data / Aja Hammerly"
+  event_name: "RubyKaigi 2016"
+  date: "2016-09-09"
+  published_at: "2016-09-20T03:56:47Z"
+  language: "English"
+  track: "Main Hall"
+  slides_url: "https://thagomizer.com/files/ruby_kaigi_2016.pdf"
+  video_provider: "youtube"
+  video_id: "kLzkkL_V2Ts"
+  description: |-
+    https://rubykaigi.org/2016/presentations/the_thagomizer.html
+
+    Many people strive to be armchair data scientists. Google BigQuery provides an easy way for anyone with basic SQL knowledge to dig into large data sets and just explore. Using the rubygems.org download data we'll see how the Ruby and SQL you already know can help you parse, upload, and analyze multiple gigabytes of data quickly and easily without any previous Big Data experience.
+
+    Aja Hammerly, @the_thagomizer
+    Aja lives in Seattle where she is a developer advocate at Google and a member of the Seattle Ruby Brigade. Her favorite languages are Ruby and Prolog. She also loves working with large piles of data. In her free time she enjoys skiing, cooking, knitting, and long coding sessions on the beach.
+  speakers:
+    - Aja Hammerly
+
+- id: "shibata-hiroshi-rubykaigi-2016"
+  title: "How DSL works on Ruby"
+  raw_title: "[JA] How DSL works on Ruby / SHIBATA Hiroshi"
+  event_name: "RubyKaigi 2016"
+  date: "2016-09-09"
+  published_at: "2016-09-21T04:00:06Z"
+  language: "Japanese"
+  track: "Room D"
+  slides_url: "http://www.slideshare.net/hsbt/how-dsl-works-on-ruby"
+  video_provider: "youtube"
+  video_id: "JwjwnPTt_k8"
+  description: |-
+    https://rubykaigi.org/2016/presentations/hsbt.html
+
+    Domain-Specific Language(DSL) is a useful tool for communication between programmers and businesses. One of the greatest present from Ruby to programmers is to allow them to develop DSL easily. Ruby has a variety of functionalities for DSL making.
+    I started to maintain Rake last year. I found interesting techniques in Rake and felt different things on other popular DSLs like rspec examples, rails routes, and thor tasks etc. And I found patterns of code for DSL with Ruby.
+    I’m going to try to improve Rake 12 using these patterns. So I will describe these patterns of code for DSL with Ruby and talk on the future of Rake 12.
+
+    SHIBATA Hiroshi, @hsbt
+    Ruby Committer, Chief Engineer at GMO Pepabo, Inc.
+  speakers:
+    - Hiroshi SHIBATA
+
+- id: "mitsutaka-mimura-rubykaigi-2016"
+  title: "Learn Programming Essence from Ruby patches"
+  raw_title: "[JA] Learn Programming Essence from Ruby patches / Mitsutaka Mimura"
+  event_name: "RubyKaigi 2016"
+  date: "2016-09-09"
+  published_at: "2016-09-20T03:56:49Z"
+  language: "Japanese"
+  track: "Main Hall"
+  slides_url: "https://speakerdeck.com/takkanm/learn-programming-essence-from-ruby-patches"
+  video_provider: "youtube"
+  video_id: "ktuMYe-Q9SY"
+  description: |-
+    https://rubykaigi.org/2016/presentations/takkanm.html
+
+    Various patches are sent to Ruby. Those patches contain various ideas on programming.
+
+    In this session, I would like to discuss the knowledge underlying programming, such as the original algorithm and data structure patches of Ruby and some libraries.
+
+    Mitsutaka Mimura, @takkanm
+    member of Asakusa.rb, eiwa-system-management.
+  speakers:
+    - Mitsutaka Mimura
+
+- id: "eric-weinstein-rubykaigi-2016"
+  title: "A Nil Device, a Lonely Operator, & a Voyage to the Void Star"
+  raw_title: "[EN] A Nil Device, a Lonely Operator, & a Voyage to the Void Star / Eric Weinstein"
+  event_name: "RubyKaigi 2016"
+  date: "2016-09-09"
+  language: "English"
+  track: "Room D"
+  slides_url: "https://speakerdeck.com/ericqweinstein/a-nil-device-a-lonely-operator-and-a-voyage-to-the-void-star"
+  video_provider: "not_recorded"
+  video_id: "eric-weinstein-rubykaigi-2016"
+  description: |-
+    https://rubykaigi.org/2016/presentations/ericqweinstein.html
+
+    Ruby 2.3 introduced the safe navigation ("lonely") operator, &., for gracefully handling nil. In this talk we explore nil, NilClass, and the void star at the heart of Ruby, taking a journey through how Ruby represents nothingness and how the lonely operator helps us write safer code.
+
+    Eric Weinstein, @ericqweinstein
+  speakers:
+    - Eric Weinstein
+
 - id: "kirk-haines-rubykaigi-2016"
   title: "Web Server Concurrency Architecture"
   raw_title: "[EN] Web Server Concurrency Architecture / Kirk Haines"
   event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
+  date: "2016-09-09"
   published_at: "2016-09-20T03:56:49Z"
   language: "English"
+  track: "Main Hall"
   slides_url: "https://engineyard.github.io/rubykaigi2016-concurrency/"
   video_provider: "youtube"
   video_id: "4FsZfcv28ig"
@@ -232,56 +521,33 @@
   speakers:
     - Kirk Haines
 
-- id: "justin-searls-rubykaigi-2016"
-  title: "Fearlessly Refactoring Legacy Ruby"
-  raw_title: "[EN] Fearlessly Refactoring Legacy Ruby / Justin Searls"
+- id: "kenji-okimoto-rubykaigi-2016"
+  title: "Ruby Reference Manual 2016 Autumn"
+  raw_title: "[JA] Ruby Reference Manual 2016 Autumn / Kenji Okimoto"
   event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
-  published_at: "2016-09-20T03:56:49Z"
-  language: "English"
-  slides_url: "https://speakerdeck.com/searls/surgical-refactors"
-  video_provider: "youtube"
-  video_id: "lQvDd9GPSB4"
+  date: "2016-09-09"
+  language: "Japanese"
+  track: "Room D"
+  slides_url: "https://slide.rabbit-shocker.org/authors/okkez/rubykaigi2016/"
+  video_provider: "not_recorded"
+  video_id: "kenji-okimoto-rubykaigi-2016"
   description: |-
-    https://rubykaigi.org/2016/presentations/searls.html
+    https://rubykaigi.org/2016/presentations/okkez.html
 
-    Until recently, we didn't talk much about "legacy Ruby". But today, so many companies rely on Ruby that legacy code is inevitable.
-    When code is hard-to-understand, we fear our changes may silently break something. This fear erodes the courage to improve code's design, making future change even harder.
-    If we combine proven refactoring techniques with Ruby's flexibility, we can safely add features while gradually improving our design. This talk will draw on code analysis, testing, and object-oriented design to equip attendees with a process for refactoring legacy code without fear.
+    This talk reports on the activities around the Japanese Ruby reference manual (rurema) since 2013, how it is built with bitclust and doctree, and how you can contribute to keeping the documentation up to date.
 
-    Justin Searls @searls
-    Nobody knows bad code like Justin Searls—he writes bad code effortlessly. And it's given him the chance to study why the industry has gotten so good at making bad software. He co-founded Test Double, an agency focused on fixing what's broken in software.
+    Kenji Okimoto, @okkez
   speakers:
-    - Justin Searls
-
-- id: "sameer-deshmukh-rubykaigi-2016"
-  title: "Data Analysis in RUby with daru"
-  raw_title: "[EN] Data Analysis in RUby with daru / Sameer Deshmukh"
-  event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
-  published_at: "2016-09-20T03:56:48Z"
-  language: "English"
-  slides_url: "https://speakerdeck.com/v0dro/data-analysis-in-ruby-with-daru"
-  video_provider: "youtube"
-  video_id: "ZLBGyACJJS4"
-  description: |-
-    https://rubykaigi.org/2016/presentations/v0dro.html
-
-    Easy and fast analysis of data is an uphill task for any Rubyist today. Ruby has been mostly restricted to web development and scripting, until now. In this talk we will have a look at daru, a gem from the Ruby Science Foundation specifically developed for simplifying data analysis tasks for Rubyists.
-    You will learn how you can use daru for analyzing large data sets and get a tour of daru being coupled with other Ruby tools like pry, iruby and nyaplot for interactive and standalone data analysis and plotting for gaining quick insights into your data — all with a few lines of Ruby code.
-
-    Sameer Deshmukh, @v0dro
-    Sameer is a student and a contributor to the Ruby Science Foundation, where he helps build scientific computation tools in Ruby. He is currently maintaining daru, a library for data analysis and manipulation in Ruby. He enjoys spending spare time with friends, books and his bass guitar.
-  speakers:
-    - Sameer Deshmukh
+    - Kenji Okimoto
 
 - id: "masahiro-tanaka-rubykaigi-2016"
   title: "Pwrake: Distributed Workflow Engine based on Rake"
   raw_title: "[JA] Pwrake: Distributed Workflow Engine based on Rake / Masahiro TANAKA"
   event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
+  date: "2016-09-09"
   published_at: "2016-09-20T03:56:48Z"
   language: "Japanese"
+  track: "Main Hall"
   slides_url: "https://speakerdeck.com/masa16tanaka/pwrake-distributed-workflow-engine-based-on-rake"
   video_provider: "youtube"
   video_id: "a4kMUrETrLk"
@@ -296,33 +562,86 @@
   speakers:
     - Masahiro TANAKA
 
-- id: "aja-hammerly-rubykaigi-2016"
-  title: "Exploring Big Data with rubygems.org Download Data"
-  raw_title: "[EN] Exploring Big Data with rubygems.org Download Data / Aja Hammerly"
+- id: "eric-hodel-rubykaigi-2016"
+  title: "Building maintainable command-line tools with mruby"
+  raw_title: "[EN] Building maintainable command-line tools with mruby / Eric Hodel"
   event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
-  published_at: "2016-09-20T03:56:47Z"
+  date: "2016-09-09"
+  published_at: "2016-09-21T04:00:06Z"
   language: "English"
-  slides_url: "https://thagomizer.com/files/ruby_kaigi_2016.pdf"
+  track: "Room D"
+  slides_url: "https://speakerdeck.com/drbrain/building-maintainable-command-line-tools-with-mruby"
   video_provider: "youtube"
-  video_id: "kLzkkL_V2Ts"
+  video_id: "u6SB-Alat9E"
   description: |-
-    https://rubykaigi.org/2016/presentations/the_thagomizer.html
+    https://rubykaigi.org/2016/presentations/drbrain.html
 
-    Many people strive to be armchair data scientists. Google BigQuery provides an easy way for anyone with basic SQL knowledge to dig into large data sets and just explore. Using the rubygems.org download data we'll see how the Ruby and SQL you already know can help you parse, upload, and analyze multiple gigabytes of data quickly and easily without any previous Big Data experience.
+    mruby and mruby-cli makes it possible to ship single binary command-line tools that can be used without setup effort. How can we make these easy to write too?
+    Existing libraries for making command-line tools are built for experienced rubyists. This makes them a poor choice for porting to mruby.
+    In this talk we'll explore how to build a command-line tool with mruby-cli along with a design and philosophy that makes it easy to create new commands and maintain existing commands even for unfamiliar developers.
 
-    Aja Hammerly, @the_thagomizer
-    Aja lives in Seattle where she is a developer advocate at Google and a member of the Seattle Ruby Brigade. Her favorite languages are Ruby and Prolog. She also loves working with large piles of data. In her free time she enjoys skiing, cooking, knitting, and long coding sessions on the beach.
+    Eric Hodel, @drbrain
+    Eric Hodel is a ruby committer and maintainer of many gems. He works at Fastly on the API features team maintaining and building ruby services that customers use to configure their CDN services.
   speakers:
-    - Aja Hammerly
+    - Eric Hodel
+
+- id: "sameer-deshmukh-rubykaigi-2016"
+  title: "Data Analysis in RUby with daru"
+  raw_title: "[EN] Data Analysis in RUby with daru / Sameer Deshmukh"
+  event_name: "RubyKaigi 2016"
+  date: "2016-09-09"
+  published_at: "2016-09-20T03:56:48Z"
+  language: "English"
+  track: "Main Hall"
+  slides_url: "https://speakerdeck.com/v0dro/data-analysis-in-ruby-with-daru"
+  video_provider: "youtube"
+  video_id: "ZLBGyACJJS4"
+  description: |-
+    https://rubykaigi.org/2016/presentations/v0dro.html
+
+    Easy and fast analysis of data is an uphill task for any Rubyist today. Ruby has been mostly restricted to web development and scripting, until now. In this talk we will have a look at daru, a gem from the Ruby Science Foundation specifically developed for simplifying data analysis tasks for Rubyists.
+    You will learn how you can use daru for analyzing large data sets and get a tour of daru being coupled with other Ruby tools like pry, iruby and nyaplot for interactive and standalone data analysis and plotting for gaining quick insights into your data — all with a few lines of Ruby code.
+
+    Sameer Deshmukh, @v0dro
+    Sameer is a student and a contributor to the Ruby Science Foundation, where he helps build scientific computation tools in Ruby. He is currently maintaining daru, a library for data analysis and manipulation in Ruby. He enjoys spending spare time with friends, books and his bass guitar.
+  speakers:
+    - Sameer Deshmukh
+
+- id: "satoshi-moris-tagomori-rubykaigi-2016"
+  title: "Modern Black Mages Fighting in the Real World"
+  raw_title: '[JA] Modern Black Mages Fighting in the Real World / Satoshi "moris" Tagomori'
+  event_name: "RubyKaigi 2016"
+  date: "2016-09-09"
+  published_at: "2016-09-21T04:00:06Z"
+  language: "Japanese"
+  track: "Room D"
+  slides_url: "http://www.slideshare.net/tagomoris/modern-black-mages-fighting-in-the-real-world"
+  video_provider: "youtube"
+  video_id: "fXbVT_Afzsw"
+  description: |-
+    https://rubykaigi.org/2016/presentations/tagomoris.html
+
+    Fluentd v0.14, which has drastically updated Plugin APIs, also has a layer to provide compatibility for old-fashioned plugins to support them and huge amount of existing configuration files in user environments.
+
+    It was far from easy, and developers had to do everything possible, including any kind of black magics.
+    This talk will show some stories with code and commits of a software used in real world:
+    * How to provide compatibility between different APIs
+    * How to provide required methods on existing objects
+    * How to make sure to call super for existing methods without super
+
+    Satoshi "moris" Tagomori, @tagomoris
+    OSS developer/maintainer: Fluentd, Norikra, MessagePack-Ruby, Woothee and many others mainly about Web services, data collecting and distributed/streaming data processing. Living in Tokyo, and day job is for Treasure Data.
+  speakers:
+    - "Satoshi \"moris\" Tagomori"
 
 - id: "kenta-murata-rubykaigi-2016"
   title: "SciRuby Machine Learning Current Status and Future"
   raw_title: "[JA] SciRuby Machine Learning Current Status and Future / Kenta Murata"
   event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
+  date: "2016-09-09"
   published_at: "2016-09-20T03:56:47Z"
   language: "Japanese"
+  track: "Main Hall"
   slides_url: "https://speakerdeck.com/mrkn/sciruby-machine-learning-current-status-and-future"
   video_provider: "youtube"
   video_id: "gfQ8XEy7vO4"
@@ -337,13 +656,54 @@
   speakers:
     - Kenta Murata
 
+- id: "thomas-e-enebo-rubykaigi-2016"
+  title: "JRuby 9000 Last Year, Today, and Tomorrow"
+  raw_title: "[EN] JRuby 9000 Last Year, Today, and Tomorrow / Thomas E Enebo"
+  event_name: "RubyKaigi 2016"
+  date: "2016-09-09"
+  published_at: "2016-09-21T03:57:20Z"
+  language: "English"
+  track: "Room D"
+  video_provider: "youtube"
+  video_id: "vAEFVQQwo1c"
+  description: |-
+    https://rubykaigi.org/2016/presentations/tom_enebo.html
+
+    JRuby 9000 was released over a year ago after a lengthy set of pre-releases. Our most significant major release in nearly 10 years. New runtime. Native IO subsystem. Complete port of C Ruby's transcoding facilities. How did things go? Is the new runtime faster? Did it enable more aggressive optimizations? Does it help aid debugging in development? This talk will discuss lessons learned and where we are focused for upcoming improvements.
+
+    Thomas E Enebo, @tom_enebo
+    Thomas Enebo co-leads the JRuby project. He has been passionately working on JRuby for many years. When not working on JRuby, he is writing Ruby applications, playing with Java, and enjoying a decent beer.
+  speakers:
+    - Thomas E Enebo
+
+## Day 3 - 2016-09-10
+
+- id: "ruby-committers-rubykaigi-2016"
+  title: "Ruby Committers vs the World"
+  raw_title: "Ruby Committers vs the World"
+  kind: "q_and_a"
+  event_name: "RubyKaigi 2016"
+  date: "2016-09-10"
+  published_at: "2016-09-20T14:00:00Z"
+  language: "Japanese"
+  track: "Main Hall"
+  video_provider: "youtube"
+  video_id: "gcqbvLHNPTM"
+  description: |-
+    TBA
+
+    RubyKaigi 2016: https://rubykaigi.org/2016/presentations/cruby_committers.html
+  speakers:
+    - Ruby Committers # TODO: list each person
+
 - id: "matthew-gaudet-rubykaigi-2016"
   title: "Ruby3x3: How are we going to measure 3x?"
   raw_title: "[EN] Ruby3x3: How are we going to measure 3x? / Matthew Gaudet"
   event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
+  date: "2016-09-10"
   published_at: "2016-09-20T03:56:47Z"
   language: "English"
+  track: "Main Hall"
   slides_url: "http://www.slideshare.net/MatthewGaudet/ruby3x3-how-are-we-going-to-measure-3x"
   video_provider: "youtube"
   video_id: "kJDOpucaUR4"
@@ -357,13 +717,36 @@
   speakers:
     - Matthew Gaudet
 
+- id: "toru-kawamura-rubykaigi-2016"
+  title: "Web Clients for Ruby and What they should be in the future"
+  raw_title: "[JA] Web Clients for Ruby and What they should be in the future / Toru Kawamura"
+  event_name: "RubyKaigi 2016"
+  date: "2016-09-10"
+  published_at: "2016-09-21T04:00:07Z"
+  language: "Japanese"
+  track: "Room D"
+  slides_url: "http://www.slideshare.net/tkawa1/rubykaigi2016-web-clients-for-ruby"
+  video_provider: "youtube"
+  video_id: "DeK6EDzEMI0"
+  description: |-
+    https://rubykaigi.org/2016/presentations/tkawa.html
+
+    REST and Hypermedia Web APIs such as Amazon Web Services are getting more common every day. Of course it is also common to integrate those APIs into Ruby app. There are so many HTTP clients we use for integration written in Ruby but all of them lack the feature "state management" for taking advantage of Web APIs.
+    I implemented the feature on Faraday, a typical HTTP client in Ruby. I'll show you the key point and the usefulness of the implementation.
+
+    Toru Kawamura, @tkawa
+    RESTafarian, freelance programmer, technology assistance partner at SonicGarden Inc., co-organizer of Sendagaya.rb (regional rubyist meetup), and facilitator of RESTful-towa (“What is RESTful”) Workshop
+  speakers:
+    - Toru Kawamura
+
 - id: "yurie-yamane-rubykaigi-2016"
   title: "High Tech Seat in mruby"
   raw_title: "[JA] High Tech Seat in mruby / Yurie Yamane"
   event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
+  date: "2016-09-10"
   published_at: "2016-09-20T03:56:47Z"
   language: "Japanese"
+  track: "Main Hall"
   slides_url: "http://www.slideshare.net/yamanekko/rubykaigi2016-high-tech-seat-in-mruby"
   video_provider: "youtube"
   video_id: "z93299YHVYI"
@@ -390,54 +773,35 @@
   speakers:
     - Yurie Yamane
 
-- id: "franck-verrot-rubykaigi-2016"
-  title: "Hijacking syscalls with (m)ruby"
-  raw_title: "[EN] Hijacking syscalls with (m)ruby / Franck Verrot"
+- id: "chris-arcand-rubykaigi-2016"
+  title: "Deletion Driven Development: Code to delete code!"
+  raw_title: "[EN] Deletion Driven Development: Code to delete code!"
   event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
-  published_at: "2016-09-20T03:56:47Z"
+  date: "2016-09-10"
+  published_at: "2016-09-21T03:41:26Z"
   language: "English"
-  slides_url: "https://speakerdeck.com/franckverrot/rubykaigi-2016-hijacking-syscalls-with-ruby"
+  track: "Room D"
+  slides_url: "https://chrisarcand.com/talks/deletion-driven-development-code-to-delete-code/"
   video_provider: "youtube"
-  video_id: "zRoiX0BES0s"
+  video_id: "UlfyX8zRVc8"
   description: |-
-    https://rubykaigi.org/2016/presentations/franckverrot.html
+    https://rubykaigi.org/2016/presentations/chrisarcand.html
 
-    mruby's unique packaging strategy gives developers the possibility to inject Ruby code in any program, written in any language.
-    In this talk we'll discover how a mruby application can be distributed, how one could replace OS system calls with custom Ruby apps, and real-world usages of this technique.
+    Good news! Ruby is a successful and mature programming language with a wealth of libraries and legacy applications that have been contributed to for many years. The bad news: Those projects might contain a large amount of useless, unused code which adds needless complexity and confuses new developers. In this talk I'll explain how to build a static analysis tool to help you clear out the cruft - because there's no code that's easier to maintain than no code at all!
 
-    Franck Verrot, @franckverrot
-    Franck is a software engineer. He specializes in Ruby and JavaScript, with a focus on performance.
+    Chris Arcand, @chrisarcand
+    Chris is a Ruby developer at Red Hat on the ManageIQ core team. He enjoys working full time on open source software to manage The Cloud™ and has contributed to various projects in the Ruby ecosystem. Chris hails from Minnesota in the United States and also enjoys hockey, hiking, and tasty beers.
   speakers:
-    - Franck Verrot
-
-- id: "urabe-shyouhei-rubykaigi-2016"
-  title: "Optimizing Ruby"
-  raw_title: "[JA] Optimizing Ruby / Urabe, Shyouhei"
-  event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
-  published_at: "2016-09-20T03:56:47Z"
-  language: "Japanese"
-  slides_url: "https://speakerdeck.com/shyouhei/optimizing-ruby"
-  video_provider: "youtube"
-  video_id: "spxcAHidm5o"
-  description: |-
-    https://rubykaigi.org/2016/presentations/shyouhei.html
-
-    I made ruby 10x faster. Let me show you how.
-
-    Urabe, Shyouhei, @shyouhei
-    Money Forward, Inc. hire Shyouhei, a long-time ruby-core committer, to contribute to the whole ruby ecosystem. Being a full-time ruby-core developer, his current interest is to speed up ruby execution by modifying its internals. Doing so is not straight-forward because of ruby's highly dynamic nature. To tackle this problem he is implementing a deoptimization engine onto ruby, which enables lots of optimization techniques that are yet to be applied to it.
-  speakers:
-    - Shyouhei Urabe
+    - Chris Arcand
 
 - id: "julian-cheal-rubykaigi-2016"
   title: "It's More Fun to Compute"
   raw_title: "[EN] It's More Fun to Compute / Julian Cheal"
   event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
+  date: "2016-09-10"
   published_at: "2016-09-20T03:56:47Z"
   language: "English"
+  track: "Main Hall"
   video_provider: "youtube"
   video_id: "z7So-iCJSUY"
   description: |-
@@ -451,234 +815,14 @@
   speakers:
     - Julian Cheal
 
-- id: "naruse-yui-rubykaigi-2016"
-  title: "Keynote: Dive into CRuby"
-  raw_title: "[JA Keynote] Dive into CRuby / NARUSE, Yui"
-  kind: "keynote"
-  event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
-  published_at: "2016-09-20T03:56:46Z"
-  language: "Japanese"
-  slides_url: "https://speakerdeck.com/naruse/dive-into-cruby"
-  video_provider: "youtube"
-  video_id: "iMtpCes8VqU"
-  description: |-
-    https://rubykaigi.org/2016/presentations/nalsh.html
-
-    People sometimes want to involve CRuby development, but won't. I guess it's because they couldn't embody the motivation and don't know how to work about it.
-
-    I explain how to find an entry point, write code, make matz merge it.
-
-    NARUSE, Yui / @nalsh
-    Ruby committer, nkf maintainer, working at Treasure Data Inc.
-  speakers:
-    - NARUSE Yui
-
-- id: "takashi-kokubun-rubykaigi-2016"
-  title: "Scalable job queue system built with Docker"
-  raw_title: "[JA] Scalable job queue system built with Docker / Takashi Kokubun"
-  event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
-  published_at: "2016-09-20T13:54:11Z"
-  language: "Japanese"
-  slides_url: "https://speakerdeck.com/k0kubun/scalable-job-queue-system-built-with-docker"
-  video_provider: "youtube"
-  video_id: "MO2Zs0q6T9Y"
-  description: |-
-    https://rubykaigi.org/2016/presentations/k0kubun.html
-
-    While job queue system has been indispensable to execute a task asynchronously for a long time, we have some problems in typical job queue systems built with Ruby. Have you ever suffered from job queue system's availability, scalability or operation cost? Don't you want to implement a job with another language which is suitable for the job?
-    We built a new job queue system using Docker this year. In this talk, you'll know how these problems can be solved with the system constructed with Ruby.
-
-    Takashi Kokubun, @k0kubun
-    A software engineer working to improve developer's productivity at Cookpad Inc.
-  speakers:
-    - Takashi Kokubun
-
-- id: "toru-kawamura-rubykaigi-2016"
-  title: "Web Clients for Ruby and What they should be in the future"
-  raw_title: "[JA] Web Clients for Ruby and What they should be in the future / Toru Kawamura"
-  event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
-  published_at: "2016-09-21T04:00:07Z"
-  language: "Japanese"
-  slides_url: "http://www.slideshare.net/tkawa1/rubykaigi2016-web-clients-for-ruby"
-  video_provider: "youtube"
-  video_id: "DeK6EDzEMI0"
-  description: |-
-    https://rubykaigi.org/2016/presentations/tkawa.html
-
-    REST and Hypermedia Web APIs such as Amazon Web Services are getting more common every day. Of course it is also common to integrate those APIs into Ruby app. There are so many HTTP clients we use for integration written in Ruby but all of them lack the feature "state management" for taking advantage of Web APIs.
-    I implemented the feature on Faraday, a typical HTTP client in Ruby. I'll show you the key point and the usefulness of the implementation.
-
-    Toru Kawamura, @tkawa
-    RESTafarian, freelance programmer, technology assistance partner at SonicGarden Inc., co-organizer of Sendagaya.rb (regional rubyist meetup), and facilitator of RESTful-towa (“What is RESTful”) Workshop
-  speakers:
-    - Toru Kawamura
-
-- id: "lin-yu-hsiang-rubykaigi-2016"
-  title: "ErRuby: Ruby on Erlang/OTP"
-  raw_title: "[EN] ErRuby: Ruby on Erlang/OTP / Lin Yu Hsiang"
-  event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
-  published_at: "2016-09-20T13:59:09Z"
-  language: "English"
-  slides_url: "https://speakerdeck.com/johnlinvc/erruby-ruby-on-erlang"
-  video_provider: "youtube"
-  video_id: "Yl7F3wyEMlQ"
-  description: |-
-    https://rubykaigi.org/2016/presentations/johnlinvc.html
-
-    Concurrency will be an important feature for future Ruby, and Erlang programming language is famous for its concurrency features such as Actor model, Lightweight process and ability to build fault tolerant distributed systems such as the telecom.
-
-    ErRuby, an Ruby interpreter on Erlang/OTP, tries to bring Ruby to the concurrent world. ErRuby use Actor and process to create an Object-Oriented realm in immutable Erlang universe. I'll talk about how to implement key Ruby features in a functional way and demonstrate experimental concurrency features of ErRuby.
-
-    ErRuby is at github.com/johnlinvc/erruby
-  speakers:
-    - Lin Yu Hsiang
-
-- id: "thomas-e-enebo-rubykaigi-2016"
-  title: "JRuby 9000 Last Year, Today, and Tomorrow"
-  raw_title: "[EN] JRuby 9000 Last Year, Today, and Tomorrow / Thomas E Enebo"
-  event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
-  published_at: "2016-09-21T03:57:20Z"
-  language: "English"
-  video_provider: "youtube"
-  video_id: "vAEFVQQwo1c"
-  description: |-
-    https://rubykaigi.org/2016/presentations/tom_enebo.html
-
-    JRuby 9000 was released over a year ago after a lengthy set of pre-releases. Our most significant major release in nearly 10 years. New runtime. Native IO subsystem. Complete port of C Ruby's transcoding facilities. How did things go? Is the new runtime faster? Did it enable more aggressive optimizations? Does it help aid debugging in development? This talk will discuss lessons learned and where we are focused for upcoming improvements.
-
-    Thomas E Enebo, @tom_enebo
-    Thomas Enebo co-leads the JRuby project. He has been passionately working on JRuby for many years. When not working on JRuby, he is writing Ruby applications, playing with Java, and enjoying a decent beer.
-  speakers:
-    - Thomas E Enebo
-
-- id: "ruby-committers-rubykaigi-2016"
-  title: "Ruby Committers vs the World"
-  raw_title: "Ruby Committers vs the World"
-  kind: "q_and_a"
-  event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
-  published_at: "2016-09-20T14:00:00Z"
-  video_provider: "youtube"
-  video_id: "gcqbvLHNPTM"
-  description: |-
-    TBA
-
-    RubyKaigi 2016: https://rubykaigi.org/2016/presentations/cruby_committers.html
-  speakers:
-    - Ruby Committers # TODO: list each person
-
-- id: "ritta-narita-rubykaigi-2016"
-  title: "How to create multiprocess server on Windows with Ruby"
-  raw_title: "[EN] How to create multiprocess server on Windows with Ruby / Ritta Narita"
-  event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
-  published_at: "2016-09-20T13:57:09Z"
-  language: "English"
-  slides_url: "http://www.slideshare.net/RittaNarita/how-to-create-multiprocess-server-on-windows-with-ruby-rubykaigi2016-ritta-narita"
-  video_provider: "youtube"
-  video_id: "h3Vg6B-mg6o"
-  description: |-
-    https://rubykaigi.org/2016/presentations/narittan.html
-
-    Unicorn is the most used multiprocess server framework implemented in ruby. But it doesn't work on Windows unfortunately.
-
-    Serverengine is a robust multiprocess server implemented in ruby and it works on windows now. This is the first multiprocess server with ruby which can work on windows.
-    I'll talk about what only ruby can do and my original effort for realizing a robust multiprocess server for restricted environment.
-
-    And in the end, I'll introduce real demos on windows.
-
-    Ritta Narita, @narittan
-    Ritta graduated from university last September and now is working at Treasure Data.Inc. And he is maintainer of serverengine.
-  speakers:
-    - Ritta Narita
-
-- id: "uchio-kondo-rubykaigi-2016"
-  title: "Welcome to haconiwa - the (m)Ruby on Container"
-  raw_title: "[EN] Welcome to haconiwa - the (m)Ruby on Container / Uchio KONDO"
-  kind: "talk"
-  event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
-  published_at: "2016-09-20T13:52:22Z"
-  language: "English"
-  slides_url: "https://speakerdeck.com/udzura/mruby-on-container"
-  video_provider: "youtube"
-  video_id: "ZKMC5uFlo9s"
-  description: |-
-    https://rubykaigi.org/2016/presentations/udzura.html
-
-    In the current tech scene, many developers use so-called Container-based virtualization such as Docker or LXC.
-
-    Uchio KONDO, @udzura
-    An 8 y.o. Rubyist, Hashicorp freak, DevOps enthusiast, system programming novice. One of the writers of books "Perfect Ruby" / "Perfect Ruby on Rails" (both in Japanese). He lives in Fukuoka - the "coast" city of "west" Japan, works at GMO Pepabo, Inc. as SRE/R&D/Dev Productivity Engineer, and holds Fukuoka.rb local meetup. He also is a organizer of RailsGirls Fukuoka #1.
-  speakers:
-    - Uchio KONDO
-
-- id: "mitsutaka-mimura-rubykaigi-2016"
-  title: "Learn Programming Essence from Ruby patches"
-  raw_title: "[JA] Learn Programming Essence from Ruby patches / Mitsutaka Mimura"
-  event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
-  published_at: "2016-09-20T03:56:49Z"
-  language: "Japanese"
-  slides_url: "https://speakerdeck.com/takkanm/learn-programming-essence-from-ruby-patches"
-  video_provider: "youtube"
-  video_id: "ktuMYe-Q9SY"
-  description: |-
-    https://rubykaigi.org/2016/presentations/takkanm.html
-
-    Various patches are sent to Ruby. Those patches contain various ideas on programming.
-
-    In this session, I would like to discuss the knowledge underlying programming, such as the original algorithm and data structure patches of Ruby and some libraries.
-
-    Mitsutaka Mimura, @takkanm
-    member of Asakusa.rb, eiwa-system-management.
-  speakers:
-    - Mitsutaka Mimura
-
-- id: "yoh-osaki-rubykaigi-2016"
-  title: "Isomorphic web programming in Ruby"
-  raw_title: "[JA] Isomorphic web programming in Ruby / Yoh Osaki"
-  event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
-  published_at: "2016-09-20T03:56:46Z"
-  language: "Japanese"
-  slides_url: "http://rubykaigi.youchan.org/"
-  video_provider: "youtube"
-  video_id: "gKDs4V5D_k0"
-  description: |-
-    https://rubykaigi.org/2016/presentations/youchan.html
-
-    Last year at RubyKaigi, I introduced Hyalite, a virtual DOM implemented in Ruby.
-
-    Hyalite allows Rubyists to write front and back-end code in Ruby, an approach that has proven to provide many benefits. Using a single language across an application stack is sometimes referred to as isomorphic programming.
-
-    This talk introduces a new framework for isomorphic programming with the Opal: Menilite.
-
-    Menilite shares model code between the server side and the client side by marshalling objects and storing them in the database automatically.
-
-    As a result, code duplication is reduced and APIs are no longer a necessity.
-
-    Isomorphic programming can significantly accelerate your progress on a project; I sincerely hope you find it helpful in developing web applications.
-
-    Menilite aims to expand the playing field for the Ruby language, a language optimized for developer happiness. I'm sure you will agree that we will find even more happiness by bringing Ruby to the front-end as well.
-
-    Yoh Osaki, @youchan
-    Software engineer at Ubiregi inc. Author of Hyalite which is react like virtual DOM library. Member of Asakusa.rb, Chidoriashi.rb
-  speakers:
-    - Yoh Osaki
-
 - id: "kazuho-oku-rubykaigi-2016"
   title: "Recent Advances in HTTP and Controlling them using ruby"
   raw_title: "[JA] Recent Advances in HTTP and Controlling them using ruby / Kazuho Oku"
   event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
+  date: "2016-09-10"
   published_at: "2016-09-21T03:47:20Z"
   language: "Japanese"
+  track: "Room D"
   slides_url: "http://www.slideshare.net/kazuho/recent-advances-in-http-controlling-them-using-ruby"
   video_provider: "youtube"
   video_id: "_YroMCap4y8"
@@ -692,125 +836,35 @@
   speakers:
     - Kazuho Oku
 
-- id: "satoshi-moris-tagomori-rubykaigi-2016"
-  title: "Modern Black Mages Fighting in the Real World"
-  raw_title: '[JA] Modern Black Mages Fighting in the Real World / Satoshi "moris" Tagomori'
+- id: "urabe-shyouhei-rubykaigi-2016"
+  title: "Optimizing Ruby"
+  raw_title: "[JA] Optimizing Ruby / Urabe, Shyouhei"
   event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
-  published_at: "2016-09-21T04:00:06Z"
+  date: "2016-09-10"
+  published_at: "2016-09-20T03:56:47Z"
   language: "Japanese"
-  slides_url: "http://www.slideshare.net/tagomoris/modern-black-mages-fighting-in-the-real-world"
+  track: "Main Hall"
+  slides_url: "https://speakerdeck.com/shyouhei/optimizing-ruby"
   video_provider: "youtube"
-  video_id: "fXbVT_Afzsw"
+  video_id: "spxcAHidm5o"
   description: |-
-    https://rubykaigi.org/2016/presentations/tagomoris.html
+    https://rubykaigi.org/2016/presentations/shyouhei.html
 
-    Fluentd v0.14, which has drastically updated Plugin APIs, also has a layer to provide compatibility for old-fashioned plugins to support them and huge amount of existing configuration files in user environments.
+    I made ruby 10x faster. Let me show you how.
 
-    It was far from easy, and developers had to do everything possible, including any kind of black magics.
-    This talk will show some stories with code and commits of a software used in real world:
-    * How to provide compatibility between different APIs
-    * How to provide required methods on existing objects
-    * How to make sure to call super for existing methods without super
-
-    Satoshi "moris" Tagomori, @tagomoris
-    OSS developer/maintainer: Fluentd, Norikra, MessagePack-Ruby, Woothee and many others mainly about Web services, data collecting and distributed/streaming data processing. Living in Tokyo, and day job is for Treasure Data.
+    Urabe, Shyouhei, @shyouhei
+    Money Forward, Inc. hire Shyouhei, a long-time ruby-core committer, to contribute to the whole ruby ecosystem. Being a full-time ruby-core developer, his current interest is to speed up ruby execution by modifying its internals. Doing so is not straight-forward because of ruby's highly dynamic nature. To tackle this problem he is implementing a deoptimization engine onto ruby, which enables lots of optimization techniques that are yet to be applied to it.
   speakers:
-    - "Satoshi \"moris\" Tagomori"
-
-- id: "elct9620-rubykaigi-2016"
-  title: "Play with GLSL on OpenFrameworks"
-  raw_title: "[EN] Play with GLSL on OpenFrameworks"
-  event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
-  published_at: "2016-09-21T19:03:23Z"
-  language: "English"
-  slides_url: "https://speakerdeck.com/elct9620/play-glsl-on-mruby-with-openframeworks"
-  video_provider: "youtube"
-  video_id: "C2t05Y3dOFQ"
-  description: |-
-    https://rubykaigi.org/2016/presentations/elct9620.html
-
-    Learning GLSL (OpenGL Shader Language) is a little harder to me, but if I can create shader like Unreal Engine 4's material design tool? Let's play with Shader on OpenFrameworks.
-    I using mruby and OpenFrameworks to create a scriptable GLSL generator to create shader. By the power of Ruby DSL, the shader generate becomes very fun and simplely.
-
-    蒼時弦也, @elct9620
-    A Web Developer focus on Interaction Design, and love Game, Animation and Comic. Current working on develop game and website.
-  speakers:
-    - elct9620
-
-- id: "shibata-hiroshi-rubykaigi-2016"
-  title: "How DSL works on Ruby"
-  raw_title: "[JA] How DSL works on Ruby / SHIBATA Hiroshi"
-  event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
-  published_at: "2016-09-21T04:00:06Z"
-  language: "Japanese"
-  slides_url: "http://www.slideshare.net/hsbt/how-dsl-works-on-ruby"
-  video_provider: "youtube"
-  video_id: "JwjwnPTt_k8"
-  description: |-
-    https://rubykaigi.org/2016/presentations/hsbt.html
-
-    Domain-Specific Language(DSL) is a useful tool for communication between programmers and businesses. One of the greatest present from Ruby to programmers is to allow them to develop DSL easily. Ruby has a variety of functionalities for DSL making.
-    I started to maintain Rake last year. I found interesting techniques in Rake and felt different things on other popular DSLs like rspec examples, rails routes, and thor tasks etc. And I found patterns of code for DSL with Ruby.
-    I’m going to try to improve Rake 12 using these patterns. So I will describe these patterns of code for DSL with Ruby and talk on the future of Rake 12.
-
-    SHIBATA Hiroshi, @hsbt
-    Ruby Committer, Chief Engineer at GMO Pepabo, Inc.
-  speakers:
-    - Hiroshi SHIBATA
-
-- id: "colby-swandale-rubykaigi-2016"
-  title: "Writing A Gameboy Emulator in Ruby"
-  raw_title: "[EN] Writing A Gameboy Emulator in Ruby / Colby Swandale"
-  event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
-  published_at: "2016-09-21T04:00:06Z"
-  language: "English"
-  slides_url: "https://speakerdeck.com/colby/making-a-gameboy-emulator-in-ruby"
-  video_provider: "youtube"
-  video_id: "_mHdUhVQOb8"
-  description: |-
-    https://rubykaigi.org/2016/presentations/0xColby.html
-
-    Released in 1989 the Gameboy was the first handheld console of the Gameboy series to be released by Nintendo. It featured games such as Pokemon Red & Blue, Tetris, Super Mario Land and went on to sell 64 million units worldwide.
-    My talk will be discussing what components make up a Gameboy, such as the CPU, RAM, Graphics and Game Cartridge. How each component works individually and how they work together to let trainers catch em all. Then how to replicate the behavior of the Gameboy in code to eventually make an emulator.
-
-    Colby Swandale, @0xColby
-    Working in Melbourne at Marketplacer. I enjoy working on Ruby on Rails projects, low level computing and encryption.
-  speakers:
-    - Colby Swandale
-
-- id: "eric-hodel-rubykaigi-2016"
-  title: "Building maintainable command-line tools with mruby"
-  raw_title: "[EN] Building maintainable command-line tools with mruby / Eric Hodel"
-  event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
-  published_at: "2016-09-21T04:00:06Z"
-  language: "English"
-  slides_url: "https://speakerdeck.com/drbrain/building-maintainable-command-line-tools-with-mruby"
-  video_provider: "youtube"
-  video_id: "u6SB-Alat9E"
-  description: |-
-    https://rubykaigi.org/2016/presentations/drbrain.html
-
-    mruby and mruby-cli makes it possible to ship single binary command-line tools that can be used without setup effort. How can we make these easy to write too?
-    Existing libraries for making command-line tools are built for experienced rubyists. This makes them a poor choice for porting to mruby.
-    In this talk we'll explore how to build a command-line tool with mruby-cli along with a design and philosophy that makes it easy to create new commands and maintain existing commands even for unfamiliar developers.
-
-    Eric Hodel, @drbrain
-    Eric Hodel is a ruby committer and maintainer of many gems. He works at Fastly on the API features team maintaining and building ruby services that customers use to configure their CDN services.
-  speakers:
-    - Eric Hodel
+    - Shyouhei Urabe
 
 - id: "anil-wadghule-rubykaigi-2016"
   title: "Ruby Concurrency compared"
   raw_title: "[EN] Ruby Concurrency compared / Anil Wadghule"
   event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
+  date: "2016-09-10"
   published_at: "2016-09-21T03:45:32Z"
   language: "English"
+  track: "Room D"
   slides_url: "https://speakerdeck.com/anildigital/ruby-concurrency-compared"
   video_provider: "youtube"
   video_id: "lbX-9mDUOIw"
@@ -829,13 +883,36 @@
   speakers:
     - Anil Wadghule
 
+- id: "franck-verrot-rubykaigi-2016"
+  title: "Hijacking syscalls with (m)ruby"
+  raw_title: "[EN] Hijacking syscalls with (m)ruby / Franck Verrot"
+  event_name: "RubyKaigi 2016"
+  date: "2016-09-10"
+  published_at: "2016-09-20T03:56:47Z"
+  language: "English"
+  track: "Main Hall"
+  slides_url: "https://speakerdeck.com/franckverrot/rubykaigi-2016-hijacking-syscalls-with-ruby"
+  video_provider: "youtube"
+  video_id: "zRoiX0BES0s"
+  description: |-
+    https://rubykaigi.org/2016/presentations/franckverrot.html
+
+    mruby's unique packaging strategy gives developers the possibility to inject Ruby code in any program, written in any language.
+    In this talk we'll discover how a mruby application can be distributed, how one could replace OS system calls with custom Ruby apps, and real-world usages of this technique.
+
+    Franck Verrot, @franckverrot
+    Franck is a software engineer. He specializes in Ruby and JavaScript, with a focus on performance.
+  speakers:
+    - Franck Verrot
+
 - id: "amir-rajan-rubykaigi-2016"
   title: "Game Development + Ruby = Happiness"
   raw_title: "[EN] Game Development + Ruby = Happiness / Amir Rajan"
   event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
+  date: "2016-09-10"
   published_at: "2016-09-21T04:00:05Z"
   language: "English"
+  track: "Room D"
   slides_url: "http://slides.com/amirrajan/deck"
   video_provider: "youtube"
   video_id: "jfTM_0ezZuI"
@@ -849,22 +926,26 @@
   speakers:
     - Amir Rajan
 
-- id: "chris-arcand-rubykaigi-2016"
-  title: "Deletion Driven Development: Code to delete code!"
-  raw_title: "[EN] Deletion Driven Development: Code to delete code!"
+- id: "naruse-yui-rubykaigi-2016"
+  title: "Keynote: Dive into CRuby"
+  raw_title: "[JA Keynote] Dive into CRuby / NARUSE, Yui"
+  kind: "keynote"
   event_name: "RubyKaigi 2016"
-  date: "2016-09-08"
-  published_at: "2016-09-21T03:41:26Z"
-  language: "English"
-  slides_url: "https://chrisarcand.com/talks/deletion-driven-development-code-to-delete-code/"
+  date: "2016-09-10"
+  published_at: "2016-09-20T03:56:46Z"
+  language: "Japanese"
+  track: "Main Hall"
+  slides_url: "https://speakerdeck.com/naruse/dive-into-cruby"
   video_provider: "youtube"
-  video_id: "UlfyX8zRVc8"
+  video_id: "iMtpCes8VqU"
   description: |-
-    https://rubykaigi.org/2016/presentations/chrisarcand.html
+    https://rubykaigi.org/2016/presentations/nalsh.html
 
-    Good news! Ruby is a successful and mature programming language with a wealth of libraries and legacy applications that have been contributed to for many years. The bad news: Those projects might contain a large amount of useless, unused code which adds needless complexity and confuses new developers. In this talk I'll explain how to build a static analysis tool to help you clear out the cruft - because there's no code that's easier to maintain than no code at all!
+    People sometimes want to involve CRuby development, but won't. I guess it's because they couldn't embody the motivation and don't know how to work about it.
 
-    Chris Arcand, @chrisarcand
-    Chris is a Ruby developer at Red Hat on the ManageIQ core team. He enjoys working full time on open source software to manage The Cloud™ and has contributed to various projects in the Ruby ecosystem. Chris hails from Minnesota in the United States and also enjoys hockey, hiking, and tasty beers.
+    I explain how to find an entry point, write code, make matz merge it.
+
+    NARUSE, Yui / @nalsh
+    Ruby committer, nkf maintainer, working at Treasure Data Inc.
   speakers:
-    - Chris Arcand
+    - NARUSE Yui

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -4961,6 +4961,7 @@
 - name: "Eric Weinstein"
   github: "ericqweinstein"
   website: "http://ericweinste.in/"
+  speakerdeck: "ericqweinstein"
   slug: "eric-weinstein"
 - name: "Eric West"
   github: "edubkendo"


### PR DESCRIPTION
## Description

Populates **RubyKaigi 2016** (Kyoto International Conference Center, Kyoto, Sept 8–10, 2016) to parity with RubyKaigi 2014/2015, and enriches the existing talk data. The event previously had only `event.yml` and a stub `videos.yml` (which still carried a `# TODO:` header and had every talk stamped `2016-09-08` with no `track`).

**Added**
- `schedule.yml` — 3-day grid with **Main Hall** / **Room D** tracks; Door Open, Opening, Lunch/Afternoon breaks and Closing as schedule items
- `venue.yml` — Kyoto International Conference Center (Takaragaike, Sakyo-ku, Kyoto 606-0001)
- `sponsors.yml` — 48 sponsors across 10 tiers (Ruby / Name Badge / Platinum / Drinkup / Bento / Nursery / Gold / Mobile Application / RubyKaraoke / Silver), reusing existing sponsor slugs where they already exist
- `cfp.yml` — Call for Presentations (closed 2016-06-12)

**Changed — `videos.yml`**
- Reordered all 38 talks into running order with correct per-day dates and Main Hall / Room D `track` labels (the schedule maps talks to slots by file order)
- Added the two scheduled-but-unrecorded Day 2 Room D talks — "A Nil Device, a Lonely Operator, & a Voyage to the Void Star" (Eric Weinstein) and "Ruby Reference Manual 2016 Autumn" (Kenji Okimoto) — as `not_recorded` entries so the running-order count stays aligned with the grid (40 grid cells = 38 recorded + 2 not_recorded)
- Added the missing `language` on "Ruby Committers vs the World"
- Removed the `# TODO:` header and added `## Day N` separators

**Changed — `event.yml`**
- Corrected `coordinates` to the venue (35.0610839 / 135.7831473); they previously pointed near Kyoto Station

## Screenshots

**Schedule — Day 1** (talks placed in the correct Main Hall / Room D slots)
<img width="900" alt="rk2016-schedule-day1" src="https://raw.githubusercontent.com/yahonda/rubyevents/rk2016-screenshots/screenshots/02-schedule-day1.png" />

**Schedule — Day 2** (the two unrecorded Room D talks — "A Nil Device…" and "Ruby Reference Manual 2016 Autumn" — render in their correct slots)
<img width="900" alt="rk2016-schedule-day2" src="https://raw.githubusercontent.com/yahonda/rubyevents/rk2016-screenshots/screenshots/03-schedule-day2.png" />

**Venue** — Kyoto International Conference Center
<img width="900" alt="rk2016-venue" src="https://raw.githubusercontent.com/yahonda/rubyevents/rk2016-screenshots/screenshots/05-venue-map.png" />

**Sponsors** — 48 sponsors across 10 tiers
<img width="900" alt="rk2016-sponsors" src="https://raw.githubusercontent.com/yahonda/rubyevents/rk2016-screenshots/screenshots/06-sponsors.png" />

**CFP** — Call for Presentations (closed 2016-06-12)
<img width="900" alt="rk2016-cfp" src="https://raw.githubusercontent.com/yahonda/rubyevents/rk2016-screenshots/screenshots/07-cfp.png" />

## Testing Steps

Verified locally after `bin/rails db:seed:event_series[rubykaigi]`:

- `talks_in_running_order` count = 40, and `schedule.talk_offsets` = `[13, 15, 12]` (matches the per-day grid exactly)
- the two `not_recorded` talks resolve to running-order positions #20 and #22 — Day 2, Room D — keeping every other talk in its correct hall/slot
- `bin/dev`, then review:
  - [`/events/rubykaigi-2016`](https://www.rubyevents.org/events/rubykaigi-2016) (Overview)
  - `/events/rubykaigi-2016/schedule` — Sep 8 / 9 / 10, talks land in the correct Main Hall / Room D slots
  - `/events/rubykaigi-2016/venue`
  - `/events/rubykaigi-2016/sponsors`
  - `/events/rubykaigi-2016/cfp`
- `bundle exec yerba check` passes

## References

- Schedule / talks: https://rubykaigi.org/2016/schedule/
- Venue: https://rubykaigi.org/2016/venue/
- Sponsors: https://rubykaigi.org/2016/sponsors/
- CFP: https://cfp.rubykaigi.org/events/2016
- Follows the RubyKaigi 2015 (#1901) and 2014 (#1886) data sets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
