### PR TITLE
Introduce `ApplicationSchema`, validate with Yerba, drop `json_schemer`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,10 +67,7 @@ gem "minisky", "~> 0.4.0"
 gem "ruby_llm", "~> 1.15.0"
 
 # A simple and clean Ruby DSL for creating JSON schemas.
-gem "ruby_llm-schema", github: "crmne/ruby_llm-schema", branch: "main"
-
-# JSON Schema validator
-gem "json_schemer"
+gem "ruby_llm-schema", "~> 0.4.0"
 
 # YouTube V3 API client.
 gem "yt"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,13 +7,6 @@ GIT
       csv (>= 3.0.0)
 
 GIT
-  remote: https://github.com/crmne/ruby_llm-schema.git
-  revision: 2c5629ed0b13b28891b6f2ef7e4c6116164578b2
-  branch: main
-  specs:
-    ruby_llm-schema (0.3.1)
-
-GIT
   remote: https://github.com/joshleblanc/solid_queue.git
   revision: f7feb485de3021c72310ea8a4ed16ffaa132484a
   branch: async-mode
@@ -356,7 +349,6 @@ GEM
     gum (0.3.2-arm64-darwin)
     gum (0.3.2-x86_64-darwin)
     gum (0.3.2-x86_64-linux)
-    hana (1.3.7)
     hashdiff (1.2.1)
     hashie (5.1.0)
       logger
@@ -398,11 +390,6 @@ GEM
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
     json (2.20.0)
-    json_schemer (2.5.0)
-      bigdecimal
-      hana (~> 1.3)
-      regexp_parser (~> 2.0)
-      simpleidn (~> 0.2)
     jwt (3.2.0)
       base64
     kamal (2.7.0)
@@ -656,6 +643,7 @@ GEM
       marcel (~> 1)
       ruby_llm-schema (~> 0)
       zeitwerk (~> 2)
+    ruby_llm-schema (0.4.0)
     rubyzip (3.2.2)
     safely_block (0.5.0)
     securerandom (0.4.1)
@@ -672,7 +660,6 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
-    simpleidn (0.2.3)
     sitemap_generator (6.3.0)
       builder (~> 3.0)
     smart_properties (1.17.0)
@@ -840,7 +827,6 @@ DEPENDENCIES
   image_processing (~> 1.2)
   iso-639
   jbuilder
-  json_schemer
   kamal (= 2.7.0)
   listen (~> 3.5)
   mapkick-rb (~> 0.2.0)
@@ -869,7 +855,7 @@ DEPENDENCIES
   ruby-lsp-rails
   ruby-openai
   ruby_llm (~> 1.15.0)
-  ruby_llm-schema!
+  ruby_llm-schema (~> 0.4.0)
   selenium-webdriver
   simplecov
   sitemap_generator (~> 6.3)

--- a/app/models/static/event.rb
+++ b/app/models/static/event.rb
@@ -110,17 +110,15 @@ module Static
         data["featured_background"] = featured_background if featured_background.present?
         data["featured_color"] = featured_color if featured_color.present?
 
-        schema = JSON.parse(EventSchema.new.to_json_schema[:schema].to_json)
-        schemer = JSONSchemer.schema(schema)
-        errors = schemer.validate(data).to_a
+        errors = Yerba.parse(data.to_yaml).validate(EventSchema.json_schema)
 
         if errors.any?
-          error_messages = errors.map { |e| "#{e["error"]} at #{e["data_pointer"]}" }
+          error_messages = errors.map { |error| "#{error["message"]} at #{error["path"]}" }
           raise ArgumentError, "Validation failed: #{error_messages.join(", ")}"
         end
 
         FileUtils.mkdir_p(event_dir)
-        File.write(event_file, data.to_yaml)
+        File.write(event_file, content)
 
         videos_file = event_dir.join("videos.yml")
         File.write(videos_file, "[]\n") unless videos_file.exist?

--- a/app/models/static/event_series.rb
+++ b/app/models/static/event_series.rb
@@ -73,17 +73,15 @@ module Static
         data["youtube_channels"] = youtube_channels if youtube_channels.present?
         data["aliases"] = Array(aliases) if aliases.present?
 
-        schema = JSON.parse(SeriesSchema.new.to_json_schema[:schema].to_json)
-        schemer = JSONSchemer.schema(schema)
-        errors = schemer.validate(data).to_a
+        errors = Yerba.parse(data.to_yaml).validate(SeriesSchema.json_schema)
 
         if errors.any?
-          error_messages = errors.map { |e| "#{e["error"]} at #{e["data_pointer"]}" }
+          error_messages = errors.map { |error| "#{error["message"]} at #{error["path"]}" }
           raise ArgumentError, "Validation failed: #{error_messages.join(", ")}"
         end
 
         FileUtils.mkdir_p(series_dir)
-        File.write(series_file, data.to_yaml)
+        File.write(series_file, content)
 
         @slug_index = nil
         unload!

--- a/app/models/static/validators/schema.rb
+++ b/app/models/static/validators/schema.rb
@@ -31,26 +31,22 @@ module Static
         return [] unless applicable?
 
         document = Yerba.parse_file(@file_path.to_s)
-        raw_errors = build_schemer.validate(document.to_h).to_a
 
-        raw_errors.map do |e|
-          data_pointer = e["data_pointer"].gsub(/\A\//, "").tr("/", ".") || ""
-          location = document[data_pointer]&.location
+        document.validate(json_schema).map do |error|
+          message = [error["message"], error["path"].presence].compact.join(" at ")
+
           Static::Validators::Error.new(
-            "#{e["error"]} at #{e["data_pointer"]}",
+            message,
             file_path: @file_path,
-            line: location&.start_line || 1,
-            end_line: location&.end_line
+            line: error["line"] || 1
           )
         end
       end
 
       private
 
-      def build_schemer
-        schema_instance = @schema.is_a?(Class) ? @schema.new : @schema
-        schema_json = JSON.parse(schema_instance.to_json_schema[:schema].to_json)
-        JSONSchemer.schema(schema_json)
+      def json_schema
+        @schema.json_schema
       end
     end
   end

--- a/app/models/static/validators/schema_array.rb
+++ b/app/models/static/validators/schema_array.rb
@@ -3,11 +3,6 @@
 module Static
   module Validators
     class SchemaArray
-      def initialize(file_path:)
-        @file_path = file_path
-        @schema = PATH_TO_SCHEMA.find { |pattern, _| File.fnmatch?(pattern, @file_path, File::FNM_PATHNAME) }&.last
-      end
-
       PATH_TO_SCHEMA = {
         "**/cfp.yml" => CFPSchema,
         "**/featured_cities.yml" => FeaturedCitySchema,
@@ -17,6 +12,11 @@ module Static
         "**/transcripts.yml" => TranscriptSchema,
         "**/videos.yml" => VideoSchema
       }.freeze
+
+      def initialize(file_path:)
+        @file_path = file_path
+        @schema = PATH_TO_SCHEMA.find { |pattern, _| File.fnmatch?(pattern, @file_path, File::FNM_PATHNAME) }&.last
+      end
 
       def applicable?
         return false unless File.exist?(@file_path)
@@ -32,33 +32,22 @@ module Static
 
       def validate
         return [] unless applicable?
-        schemer = build_schemer
+
         document = Yerba.parse_file(@file_path)
-        errors = []
 
-        Array(document.to_h).each_with_index do |item, index|
-          schemer.validate(item).each do |error|
-            data_pointer = error["data_pointer"].tr("/", ".") || ""
-            location = document["[#{index}]#{data_pointer}"]&.location
-            error = Static::Validators::Error.new(
-              error["error"],
-              file_path: @file_path,
-              line: location&.start_line || 1,
-              end_line: location&.end_line
-            )
-            errors << error
-          end
+        document.validate(json_schema, selector: "[]").map do |error|
+          Static::Validators::Error.new(
+            error["message"],
+            file_path: @file_path,
+            line: error["line"] || 1
+          )
         end
-
-        errors
       end
 
       private
 
-      def build_schemer
-        schema_instance = @schema.is_a?(Class) ? @schema.new : @schema
-        schema_json = JSON.parse(schema_instance.to_json_schema[:schema].to_json)
-        JSONSchemer.schema(schema_json)
+      def json_schema
+        @schema.json_schema
       end
     end
   end

--- a/app/schemas/additional_resource_schema.rb
+++ b/app/schemas/additional_resource_schema.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AdditionalResourceSchema < RubyLLM::Schema
+class AdditionalResourceSchema < ApplicationSchema
   string :name, description: "Display name for the resource", required: true
   string :url, description: "URL to the resource", required: true
   string :type, description: "Type of resource", enum: ["write-up", "blog", "article", "source-code", "code", "repo", "github", "documentation", "docs", "presentation", "video", "podcast", "audio", "gem", "library", "transcript", "handout", "notes", "photos", "link", "book"], required: true

--- a/app/schemas/address_schema.rb
+++ b/app/schemas/address_schema.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddressSchema < RubyLLM::Schema
+class AddressSchema < ApplicationSchema
   string :street, description: "Street address"
   string :city, description: "City name"
   string :region, description: "State/Province/Region", required: false

--- a/app/schemas/alternative_recording_schema.rb
+++ b/app/schemas/alternative_recording_schema.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AlternativeRecordingSchema < RubyLLM::Schema
+class AlternativeRecordingSchema < ApplicationSchema
   string :title, required: false
   string :raw_title, required: false
   string :language, enum: Language.english_names, required: false

--- a/app/schemas/application_schema.rb
+++ b/app/schemas/application_schema.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class ApplicationSchema < RubyLLM::Schema
+  def self.schemas
+    Rails.autoloaders.main.eager_load_dir(Rails.root.join("app/schemas"))
+
+    registry.sort_by(&:name)
+  end
+
+  def self.inherited(schema)
+    super
+
+    ApplicationSchema.registry.reject! { |registered| registered.name == schema.name }
+    ApplicationSchema.registry << schema
+  end
+
+  def self.registry
+    @registry ||= []
+  end
+
+  def self.json_schema
+    new.to_json_schema[:schema].as_json
+  end
+
+  def self.export!
+    export_path.write(JSON.pretty_generate(json_schema))
+
+    export_path
+  end
+
+  def self.export_path
+    Rails.root.join("lib/schemas/#{name.underscore}.json")
+  end
+
+  def self.in_sync?
+    export_path.exist? && export_path.read == JSON.pretty_generate(json_schema)
+  end
+end

--- a/app/schemas/cfp_schema.rb
+++ b/app/schemas/cfp_schema.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CFPSchema < RubyLLM::Schema
+class CFPSchema < ApplicationSchema
   string :link, description: "CFP link", required: true
   string :name, description: 'Name for the CFP (default: "Call for Proposals")', required: false
   string :open_date, description: "CFP open date (YYYY-MM-DD format)", required: false

--- a/app/schemas/coordinates_schema.rb
+++ b/app/schemas/coordinates_schema.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CoordinatesSchema < RubyLLM::Schema
+class CoordinatesSchema < ApplicationSchema
   number :latitude, description: "Latitude coordinate"
   number :longitude, description: "Longitude coordinate"
 end

--- a/app/schemas/event_schema.rb
+++ b/app/schemas/event_schema.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class EventSchema < RubyLLM::Schema
+class EventSchema < ApplicationSchema
   string :id, description: "Unique identifier for the event (YouTube playlist ID or custom slug)"
 
   string :title, description: "Full name of the event (e.g., 'RailsConf 2024')"

--- a/app/schemas/featured_city_schema.rb
+++ b/app/schemas/featured_city_schema.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class FeaturedCitySchema < RubyLLM::Schema
+class FeaturedCitySchema < ApplicationSchema
   string :name, description: "Full city name"
   string :slug, description: "URL-friendly slug for the city"
   string :state_code, description: "State or province code", required: false

--- a/app/schemas/hotel_schema.rb
+++ b/app/schemas/hotel_schema.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class HotelSchema < RubyLLM::Schema
+class HotelSchema < ApplicationSchema
   string :name, description: "Hotel name"
   string :kind, description: "Type of hotel (e.g., 'Speaker Hotel')", required: false
   string :description, description: "Hotel description", required: false

--- a/app/schemas/involvement_schema.rb
+++ b/app/schemas/involvement_schema.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class InvolvementSchema < RubyLLM::Schema
+class InvolvementSchema < ApplicationSchema
   string :name, description: "Role or involvement type (e.g., 'Organizer', 'Program Committee member')"
   array :users, of: :string, description: "Person names involved in this role", required: false
   array :organisations, of: :string, description: "Organization names involved in this role", required: false

--- a/app/schemas/location_schema.rb
+++ b/app/schemas/location_schema.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class LocationSchema < RubyLLM::Schema
+class LocationSchema < ApplicationSchema
   string :name, description: "Location name"
   string :kind, description: "Type of location (e.g., 'After Party Location')"
   string :description, description: "Location description", required: false

--- a/app/schemas/maps_schema.rb
+++ b/app/schemas/maps_schema.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MapsSchema < RubyLLM::Schema
+class MapsSchema < ApplicationSchema
   string :google, description: "Google Maps URL", required: false
   string :apple, description: "Apple Maps URL", required: false
   string :openstreetmap, description: "OpenStreetMap URL", required: false

--- a/app/schemas/schedule_schema.rb
+++ b/app/schemas/schedule_schema.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ScheduleSchema < RubyLLM::Schema
+class ScheduleSchema < ApplicationSchema
   array :days, description: "List of conference days" do
     object do
       string :name, description: "Name of the day (e.g., 'Day 1', 'Workshop Day')"

--- a/app/schemas/series_schema.rb
+++ b/app/schemas/series_schema.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SeriesSchema < RubyLLM::Schema
+class SeriesSchema < ApplicationSchema
   string :name, description: "Name of the event series (e.g., 'RailsConf')"
   string :description, description: "Description of the event series", required: false
 

--- a/app/schemas/speaker_schema.rb
+++ b/app/schemas/speaker_schema.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SpeakerSchema < RubyLLM::Schema
+class SpeakerSchema < ApplicationSchema
   string :name, description: "Full name of the speaker", required: true
   string :slug, description: "URL-friendly slug for the speaker", required: true
   string :github, description: "GitHub username (not a URL)", required: true, pattern: "^([^/:\\s]+)?$"

--- a/app/schemas/sponsors_schema.rb
+++ b/app/schemas/sponsors_schema.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SponsorsSchema < RubyLLM::Schema
+class SponsorsSchema < ApplicationSchema
   array :tiers, description: "List of sponsorship tiers", required: true do
     object do
       string :name, description: "Sponsorship Tier Name", required: false

--- a/app/schemas/sub_video_schema.rb
+++ b/app/schemas/sub_video_schema.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SubVideoSchema < RubyLLM::Schema
+class SubVideoSchema < ApplicationSchema
   string :id, required: true
   string :old_id, description: "Previous id, kept so production records can be migrated to the new id on the next seed", required: false
   string :title, required: false

--- a/app/schemas/transcript_schema.rb
+++ b/app/schemas/transcript_schema.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class TranscriptSchema < RubyLLM::Schema
+class TranscriptSchema < ApplicationSchema
   string :video_id, description: "Video ID on the provider platform"
   array :cues, description: "Transcript cues" do
     object do

--- a/app/schemas/venue_schema.rb
+++ b/app/schemas/venue_schema.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class VenueSchema < RubyLLM::Schema
+class VenueSchema < ApplicationSchema
   string :name, description: "Name of the venue"
   string :description, description: "Description of the venue", required: false
   string :instructions, description: "Instructions for getting to the venue", required: false

--- a/app/schemas/video_schema.rb
+++ b/app/schemas/video_schema.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class VideoSchema < RubyLLM::Schema
+class VideoSchema < ApplicationSchema
   string :id, description: "Unique identifier for the video", required: true
   string :old_id, description: "Previous id, kept so production records can be migrated to the new id on the next seed", required: false
   string :title, description: "Title of the talk"

--- a/app/schemas/youtube_channel_schema.rb
+++ b/app/schemas/youtube_channel_schema.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class YouTubeChannelSchema < RubyLLM::Schema
+class YouTubeChannelSchema < ApplicationSchema
   string :id, description: "YouTube channel ID (starts with UC...)"
   string :name, description: "YouTube channel display name", required: true
   string :handle, description: "YouTube channel handle (e.g. @HelveticRuby)", required: true

--- a/lib/tasks/schema.rake
+++ b/lib/tasks/schema.rake
@@ -1,18 +1,8 @@
 namespace :schema do
-  # This is to support validating schemas using the YAML language tools
-  # aka the VS Code YAML extension
   desc "Export all schemas as JSON Schemas to lib/schemas"
   task export: :environment do
-    require "fileutils"
-
-    schema_files = Dir.glob(Rails.root.join("app/schemas/*_schema.rb"))
-    schema_files.each do |file|
-      base = File.basename(file, ".rb")
-      schema_class = base.camelize.constantize
-      json_schema_path = Rails.root.join("lib/schemas/#{base}.json")
-      json_schema = JSON.pretty_generate(schema_class.new.to_json_schema[:schema])
-      File.write(json_schema_path, json_schema)
-      puts "Exported #{schema_class} to #{json_schema_path}"
+    ApplicationSchema.schemas.each do |schema_class|
+      puts "Exported #{schema_class} to #{schema_class.export!}"
     end
   end
 end

--- a/test/lib/schema_export_test.rb
+++ b/test/lib/schema_export_test.rb
@@ -2,18 +2,9 @@ require "test_helper"
 require "json"
 
 class SchemaExportTest < ActiveSupport::TestCase
-  SCHEMA_DIR = Rails.root.join("app/schemas")
-  JSON_DIR = Rails.root.join("lib/schemas")
-
-  Dir.glob(SCHEMA_DIR.join("*_schema.rb")).each do |schema_file|
-    base = File.basename(schema_file, ".rb")
-    test "#{base} generates matching JSON schema" do
-      schema_class = base.camelize.constantize
-      generated = JSON.pretty_generate(schema_class.new.to_json_schema[:schema])
-      json_path = JSON_DIR.join("#{base}.json")
-      assert File.exist?(json_path), "Missing JSON schema for #{base}. Run `bin/rails schema:export` to generate it."
-      expected = File.read(json_path)
-      assert_equal expected, generated, "Schema for #{base} is out of date. Run `bin/rails schema:export` to update it."
+  ApplicationSchema.schemas.each do |schema_class|
+    test "#{schema_class.name.underscore} is in sync with its exported JSON schema" do
+      assert schema_class.in_sync?, "The JSON schema for #{schema_class} is missing or out of date. Run `bin/rails schema:export` to update it."
     end
   end
 end

--- a/test/models/static/validators/schema_array_test.rb
+++ b/test/models/static/validators/schema_array_test.rb
@@ -14,7 +14,7 @@ class Static::Validators::SchemaArrayTest < ActiveSupport::TestCase
   test "returns errors for invalid items" do
     with_temp_cfp_yaml([{"name" => "CFP without required link"}].to_yaml) do |path|
       validator = Static::Validators::SchemaArray.new(file_path: path)
-      assert_match(/object at root is missing required properties: link/, validator.validate.first.as_error)
+      assert_match(/"link" is a required property/, validator.validate.first.as_error)
     end
   end
 

--- a/test/models/static/validators/schema_test.rb
+++ b/test/models/static/validators/schema_test.rb
@@ -36,7 +36,7 @@ class Static::Validators::SchemaTest < ActiveSupport::TestCase
     yaml = {"name" => "Bad Event"}.to_yaml
     with_temp_event_yaml(yaml) do |path|
       validator = Static::Validators::Schema.new(file_path: path)
-      assert_match(/object property at `\/name` is a disallowed additional property at \/name/, validator.errors.first.as_error)
+      assert_match(/"id" is a required property/, validator.errors.first.as_error)
     end
   end
 


### PR DESCRIPTION
### Description

This pull request makes all schemas inherit from `ApplicationSchema`, which self-registers its subclasses and provides `.schemas`, `.json_schema`, `.export_path`, `.export!`, and `.in_sync?`. 

The `Schema` and `SchemaArray` validators and the `Static::Event`/`EventSeries` create paths validate through  `Yerba::Document#validate`, which resolves error line numbers itself, so the `json_schemer` gem is no longer needed.

