### PR TITLE
Parallelize `validate:*` tasks and pass parsed document around

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -199,6 +199,9 @@ gem "gems"
 # A glamorous CLI toolkit for Ruby
 gem "gum", "~> 0.3.1"
 
+# Run blocks in parallel processes
+gem "parallel"
+
 # Regex pattern searching in files
 gem "grepfruit"
 

--- a/Gemfile
+++ b/Gemfile
@@ -223,7 +223,7 @@ gem "fastimage", "~> 2.4"
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "bundler-audit", require: false
-  gem "debug", platforms: %i[mri windows]
+  gem "debug", platforms: %i[mri windows], require: "debug/prelude"
   gem "minitest-difftastic", "~> 0.2"
   gem "minitest-mock", "~> 5.27"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -841,6 +841,7 @@ DEPENDENCIES
   openssl
   ostruct
   pagy
+  parallel
   propshaft
   puma
   rack-mini-profiler

--- a/app/models/static/speakers_file.rb
+++ b/app/models/static/speakers_file.rb
@@ -17,10 +17,10 @@ module Static
 
     class StaleFileError < StandardError; end
 
-    def initialize(path = Rails.root.join(SPEAKERS_PATH).to_s)
+    def initialize(path = Rails.root.join(SPEAKERS_PATH).to_s, document: nil)
       @path = path
       @loaded_mtime = File.mtime(path)
-      @document = Yerba.parse_file(path)
+      @document = document || Yerba.parse_file(path)
     end
 
     def count

--- a/app/models/static/validators/asset_dimensions.rb
+++ b/app/models/static/validators/asset_dimensions.rb
@@ -5,7 +5,7 @@ module Static
     class AssetDimensions
       PATTERNS = ["**/*.webp"].freeze
 
-      def initialize(file_path:)
+      def initialize(file_path:, document: nil)
         @file_path = file_path.to_s
       end
 

--- a/app/models/static/validators/colors_have_assets.rb
+++ b/app/models/static/validators/colors_have_assets.rb
@@ -11,8 +11,9 @@ module Static
         "featured_color" => "featured.webp"
       }.freeze
 
-      def initialize(file_path:)
+      def initialize(file_path:, document: nil)
         @file_path = file_path
+        @document = document
       end
 
       def applicable?
@@ -30,7 +31,6 @@ module Static
       def validate
         return [] unless applicable?
 
-        document = Yerba.parse_file(@file_path)
         path_parts = @file_path.split("/")
         series_slug = path_parts[-3]
         event_slug = path_parts[-2]
@@ -52,6 +52,12 @@ module Static
               end_line: location&.end_line
             )
           end.compact
+      end
+
+      private
+
+      def document
+        @document ||= Yerba.parse_file(@file_path.to_s)
       end
     end
   end

--- a/app/models/static/validators/duplicate_youtube_channels.rb
+++ b/app/models/static/validators/duplicate_youtube_channels.rb
@@ -3,8 +3,9 @@
 module Static
   module Validators
     class DuplicateYouTubeChannels
-      def initialize(file_path:)
+      def initialize(file_path:, document: nil)
         @file_path = file_path
+        @document = document
       end
 
       PATTERNS = [
@@ -26,7 +27,6 @@ module Static
       def validate
         return [] unless applicable?
 
-        document = Yerba.parse_file(@file_path)
         event_channels = Array(document.value_at("youtube_channels"))
         return [] if event_channels.empty?
 
@@ -52,6 +52,12 @@ module Static
         end
 
         errors
+      end
+
+      private
+
+      def document
+        @document ||= Yerba.parse_file(@file_path.to_s)
       end
     end
   end

--- a/app/models/static/validators/event_city_names.rb
+++ b/app/models/static/validators/event_city_names.rb
@@ -3,8 +3,9 @@
 module Static
   module Validators
     class EventCityNames
-      def initialize(file_path:)
+      def initialize(file_path:, document: nil)
         @file_path = file_path
+        @document = document
       end
 
       PATTERNS = [
@@ -26,7 +27,6 @@ module Static
       def validate
         return [] unless applicable?
 
-        document = Yerba.parse_file(@file_path)
         location = document["location"]
 
         city_part = location&.value&.split(",")&.first&.strip
@@ -45,6 +45,12 @@ module Static
             end_line: location&.location&.end_line
           )
         ]
+      end
+
+      private
+
+      def document
+        @document ||= Yerba.parse_file(@file_path.to_s)
       end
     end
   end

--- a/app/models/static/validators/event_dates.rb
+++ b/app/models/static/validators/event_dates.rb
@@ -3,8 +3,9 @@
 module Static
   module Validators
     class EventDates
-      def initialize(file_path:)
+      def initialize(file_path:, document: nil)
         @file_path = file_path
+        @document = document
       end
 
       PATTERNS = [
@@ -26,7 +27,6 @@ module Static
       def validate
         return [] unless applicable?
 
-        document = Yerba.parse_file(@file_path)
         return [] if document["kind"] == "meetup"
 
         errors = []
@@ -52,6 +52,12 @@ module Static
         end
 
         errors
+      end
+
+      private
+
+      def document
+        @document ||= Yerba.parse_file(@file_path.to_s)
       end
     end
   end

--- a/app/models/static/validators/event_recordings_published_date.rb
+++ b/app/models/static/validators/event_recordings_published_date.rb
@@ -16,8 +16,9 @@ module Static
         sorted[[rank - 1, 0].max]
       end
 
-      def initialize(file_path:)
+      def initialize(file_path:, document: nil)
         @file_path = file_path
+        @document = document
       end
 
       PATTERNS = [
@@ -39,7 +40,7 @@ module Static
       def validate
         return [] unless applicable?
 
-        @event_document = Yerba.parse_file(@file_path)
+        @event_document = @document || Yerba.parse_file(@file_path)
 
         return validate_absence_for_meetup if meetup?
 

--- a/app/models/static/validators/redundant_thumbnails.rb
+++ b/app/models/static/validators/redundant_thumbnails.rb
@@ -6,7 +6,7 @@ module Static
       PATTERNS = ["**/thumbnails/**/*.webp"].freeze
       REMOTE_THUMBNAIL_PROVIDERS = %w[youtube vimeo].freeze
 
-      def initialize(file_path:)
+      def initialize(file_path:, document: nil)
         @file_path = file_path.to_s
       end
 
@@ -60,6 +60,10 @@ module Static
           register.call(video, nil)
           video.talks.each { |talk| register.call(talk, video.id) }
         end
+      end
+
+      def self.warmup
+        talk_lookup
       end
 
       def self.reset!

--- a/app/models/static/validators/schema.rb
+++ b/app/models/static/validators/schema.rb
@@ -3,8 +3,9 @@
 module Static
   module Validators
     class Schema
-      def initialize(file_path:, selector: nil)
+      def initialize(file_path:, selector: nil, document: nil)
         @file_path = file_path
+        @document = document
         @schema = ApplicationSchema.schemas.find { |schema| schema.matches?(@file_path) }
         @selector = selector || @schema&.data_file_selector
       end
@@ -20,8 +21,6 @@ module Static
       def validate
         return [] unless applicable?
 
-        document = Yerba.parse_file(@file_path.to_s)
-
         document.validate(@schema.json_schema, selector: @selector).map do |error|
           Static::Validators::Error.new(
             message_for(error),
@@ -32,6 +31,10 @@ module Static
       end
 
       private
+
+      def document
+        @document ||= Yerba.parse_file(@file_path.to_s)
+      end
 
       def message_for(error)
         message = [error["message"], error["path"].presence].compact.join(" at ")

--- a/app/models/static/validators/speaker_exists.rb
+++ b/app/models/static/validators/speaker_exists.rb
@@ -5,7 +5,7 @@ module Static
     class SpeakerExists
       PATTERNS = ["**/videos.yml"].freeze
 
-      def initialize(file_path:)
+      def initialize(file_path:, document: nil)
         @file_path = file_path.to_s.sub("#{Rails.root}/", "")
       end
 
@@ -31,6 +31,10 @@ module Static
             line: scalar.line || 1
           )
         end
+      end
+
+      def self.warmup
+        errors
       end
 
       def self.reset!

--- a/app/models/static/validators/speakers_or_talks.rb
+++ b/app/models/static/validators/speakers_or_talks.rb
@@ -7,8 +7,9 @@ module Static
         "**/videos.yml"
       ].freeze
 
-      def initialize(file_path:)
+      def initialize(file_path:, document: nil)
         @file_path = file_path
+        @document = document
       end
 
       def applicable?
@@ -26,7 +27,6 @@ module Static
       def validate
         return [] unless applicable?
 
-        document = Yerba.parse_file(@file_path)
         return [] unless document.root
 
         document.root.each.flat_map do |video|
@@ -37,6 +37,10 @@ module Static
       end
 
       private
+
+      def document
+        @document ||= Yerba.parse_file(@file_path.to_s)
+      end
 
       def talk_errors(node)
         has_talks = node.key?("talks")

--- a/app/models/static/validators/talk_dates.rb
+++ b/app/models/static/validators/talk_dates.rb
@@ -9,8 +9,9 @@ module Static
 
       IGNORE_PUBLISHED_AT_BEFORE_DATE = "validator:disable published_at_before_date"
 
-      def initialize(file_path:)
+      def initialize(file_path:, document: nil)
         @file_path = file_path
+        @document = document
       end
 
       def applicable?
@@ -28,8 +29,6 @@ module Static
       def validate
         return [] unless applicable?
 
-        document = Yerba.parse_file(@file_path)
-
         return [] unless document.root
 
         @start_date, @end_date, @timezone, pre_date = event_context
@@ -43,6 +42,10 @@ module Static
       end
 
       private
+
+      def document
+        @document ||= Yerba.parse_file(@file_path.to_s)
+      end
 
       def event_context
         event_path = File.join(File.dirname(@file_path), "event.yml")

--- a/app/models/static/validators/talk_id.rb
+++ b/app/models/static/validators/talk_id.rb
@@ -7,8 +7,9 @@ module Static
         "**/videos.yml"
       ].freeze
 
-      def initialize(file_path:)
+      def initialize(file_path:, document: nil)
         @file_path = file_path
+        @document = document
       end
 
       def applicable?

--- a/app/models/static/validators/talk_kind.rb
+++ b/app/models/static/validators/talk_kind.rb
@@ -7,8 +7,9 @@ module Static
         "**/videos.yml"
       ].freeze
 
-      def initialize(file_path:)
+      def initialize(file_path:, document: nil)
         @file_path = file_path
+        @document = document
       end
 
       def applicable?
@@ -26,7 +27,6 @@ module Static
       def validate
         return [] unless applicable?
 
-        document = Yerba.parse_file(@file_path)
         return [] unless document.root
 
         document.root.each.flat_map do |video|
@@ -39,6 +39,10 @@ module Static
       private
 
       DEFAULT_KIND = "talk"
+
+      def document
+        @document ||= Yerba.parse_file(@file_path.to_s)
+      end
 
       def short?(node)
         duration = CueDuration.duration_in_seconds(node)

--- a/app/models/static/validators/talk_published_at.rb
+++ b/app/models/static/validators/talk_published_at.rb
@@ -7,8 +7,9 @@ module Static
         "**/videos.yml"
       ].freeze
 
-      def initialize(file_path:)
+      def initialize(file_path:, document: nil)
         @file_path = file_path
+        @document = document
       end
 
       def applicable?
@@ -26,7 +27,6 @@ module Static
       def validate
         return [] unless applicable?
 
-        document = Yerba.parse_file(@file_path)
         return [] unless document.root
 
         document.root.each.flat_map do |video|
@@ -39,6 +39,10 @@ module Static
       private
 
       PROVIDERS_WITHOUT_PUBLISHED_AT = (Talk::UNPUBLISHED_PROVIDERS + ["children", "parent"]).freeze
+
+      def document
+        @document ||= Yerba.parse_file(@file_path.to_s)
+      end
 
       def talk_errors(node)
         provider = node.value_at("video_provider")

--- a/app/models/static/validators/talk_renames.rb
+++ b/app/models/static/validators/talk_renames.rb
@@ -9,9 +9,10 @@ module Static
         "**/videos.yml"
       ].freeze
 
-      def initialize(file_path:, baseline: nil)
+      def initialize(file_path:, baseline: nil, document: nil)
         @file_path = file_path
         @baseline = baseline
+        @document = document
       end
 
       def applicable?
@@ -33,7 +34,7 @@ module Static
       end
 
       def current
-        @current ||= Static::VideosFile.new(@file_path)
+        @current ||= Static::VideosFile.new(@file_path, document: @document)
       end
 
       def renamed_talks

--- a/app/models/static/validators/talk_short_kind.rb
+++ b/app/models/static/validators/talk_short_kind.rb
@@ -9,8 +9,9 @@ module Static
 
       SHORT_DURATION_THRESHOLD = 10.minutes.to_i
 
-      def initialize(file_path:)
+      def initialize(file_path:, document: nil)
         @file_path = file_path
+        @document = document
       end
 
       def applicable?
@@ -28,7 +29,6 @@ module Static
       def validate
         return [] unless applicable?
 
-        document = Yerba.parse_file(@file_path)
         return [] unless document.root
 
         document.root.each.flat_map do |video|
@@ -39,6 +39,10 @@ module Static
       end
 
       private
+
+      def document
+        @document ||= Yerba.parse_file(@file_path.to_s)
+      end
 
       def talk_errors(node)
         return [] unless node.value_at("kind").to_s.strip.empty?

--- a/app/models/static/validators/unique_speaker_fields.rb
+++ b/app/models/static/validators/unique_speaker_fields.rb
@@ -3,8 +3,9 @@
 module Static
   module Validators
     class UniqueSpeakerFields
-      def initialize(file_path:)
+      def initialize(file_path:, document: nil)
         @file_path = file_path
+        @document = document
       end
 
       PATTERNS = [
@@ -35,7 +36,7 @@ module Static
       def validate
         return [] unless applicable?
 
-        speakers = Static::SpeakersFile.new(@file_path)
+        speakers = Static::SpeakersFile.new(@file_path, document: @document)
         errors = []
 
         UNIQUE_FIELDS.each do |field|

--- a/app/models/static/validators/unique_speakers.rb
+++ b/app/models/static/validators/unique_speakers.rb
@@ -3,8 +3,9 @@
 module Static
   module Validators
     class UniqueSpeakers
-      def initialize(file_path:)
+      def initialize(file_path:, document: nil)
         @file_path = file_path
+        @document = document
       end
 
       PATTERNS = [
@@ -26,7 +27,7 @@ module Static
       def validate
         return [] unless applicable?
 
-        speakers = Static::SpeakersFile.new(@file_path)
+        speakers = Static::SpeakersFile.new(@file_path, document: @document)
         errors = []
 
         errors += validate_same_name_duplicates(speakers)

--- a/app/models/static/validators/unique_talk_ids.rb
+++ b/app/models/static/validators/unique_talk_ids.rb
@@ -7,7 +7,7 @@ module Static
 
       KEYS = %w[id old_id].freeze
 
-      def initialize(file_path:)
+      def initialize(file_path:, document: nil)
         @file_path = file_path.to_s.sub("#{Rails.root}/", "")
       end
 
@@ -27,6 +27,10 @@ module Static
 
       def self.errors
         @errors ||= duplicate_errors(files: Static::VideosFile.all)
+      end
+
+      def self.warmup
+        errors
       end
 
       def self.reset!

--- a/lib/tasks/validate.rake
+++ b/lib/tasks/validate.rake
@@ -5,19 +5,35 @@ require "parallel"
 
 namespace :validate do
   def collect_validator_errors(files:, validators:)
+    return {} if files.empty? || validators.empty?
+
+    validators.each { |validator_class| validator_class.warmup if validator_class.respond_to?(:warmup) }
+
     worker_count = [files.size, Parallel.processor_count].min
 
     Parallel.map(files, in_processes: worker_count) do |file|
-      validators.flat_map { |validator_class| validator_class.new(file_path: file).errors }
+      document = parse_document(file)
+
+      validators.flat_map { |validator_class| validator_class.new(file_path: file, document: document).errors }
     end.flatten.group_by(&:file_path)
+  end
+
+  def parse_document(file)
+    return nil unless file.to_s.end_with?(".yml")
+
+    Yerba.parse_file(file)
+  rescue
+    nil
   end
 
   def print_validator_errors(file_errors, warning_only: false)
     file_errors.each do |file, errors|
       puts Gum.style(file, foreground: (warning_only ? "3" : "1"))
+
       errors.each do |error|
         puts warning_only ? error.as_warning : error.as_error
       end
+
       puts
     end
   end
@@ -116,8 +132,7 @@ namespace :validate do
     exit 1 if validate_speakers_in_videos.any?
   end
 
-  desc "Validate that all Static::Video records have unique ids"
-  task unique_video_ids: :environment do
+  def validate_unique_video_ids
     all_ids = []
 
     Static::Video.all.each do |video|
@@ -137,10 +152,17 @@ namespace :validate do
 
       puts
 
-      exit 1
+      false
     else
       puts Gum.style("✓ All video ids are unique", foreground: "2")
+
+      true
     end
+  end
+
+  desc "Validate that all Static::Video records have unique ids"
+  task unique_video_ids: :environment do
+    exit 1 unless validate_unique_video_ids
   end
 
   def check_city_alias(city_name, field, path, alias_to_canonical, issues)
@@ -253,7 +275,7 @@ namespace :validate do
 
   desc "Warn when event assets do not match expected dimensions"
   task event_assets: :environment do
-    exit 1 unless validate_event_assets.any?
+    exit 1 if validate_event_assets.any?
   end
 
   def validate_thumbnails
@@ -274,107 +296,92 @@ namespace :validate do
   desc "Validate all city-related data"
   task cities: [:event_city_names, :video_city_names]
 
-  desc "Validate all YAML files"
-  task all: :environment do
-    results = []
+  def run_yerba_check
+    output = `bundle exec yerba check 2>&1`
 
-    puts Gum.style("Running yerba check (schemas, formatting, uniqueness)", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
-    yerba_output = `bundle exec yerba check 2>&1`
-    yerba_passed = $?.success?
-    results << yerba_passed
-
-    if yerba_passed
+    if $?.success?
       puts Gum.style("✓ All Yerbafile rules passed", foreground: "2")
-    else
-      puts yerba_output
 
-      if yerba_output.include?("published_at")
+      true
+    else
+      puts output
+
+      if output.include?("published_at")
         puts Gum.style("Hint: Run 'rails youtube:fetch_published_at' to fetch missing published_at dates from YouTube", foreground: "3")
         puts
       end
+
+      false
     end
+  end
 
-    puts Gum.style("Validating event.yml files", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
-    results << validate_event_files.none?
-
-    puts Gum.style("Validating venue.yml files", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
-    results << validate_venue_files.none?
-
-    puts Gum.style("Validating speakers.yml file", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
-    results << validate_speakers_file.none?
-
-    puts Gum.style("Validating videos.yml files", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
-    results << validate_video_files.none?
-
-    puts Gum.style("Validating speakers.yml is in sync", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
-    speakers = Static::SpeakersFile.new
-    orphaned = speakers.orphaned_speakers
+  def validate_speakers_in_sync
+    orphaned = Static::SpeakersFile.new.orphaned_speakers
 
     if orphaned.empty?
       puts Gum.style("✓ speakers.yml is in sync", foreground: "2")
-      results << true
-    else
-      if orphaned.any?
-        puts Gum.style("#{orphaned.length} orphaned speakers in speakers.yml:", foreground: "1")
-        orphaned.sort.each { |name| puts Gum.style("  ❌ #{name}", foreground: "1") }
-        puts
-      end
 
+      true
+    else
+      puts Gum.style("#{orphaned.length} orphaned speakers in speakers.yml:", foreground: "1")
+      orphaned.sort.each { |name| puts Gum.style("  ❌ #{name}", foreground: "1") }
+      puts
       puts Gum.style("Run: rails speakers_file:sync", foreground: "3")
 
-      results << false
+      false
     end
+  end
 
-    puts Gum.style("Validating unique video ids", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
+  desc "Validate all YAML files"
+  task all: :environment do
+    sections = {
+      "Running yerba check (schemas, formatting, uniqueness)" => -> { run_yerba_check },
+      "Validating videos.yml files" => -> { validate_video_files.none? },
+      "Validating event.yml files" => -> { validate_event_files.none? },
+      "Validating venue.yml files" => -> { validate_venue_files.none? },
+      "Validating speakers.yml file" => -> { validate_speakers_file.none? },
+      "Validating speakers.yml is in sync" => -> { validate_speakers_in_sync },
+      "Validating unique video ids" => -> { validate_unique_video_ids },
+      "Validating SpeakerDeck slides URLs" => -> { validate_speakerdeck_urls },
+      "Validating SpeakerDeck handles" => -> { validate_speakerdeck_handles },
+      "Validating video city names" => -> { validate_video_city_names },
+      "Validating event asset dimensions" => -> { validate_event_assets.none? },
+      "Validating redundant thumbnails" => -> { validate_thumbnails.none? }
+    }
 
-    all_ids = []
+    print_mutex = Mutex.new
 
-    Static::Video.all.each do |video|
-      all_ids << video.id
-      video.talks.each { |talk| all_ids << talk.id }
-    end
-
-    duplicates = all_ids.tally.select { |_id, count| count > 1 }
-
-    if duplicates.any?
-      puts Gum.style("Duplicate video ids found (#{duplicates.count}):", foreground: "1")
-      puts
-
-      duplicates.each do |id, count|
-        puts Gum.style("❌ #{id} (#{count} occurrences)", foreground: "1")
+    on_finish = ->(title, _index, result) {
+      print_mutex.synchronize do
+        puts Gum.style(title, border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
+        puts result[1]
       end
+    }
 
-      puts
+    color = $stdout.tty?
 
-      results << false
-    else
-      puts Gum.style("✓ All video ids are unique", foreground: "2")
+    results = Parallel.map(sections.keys, in_processes: sections.size, finish: on_finish) do |title|
+      ENV["CLICOLOR_FORCE"] = "1" if color
 
-      results << true
+      captured = StringIO.new
+      original, $stdout = $stdout, captured
+
+      begin
+        [sections.fetch(title).call, captured.string]
+      ensure
+        $stdout = original
+      end
     end
 
-    puts Gum.style("Validating SpeakerDeck slides URLs", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
-    results << validate_speakerdeck_urls
-
-    puts Gum.style("Validating SpeakerDeck handles", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
-    results << validate_speakerdeck_handles
-
-    puts Gum.style("Validating video city names", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
-    results << validate_video_city_names
-
-    puts Gum.style("Validating event asset dimensions", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
-    results << validate_event_assets.none?
-
-    puts Gum.style("Validating redundant thumbnails", border: "rounded", padding: "0 2", margin: "1 0", border_foreground: "5")
-    results << validate_thumbnails.none?
+    passed = results.all? { |section_passed, _output| section_passed }
 
     puts
-    if results.all?
+    if passed
       puts Gum.style("All validations passed!", border: "rounded", padding: "0 2", foreground: "2", border_foreground: "2")
     else
       puts Gum.style("Some validations failed", border: "rounded", padding: "0 2", foreground: "1", border_foreground: "1")
     end
 
-    exit 1 unless results.all?
+    exit 1 unless passed
   end
 end

--- a/lib/tasks/validate.rake
+++ b/lib/tasks/validate.rake
@@ -1,17 +1,15 @@
 # frozen_string_literal: true
 
 require "gum"
+require "parallel"
 
 namespace :validate do
   def collect_validator_errors(files:, validators:)
-    files.each_with_object(Hash.new { |h, k| h[k] = [] }) do |file, file_errors|
-      validators.each do |validator_class|
-        validator = validator_class.new(file_path: file)
-        validator.errors.each do |error|
-          file_errors[error.file_path] << error
-        end
-      end
-    end
+    worker_count = [files.size, Parallel.processor_count].min
+
+    Parallel.map(files, in_processes: worker_count) do |file|
+      validators.flat_map { |validator_class| validator_class.new(file_path: file).errors }
+    end.flatten.group_by(&:file_path)
   end
 
   def print_validator_errors(file_errors, warning_only: false)
@@ -92,7 +90,8 @@ namespace :validate do
     )
   end
 
-  desc "Validate videos.yml files" do
+  desc "Validate videos.yml files"
+  task videos: :environment do
     exit 1 if validate_video_files.any?
   end
 


### PR DESCRIPTION
### Description

After https://github.com/rubyevents/rubyevents/pull/1878, the `validate:all` rake task regressed quite a bit to like ~`1m46s` for a single run.

This pull request runs the validations in parallel and brings it back down to ~`40s`.

What changed:

- `validate:all` sections run concurrently in forked processes (via the `parallel` gem). Output is captured per section and printed as each one finishes, so results stream in as they complete instead of after a long silence.
- Per-file validation is parallelized, `collect_validator_errors` fans files out across one worker per core.
- Each file is parsed once, not once per validator. All validators accept a shared `document:`  so the 10+ `videos.yml` validators no longer re-parse the same file every time.