### PR TITLE
Add `Static::Validators::SeriesDefaultColors` validator

### DIFF
--- a/app/models/static/validators/colors_have_assets.rb
+++ b/app/models/static/validators/colors_have_assets.rb
@@ -46,7 +46,7 @@ module Static
             location = document[field].location
 
             Static::Validators::Error.new(
-              "Color field configured but asset '#{asset}' not found in #{asset_dir} or #{default_asset_dir}",
+              "#{field} is defined but '#{asset}' exists neither in #{asset_dir} nor in #{default_asset_dir}, events falling back to the global default #{asset} must not define brand colors",
               file_path: @file_path,
               line: location&.start_line || 1,
               end_line: location&.end_line

--- a/app/models/static/validators/series_default_colors.rb
+++ b/app/models/static/validators/series_default_colors.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+module Static
+  module Validators
+    class SeriesDefaultColors
+      PATTERNS = ["**/event.yml"].freeze
+
+      FIELD_ASSET_MAP = {
+        "banner_background" => "banner.webp",
+        "featured_background" => "featured.webp",
+        "featured_color" => "featured.webp"
+      }.freeze
+
+      def initialize(file_path:, document: nil)
+        @file_path = file_path.to_s.sub("#{Rails.root}/", "")
+      end
+
+      def applicable?
+        return false unless File.exist?(@file_path)
+
+        PATTERNS.any? do |pattern|
+          File.fnmatch?(pattern, @file_path, File::FNM_PATHNAME)
+        end
+      end
+
+      def errors
+        return [] unless applicable?
+
+        self.class.errors.select { |error| error.file_path == @file_path }
+      end
+
+      def self.errors
+        @errors ||= mismatch_errors(
+          data_root: Rails.root.join("data").to_s,
+          assets_root: Rails.root.join("app", "assets", "images", "events").to_s
+        )
+      end
+
+      def self.warmup
+        errors
+      end
+
+      def self.reset!
+        @errors = nil
+      end
+
+      def self.mismatch_errors(data_root:, assets_root:)
+        Dir.glob(File.join(assets_root, "*", "default")).sort.flat_map do |default_dir|
+          series_errors(
+            series_slug: File.basename(File.dirname(default_dir)),
+            data_root: data_root,
+            assets_root: assets_root
+          )
+        end
+      end
+
+      def self.series_errors(series_slug:, data_root:, assets_root:)
+        references = Hash.new { |hash, key| hash[key] = [] }
+
+        Dir.glob(File.join(data_root, series_slug, "*", "event.yml")).sort.each do |file|
+          event_slug = File.basename(File.dirname(file))
+          document = Yerba.parse_file(file)
+
+          FIELD_ASSET_MAP.each do |field, asset|
+            next if File.exist?(File.join(assets_root, series_slug, event_slug, asset))
+            next unless File.exist?(File.join(assets_root, series_slug, "default", asset))
+
+            scalar = document[field]
+            next unless scalar
+
+            references[field] << {
+              value: scalar.value,
+              asset: Pathname.new(assets_root).join(series_slug, "default", asset).relative_path_from(Rails.root).to_s,
+              file: file,
+              line: scalar.location&.start_line || 1,
+              end_line: scalar.location&.end_line
+            }
+          end
+        end
+
+        references.flat_map do |field, refs|
+          tally = refs.map { |reference| reference[:value] }.tally
+          next [] unless tally.many?
+
+          expected, count = tally.max_by { |_value, occurrences| occurrences }
+
+          refs.reject { |reference| reference[:value] == expected }.map do |reference|
+            Static::Validators::Error.new(
+              %(#{field} "#{reference[:value]}" does not match "#{expected}" used by #{count} other #{series_slug} events falling back to the series default #{reference[:asset]}),
+              file_path: reference[:file],
+              line: reference[:line],
+              end_line: reference[:end_line]
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/static/validators/validator.rb
+++ b/app/models/static/validators/validator.rb
@@ -7,7 +7,8 @@ class Static::Validators::Validator
       Static::Validators::EventCityNames,
       Static::Validators::EventDates,
       Static::Validators::EventRecordingsPublishedDate,
-      Static::Validators::IdMatchesFolder
+      Static::Validators::IdMatchesFolder,
+      Static::Validators::SeriesDefaultColors
     ]
   end
 

--- a/data/rubyconf/rubyconf-2010/event.yml
+++ b/data/rubyconf/rubyconf-2010/event.yml
@@ -15,7 +15,7 @@ year: 2010
 website: "https://rubyconf.org"
 banner_background: "#FFFFFF"
 featured_background: "#FFFFFF"
-featured_color: "#000000"
+featured_color: "#F4554E"
 coordinates:
   latitude: 29.9508941
   longitude: -90.07583559999999

--- a/test/models/static/validators/series_default_colors_test.rb
+++ b/test/models/static/validators/series_default_colors_test.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Static::Validators::SeriesDefaultColorsTest < ActiveSupport::TestCase
+  test "applicable? returns true for an event.yml file" do
+    file = Dir.glob(Rails.root.join("data/**/event.yml")).first.to_s
+    assert Static::Validators::SeriesDefaultColors.new(file_path: file).applicable?
+  end
+
+  test "applicable? returns false for a non-event file" do
+    file = Dir.glob(Rails.root.join("data/**/videos.yml")).first.to_s
+    assert_not Static::Validators::SeriesDefaultColors.new(file_path: file).applicable?
+  end
+
+  test "applicable? returns false for a non-existent file" do
+    assert_not Static::Validators::SeriesDefaultColors.new(file_path: "/nonexistent/event.yml").applicable?
+  end
+
+  test "does not flag events with matching colors" do
+    events = {
+      "testconf-2024" => {"featured_background" => "#FFFFFF", "featured_color" => "#F4554E", "banner_background" => "#FFFFFF"},
+      "testconf-2025" => {"featured_background" => "#FFFFFF", "featured_color" => "#F4554E", "banner_background" => "#FFFFFF"}
+    }
+
+    with_temp_series(events, default_assets: ["featured.webp", "banner.webp"]) do |data_root, assets_root|
+      assert_empty errors_for(data_root, assets_root)
+    end
+  end
+
+  test "flags an event whose color differs from other events falling back to the default asset" do
+    events = {
+      "testconf-2024" => {"featured_color" => "#F4554E"},
+      "testconf-2025" => {"featured_color" => "#F4554E"},
+      "testconf-2026" => {"featured_color" => "#000000"}
+    }
+
+    with_temp_series(events, default_assets: ["featured.webp"]) do |data_root, assets_root|
+      errors = errors_for(data_root, assets_root)
+
+      assert_equal 1, errors.size
+      assert_includes errors.first.message, %(featured_color "#000000" does not match "#F4554E")
+      assert_includes errors.first.file_path, "testconf-2026"
+    end
+  end
+
+  test "does not flag events with their own asset" do
+    events = {
+      "testconf-2024" => {"featured_background" => "#FFFFFF"},
+      "testconf-2025" => {"featured_background" => "#123456"}
+    }
+
+    with_temp_series(events, default_assets: ["featured.webp"], event_assets: {"testconf-2025" => ["featured.webp"]}) do |data_root, assets_root|
+      assert_empty errors_for(data_root, assets_root)
+    end
+  end
+
+  test "does not flag fields whose asset is missing from the default directory" do
+    events = {
+      "testconf-2024" => {"banner_background" => "#FFFFFF"},
+      "testconf-2025" => {"banner_background" => "#123456"}
+    }
+
+    with_temp_series(events, default_assets: ["featured.webp"]) do |data_root, assets_root|
+      assert_empty errors_for(data_root, assets_root)
+    end
+  end
+
+  test "does not flag a series without a default asset directory" do
+    events = {
+      "testconf-2024" => {"featured_color" => "#F4554E"},
+      "testconf-2025" => {"featured_color" => "#000000"}
+    }
+
+    with_temp_series(events, default_assets: nil) do |data_root, assets_root|
+      assert_empty errors_for(data_root, assets_root)
+    end
+  end
+
+  test "compares banner_background and featured_background independently" do
+    events = {
+      "testconf-2024" => {"banner_background" => "#FFFFFF", "featured_background" => "#FFFFFF"},
+      "testconf-2025" => {"banner_background" => "#FFFFFF", "featured_background" => "#000000"},
+      "testconf-2026" => {"banner_background" => "#FFFFFF", "featured_background" => "#FFFFFF"}
+    }
+
+    with_temp_series(events, default_assets: ["featured.webp", "banner.webp"]) do |data_root, assets_root|
+      errors = errors_for(data_root, assets_root)
+
+      assert_equal 1, errors.size
+      assert_includes errors.first.message, "featured_background"
+    end
+  end
+
+  test "errors are Static::Validators::Error objects" do
+    events = {
+      "testconf-2024" => {"featured_color" => "#F4554E"},
+      "testconf-2025" => {"featured_color" => "#F4554E"},
+      "testconf-2026" => {"featured_color" => "#000000"}
+    }
+
+    with_temp_series(events, default_assets: ["featured.webp"]) do |data_root, assets_root|
+      assert errors_for(data_root, assets_root).all? { |error| error.is_a?(Static::Validators::Error) }
+    end
+  end
+
+  test "returns empty errors for all real event.yml files" do
+    Static::Validators::SeriesDefaultColors.reset!
+
+    errors = Dir.glob(Rails.root.join("data/**/event.yml")).flat_map do |file|
+      Static::Validators::SeriesDefaultColors.new(file_path: file).errors
+    end
+
+    assert_empty errors
+  ensure
+    Static::Validators::SeriesDefaultColors.reset!
+  end
+
+  private
+
+  def errors_for(data_root, assets_root)
+    Static::Validators::SeriesDefaultColors.mismatch_errors(data_root: data_root, assets_root: assets_root)
+  end
+
+  def with_temp_series(events, default_assets:, event_assets: {})
+    dir = Dir.mktmpdir
+    data_root = File.join(dir, "data")
+    assets_root = File.join(dir, "assets")
+
+    events.each do |event_slug, attributes|
+      event_path = File.join(data_root, "testconf", event_slug, "event.yml")
+      FileUtils.mkdir_p(File.dirname(event_path))
+      File.write(event_path, attributes.to_yaml)
+    end
+
+    Array(default_assets).each do |asset|
+      default_dir = File.join(assets_root, "testconf", "default")
+      FileUtils.mkdir_p(default_dir)
+      FileUtils.touch(File.join(default_dir, asset))
+    end
+
+    event_assets.each do |event_slug, assets|
+      event_dir = File.join(assets_root, "testconf", event_slug)
+      FileUtils.mkdir_p(event_dir)
+      assets.each { |asset| FileUtils.touch(File.join(event_dir, asset)) }
+    end
+
+    yield data_root, assets_root
+  ensure
+    FileUtils.rm_rf(dir)
+  end
+end


### PR DESCRIPTION
### Description

Events that don't have their own artwork fall back to their series' shared `default/` assets, which means they all render the same image, but nothing ensured they also declared the same brand colors, so visually identical cards could end up with mismatched backgrounds and text colors. 

This pull request adds a new `Static::Validators::SeriesDefaultColors` validator, which groups the events of a series that fall back to a shared default `banner.webp` or `featured.webp` and requires their `banner_background`, `featured_background`, and `featured_color` values to match, treating the majority value as canonical and pointing any outlier to the exact line in its `event.yml`. 