### PR TITLE
Either name or organisations should be present

### DIFF
--- a/app/models/static/validators/involvement_role_name.rb
+++ b/app/models/static/validators/involvement_role_name.rb
@@ -40,7 +40,7 @@ module Static
 
           if name.blank? && involvement["organisations"].blank?
             errors << Static::Validators::Error.new(
-              "'#{name || 'Involvement'}' must have at least one name or organisation",
+              "'#{name || "Involvement"}' must have at least one name or organisation",
               file_path: @file_path,
               line: 1
             )

--- a/app/models/static/validators/involvement_role_name.rb
+++ b/app/models/static/validators/involvement_role_name.rb
@@ -37,6 +37,14 @@ module Static
               line: 1
             )
           end
+
+          if name.blank? && involvement["organisations"].blank?
+            errors << Static::Validators::Error.new(
+              "'#{name || 'Involvement'}' must have at least one name or organisation",
+              file_path: @file_path,
+              line: 1
+            )
+          end
         end
 
         errors

--- a/test/models/static/validators/involvement_role_name_test.rb
+++ b/test/models/static/validators/involvement_role_name_test.rb
@@ -71,6 +71,28 @@ class Static::Validators::InvolvementRoleNameTest < ActiveSupport::TestCase
     end
   end
 
+  test "does not return errors when names present and organisations are not present" do
+    with_temp_involvements([
+      {
+        "name" => "Organizer"
+      }
+    ]) do |path|
+
+      assert_empty Static::Validators::InvolvementRoleName.new(file_path: path).errors
+    end
+  end
+
+  test "does not return errors when organisations present and name is not present" do
+    with_temp_involvements([
+      {
+        "organisations" => ["rails"]
+      }
+    ]) do |path|
+
+      assert_empty Static::Validators::InvolvementRoleName.new(file_path: path).errors
+    end
+  end
+
   private
 
   def with_temp_involvements(involvements)

--- a/test/models/static/validators/involvement_role_name_test.rb
+++ b/test/models/static/validators/involvement_role_name_test.rb
@@ -77,7 +77,6 @@ class Static::Validators::InvolvementRoleNameTest < ActiveSupport::TestCase
         "name" => "Organizer"
       }
     ]) do |path|
-
       assert_empty Static::Validators::InvolvementRoleName.new(file_path: path).errors
     end
   end
@@ -88,7 +87,6 @@ class Static::Validators::InvolvementRoleNameTest < ActiveSupport::TestCase
         "organisations" => ["rails"]
       }
     ]) do |path|
-
       assert_empty Static::Validators::InvolvementRoleName.new(file_path: path).errors
     end
   end

--- a/test/models/static/validators/involvement_role_name_test.rb
+++ b/test/models/static/validators/involvement_role_name_test.rb
@@ -46,6 +46,31 @@ class Static::Validators::InvolvementRoleNameTest < ActiveSupport::TestCase
     end
   end
 
+  test "does not return errors when both names and organisations are present" do
+    with_temp_involvements([
+      {
+        "name" => "Organizer",
+        "users" => ["Amanda Perino"],
+        "organisations" => ["Rails Foundation"]
+      }
+    ]) do |path|
+      assert_empty Static::Validators::InvolvementRoleName.new(file_path: path).errors
+    end
+  end
+
+  test "returns an error when neither names nor organisations are present" do
+    with_temp_involvements([
+      {
+        "name" => ""
+      }
+    ]) do |path|
+      errors = Static::Validators::InvolvementRoleName.new(file_path: path).errors
+
+      assert_equal 1, errors.size
+      assert_match "must have at least one name or organisation", errors.first.message
+    end
+  end
+
   private
 
   def with_temp_involvements(involvements)


### PR DESCRIPTION
## Description
Added validation inside validator for name or organisation

## Screenshots
<img width="723" height="99" alt="image" src="https://github.com/user-attachments/assets/18cdd31c-630c-4157-9477-9aeab14ed918" />

## Testing Steps
remove name or organisations from invoment.yml
run  bin/rails validate:involvements

## References
https://github.com/rubyevents/rubyevents/issues/1880
