### PR TITLE
Add `Static::Validators::ExpectedDataFiles` validator

### DIFF
--- a/app/models/static/validators/expected_data_files.rb
+++ b/app/models/static/validators/expected_data_files.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module Static
+  module Validators
+    class ExpectedDataFiles
+      EXPECTED = {
+        1 => %w[featured_cities.yml speakers.yml topics.yml],
+        2 => %w[series.yml],
+        3 => %w[cfp.yml event.yml involvements.yml schedule.yml sponsors.yml venue.yml videos.yml]
+      }.freeze
+
+      LOCATIONS = {
+        1 => "data/",
+        2 => "data/{series}/",
+        3 => "data/{series}/{event}/"
+      }.freeze
+
+      def initialize(file_path:, document: nil)
+        @file_path = file_path.to_s
+      end
+
+      def applicable?
+        File.exist?(@file_path) && !File.directory?(@file_path) && segments.any?
+      end
+
+      def errors
+        @errors ||= validate
+      end
+
+      def validate
+        return [] unless applicable?
+
+        filename = segments.last
+        depth = segments.size
+
+        return [] if EXPECTED[depth]&.include?(filename)
+
+        [
+          Static::Validators::Error.new(
+            "Unexpected file '#{filename}' at data/#{segments.join("/")}, #{hint(filename, depth)}",
+            file_path: @file_path,
+            line: 1
+          )
+        ]
+      end
+
+      private
+
+      def segments
+        @segments ||= begin
+          parts = File.expand_path(@file_path).split("/data/").last.to_s.split("/")
+
+          (parts.join("/") == File.expand_path(@file_path)) ? [] : parts
+        end
+      end
+
+      def hint(filename, depth)
+        expected_depth = EXPECTED.find { |_depth, filenames| filenames.include?(filename) }&.first
+
+        if expected_depth
+          return "#{filename} files belong at #{LOCATIONS[expected_depth]}#{filename}"
+        end
+
+        suggestion = DidYouMean::SpellChecker.new(dictionary: EXPECTED.fetch(depth, [])).correct(filename).first
+
+        if suggestion
+          "did you mean '#{suggestion}'?"
+        elsif EXPECTED.key?(depth)
+          "expected one of: #{EXPECTED[depth].join(", ")}"
+        else
+          "no files are expected at this level"
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/validate.rake
+++ b/lib/tasks/validate.rake
@@ -289,6 +289,21 @@ namespace :validate do
     exit 1 unless validate_speakerdeck_urls
   end
 
+  def validate_data_files
+    validate_files(
+      files: Dir.glob(Rails.root.join("data/**/*"), File::FNM_DOTMATCH).select { |file| File.file?(file) },
+      validators: [
+        Static::Validators::ExpectedDataFiles
+      ],
+      success_message: "✓ All data files are in expected locations!"
+    )
+  end
+
+  desc "Validate that data/ only contains expected files at expected nesting levels"
+  task data_files: :environment do
+    exit 1 if validate_data_files.any?
+  end
+
   def validate_event_assets
     validate_files(
       files: Dir.glob(Rails.root.join("app/assets/images/events/**/*.webp")),
@@ -381,6 +396,7 @@ namespace :validate do
       "Validating speakers.yml file" => -> { validate_speakers_file.none? },
       "Validating involvements.yml file" => -> { validate_involvements_file.none? },
       "Validating speakers.yml is in sync" => -> { validate_speakers_in_sync },
+      "Validating data file locations" => -> { validate_data_files.none? },
       "Validating unique video ids" => -> { validate_unique_video_ids },
       "Validating SpeakerDeck slides URLs" => -> { validate_speakerdeck_urls },
       "Validating SpeakerDeck handles" => -> { validate_speakerdeck_handles },

--- a/test/models/static/validators/expected_data_files_test.rb
+++ b/test/models/static/validators/expected_data_files_test.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Static::Validators::ExpectedDataFilesTest < ActiveSupport::TestCase
+  test "applicable? returns true for a file under data/" do
+    file = Dir.glob(Rails.root.join("data/**/event.yml")).first.to_s
+    assert Static::Validators::ExpectedDataFiles.new(file_path: file).applicable?
+  end
+
+  test "applicable? returns false for a file outside data/" do
+    assert_not Static::Validators::ExpectedDataFiles.new(file_path: __FILE__).applicable?
+  end
+
+  test "applicable? returns false for a non-existent file" do
+    assert_not Static::Validators::ExpectedDataFiles.new(file_path: "/nonexistent/data/blah.yml").applicable?
+  end
+
+  test "does not flag expected files at each level" do
+    %w[
+      speakers.yml
+      testconf/series.yml
+      testconf/testconf-2025/event.yml
+      testconf/testconf-2025/videos.yml
+      testconf/testconf-2025/schedule.yml
+      testconf/testconf-2025/venue.yml
+      testconf/testconf-2025/cfp.yml
+      testconf/testconf-2025/sponsors.yml
+      testconf/testconf-2025/involvements.yml
+    ].each do |path|
+      with_temp_data_file(path) do |file|
+        assert_empty Static::Validators::ExpectedDataFiles.new(file_path: file).errors, "expected no errors for #{path}"
+      end
+    end
+  end
+
+  test "flags an unknown file name" do
+    with_temp_data_file("testconf/testconf-2025/blah.yml") do |file|
+      errors = Static::Validators::ExpectedDataFiles.new(file_path: file).errors
+
+      assert_equal 1, errors.size
+      assert_includes errors.first.message, "Unexpected file 'blah.yml'"
+      assert_includes errors.first.message, "expected one of: cfp.yml, event.yml"
+    end
+  end
+
+  test "suggests the correct name for a typo" do
+    with_temp_data_file("testconf/testconf-2025/evvvent.yml") do |file|
+      assert_includes Static::Validators::ExpectedDataFiles.new(file_path: file).errors.first.message, "did you mean 'event.yml'?"
+    end
+
+    with_temp_data_file("testconf/testconf-2025/even.yml") do |file|
+      assert_includes Static::Validators::ExpectedDataFiles.new(file_path: file).errors.first.message, "did you mean 'event.yml'?"
+    end
+
+    with_temp_data_file("testconf/testconf-2025/involvments.yml") do |file|
+      assert_includes Static::Validators::ExpectedDataFiles.new(file_path: file).errors.first.message, "did you mean 'involvements.yml'?"
+    end
+  end
+
+  test "flags a known file at the wrong nesting level" do
+    with_temp_data_file("testconf/series.yml", filename: "event.yml") do |file|
+      assert_includes Static::Validators::ExpectedDataFiles.new(file_path: file).errors.first.message,
+        "event.yml files belong at data/{series}/{event}/event.yml"
+    end
+
+    with_temp_data_file("testconf/testconf-2025/series.yml") do |file|
+      assert_includes Static::Validators::ExpectedDataFiles.new(file_path: file).errors.first.message,
+        "series.yml files belong at data/{series}/series.yml"
+    end
+  end
+
+  test "flags files nested too deeply" do
+    with_temp_data_file("testconf/testconf-2025/extra/event.yml") do |file|
+      assert_includes Static::Validators::ExpectedDataFiles.new(file_path: file).errors.first.message,
+        "event.yml files belong at data/{series}/{event}/event.yml"
+    end
+
+    with_temp_data_file("testconf/testconf-2025/extra/blah.yml") do |file|
+      assert_includes Static::Validators::ExpectedDataFiles.new(file_path: file).errors.first.message,
+        "no files are expected at this level"
+    end
+  end
+
+  test "flags non-yml files" do
+    %w[
+      testconf/testconf-2025/notes.txt
+      testconf/testconf-2025/image.png
+      testconf/testconf-2025/script.rb
+      testconf/testconf-2025/.DS_Store
+      testconf/.DS_Store
+      speakers.json
+    ].each do |path|
+      with_temp_data_file(path) do |file|
+        errors = Static::Validators::ExpectedDataFiles.new(file_path: file).errors
+        assert_equal 1, errors.size, "expected #{path} to be flagged"
+      end
+    end
+  end
+
+  test "flags yaml extension and suggests the yml equivalent" do
+    with_temp_data_file("testconf/testconf-2025/event.yaml") do |file|
+      assert_includes Static::Validators::ExpectedDataFiles.new(file_path: file).errors.first.message, "did you mean 'event.yml'?"
+    end
+  end
+
+  test "returns no errors for all real data files" do
+    errors = Dir.glob(Rails.root.join("data/**/*")).select { |file| File.file?(file) }.flat_map do |file|
+      Static::Validators::ExpectedDataFiles.new(file_path: file).errors
+    end
+
+    assert_empty errors
+  end
+
+  private
+
+  def with_temp_data_file(relative_path, filename: nil)
+    dir = Dir.mktmpdir
+    file_path = File.join(dir, "data", *relative_path.split("/")[0..-2], filename || relative_path.split("/").last)
+    FileUtils.mkdir_p(File.dirname(file_path))
+    FileUtils.touch(file_path)
+
+    yield file_path
+  ensure
+    FileUtils.rm_rf(dir)
+  end
+end


### PR DESCRIPTION
### Description


The `data/` directory has a strict layout, global files like `speakers.yml` at the root, one `series.yml` per series folder, and the event files (`event.yml`, `videos.yml`, `schedule.yml`, `venue.yml`, `cfp.yml`, `sponsors.yml`, `involvements.yml`) one level below, but nothing enforced it, so a typo like `even.yml` or a `series.yml` dropped into an event folder would sit there silently ignored by the importers. 

This pull request adds a new `Static::Validators::ExpectedDataFiles` validator, which checks every file `data/` against an allowlist of expected filenames per nesting level and flags everything else, pointing misplaced known files to where they belong and suggesting the intended name for typos via `DidYouMean` (`"did you mean 'event.yml'?"`).

<img width="1718" height="374" alt="CleanShot 2026-07-08 at 23 10 02@2x" src="https://github.com/user-attachments/assets/bd1cbfe7-cc58-46ef-b0fb-800deb9dd29b" />

<img width="2278" height="316" alt="CleanShot 2026-07-08 at 23 10 23@2x" src="https://github.com/user-attachments/assets/8a5615c2-8797-468a-8c2f-d8233f6da264" />



Inspired by https://github.com/rubyevents/rubyevents/pull/1924/changes/0e08c429029c08acce832c344e9d0502f7232a57.
