### PR TITLE
Add RubyKaigi Takeout 2020 schedule

### DIFF
--- a/data/rubykaigi/rubykaigi-2020/schedule.yml
+++ b/data/rubykaigi/rubykaigi-2020/schedule.yml
@@ -1,0 +1,115 @@
+---
+# https://rubykaigi.org/2020-takeout/schedule/
+days:
+  - name: "Day 1"
+    date: "2020-09-04"
+    grid:
+      - start_time: "10:00"
+        end_time: "10:15"
+        slots: 1
+        items:
+          - "Opening"
+
+      - start_time: "10:15"
+        end_time: "10:40"
+        slots: 1
+
+      - start_time: "10:45"
+        end_time: "11:10"
+        slots: 2
+
+      - start_time: "11:15"
+        end_time: "11:40"
+        slots: 2
+
+      - start_time: "11:45"
+        end_time: "12:10"
+        slots: 2
+
+      - start_time: "12:10"
+        end_time: "13:00"
+        slots: 1
+        items:
+          - "Lunch Break"
+
+      - start_time: "13:00"
+        end_time: "13:25"
+        slots: 2
+
+      - start_time: "13:30"
+        end_time: "13:55"
+        slots: 2
+
+      - start_time: "14:00"
+        end_time: "14:25"
+        slots: 2
+
+      - start_time: "14:30"
+        end_time: "14:50"
+        slots: 2
+
+      - start_time: "15:00"
+        end_time: "15:30"
+        slots: 1
+
+  - name: "Day 2"
+    date: "2020-09-05"
+    grid:
+      - start_time: "10:00"
+        end_time: "10:05"
+        slots: 1
+        items:
+          - "Opening"
+
+      - start_time: "10:05"
+        end_time: "10:45"
+        slots: 1
+
+      - start_time: "10:50"
+        end_time: "11:10"
+        slots: 2
+
+      - start_time: "11:15"
+        end_time: "11:40"
+        slots: 2
+
+      - start_time: "11:45"
+        end_time: "12:10"
+        slots: 2
+
+      - start_time: "12:10"
+        end_time: "13:00"
+        slots: 1
+        items:
+          - "Lunch Break"
+
+      - start_time: "13:00"
+        end_time: "13:25"
+        slots: 2
+
+      - start_time: "13:30"
+        end_time: "13:55"
+        slots: 2
+
+      - start_time: "14:00"
+        end_time: "14:25"
+        slots: 2
+
+      - start_time: "14:30"
+        end_time: "15:05"
+        slots: 1
+
+      - start_time: "15:05"
+        end_time: "15:20"
+        slots: 1
+        items:
+          - "Closing"
+
+tracks:
+  - name: "#rubykaigiA"
+    color: "#7E0303"
+    text_color: "#FFFFFF"
+
+  - name: "#rubykaigiB"
+    color: "#2B2B2B"
+    text_color: "#FFFFFF"

--- a/data/rubykaigi/rubykaigi-2020/videos.yml
+++ b/data/rubykaigi/rubykaigi-2020/videos.yml
@@ -1,22 +1,132 @@
 ---
-# TODO: talks running order
-# TODO: talk dates
-# TODO: conference website
-# TODO: schedule website
+- id: "koichi-sasada-rubykaigi-2020"
+  title: "Ractor report"
+  raw_title: "[JA] Ractor report / Koichi Sasada @ko1"
+  event_name: "RubyKaigi Takeout 2020"
+  date: "2020-09-04"
+  published_at: "2020-09-09T06:55:03Z"
+  language: "Japanese"
+  track: "#rubykaigiA"
+  video_provider: "youtube"
+  video_id: "40t8EPpnujg"
+  description: |-
+    This talk will introduce Ractor, the concurrency system for Ruby 3 based on actual implementation.
 
-- id: "soutaro-matsumoto-rubykaigi-2020"
-  title: "The State of Ruby 3 Typing"
-  raw_title: "[EN] The State of Ruby 3 Typing / Soutaro Matsumoto @soutaro"
+    At RubyKaigi 2016, I proposed Guild (A proposal of new concurrency model for Ruby 3, http://rubykaigi.org/2016/presentations/ko1.html) and at RubyKaigi 2018, I introduced prototype of it (Guild Prototype - RubyKaigi 2018, https://rubykaigi.org/2018/presentations/ko1.html). For Ruby 3, we renamed Guild to Ractor and finished the first implementation. This talk will introduce Ractor API with current implementation.
+  speakers:
+    - Koichi Sasada
+
+- id: "yusuke-endoh-rubykaigi-2020"
+  title: "Type Profiler: a Progress Report of a Ruby 3 Type Analyzer"
+  raw_title: "[JA] Type Profiler: a Progress Report of a Ruby 3 Type Analyzer / Yusuke Endoh @mametter"
+  event_name: "RubyKaigi Takeout 2020"
+  date: "2020-09-04"
+  published_at: "2020-09-09T06:54:35Z"
+  language: "Japanese"
+  track: "#rubykaigiA"
+  video_provider: "youtube"
+  video_id: "6KcFdQWp8W0"
+  description: |-
+    Type Profiler is a type inference tool for plain Ruby code. It analyzes Ruby code that has no type information and guesses a type of the modules and methods in the code. The output will serve as a signature for external type checkers like Sorbet and Steep. Since 2019, we have been developing the tool as one of the key features for Ruby 3 static analysis, and now it works with some practical applications. In this talk, we briefly explain what and how Type Profiler works, present a roadmap and progress of the development, and discuss how useful it is for practical applications with some demos.
+  speakers:
+    - Yusuke Endoh
+
+- id: "kevin-newton-rubykaigi-2020"
+  title: "Prettier Ruby"
+  raw_title: "[EN] Prettier Ruby / Kevin Deisz @kddeisz"
   event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
   published_at: "2020-09-09T06:54:35Z"
   language: "English"
+  track: "#rubykaigiB"
   video_provider: "youtube"
-  video_id: "PvkpW1OEaP8"
+  video_id: "3945FmGGHhw"
   description: |-
-    Ruby 3 will ship with a new feature for type checking, RBS. It provides a language to describe types of Ruby programs, the type declarations for standard library classes, and a set of features to support using and developing type checkers. In this talk, I will introduce the feature and how the Ruby programming will be with RBS.
+    Prettier was created in 2017 and has since seen a meteoric rise within the JavaScript community. It differentiated itself from other code formatters and linters by supporting minimal configuration, eliminating the need for long discussions and arguments by enforcing an opinionated style on its users. That enforcement ended up resonating well, as it allowed developers to get back to work on the more important aspects of their job.
+
+    Since then, it has expanded to support other languages and markup, including Ruby. The Ruby plugin is now in use in dozens of applications around the world, and better formatting is being worked on daily. This talk will give you a high-level overview of prettier and how to wield it in your project. It will also dive into the nitty gritty, showing how the plugin was made and how you can help contribute to its growth. You’ll come away with a better understanding of Ruby syntax, knowledge of a new tool and how it can be used to help your team.
   speakers:
-    - Soutaro Matsumoto
+    - Kevin Newton
+
+- id: "shyouhei-urabe-rubykaigi-2020"
+  title: "On sending methods"
+  raw_title: "[JA] On sending methods / Urabe, Shyouhei @shyouhei"
+  event_name: "RubyKaigi Takeout 2020"
+  date: "2020-09-04"
+  published_at: "2020-09-09T06:54:35Z"
+  language: "Japanese"
+  track: "#rubykaigiA"
+  video_provider: "youtube"
+  video_id: "IAkrGf9XJi0"
+  description: |-
+    As you have noticed 2.7 is faster than older ruby versions. One of the main reason for this is my optimisation around method invocations. Let me share what was suboptimal, and how was that fixed.
+  speakers:
+    - Shyouhei Urabe
+
+- id: "ernesto-tagwerker-rubykaigi-2020"
+  title: "RubyMem: The Leaky Gems Database for Bundler"
+  raw_title: "[EN] RubyMem: The Leaky Gems Database for Bundler / Ernesto Tagwerker @etagwerker"
+  event_name: "RubyKaigi Takeout 2020"
+  date: "2020-09-04"
+  published_at: "2020-09-09T06:54:35Z"
+  language: "English"
+  track: "#rubykaigiB"
+  slides_url: "https://speakerdeck.com/etagwerker/rubymem-the-leaky-gems-database-for-bundler-at-ruby-kaigi-takeout-2020"
+  video_provider: "youtube"
+  video_id: "ghaA6LD5OEo"
+  description: |-
+    Out of memory errors are quite tricky. Our first reaction is always the same: "It can't be my code, it must be one of my dependencies!" What if you could quickly check that with bundler?
+
+    In this talk you will learn about memory leaks, out of memory errors, and leaky dependencies. You will learn how to use bundler-leak, a community-driven, open source tool that will make your life easier when debugging memory leaks.
+  speakers:
+    - Ernesto Tagwerker
+
+- id: "yoh-osaki-rubykaigi-2020"
+  title: "Asynchronous Opal"
+  raw_title: "[JA] Asynchronous Opal / Yoh Osaki @youchan"
+  event_name: "RubyKaigi Takeout 2020"
+  date: "2020-09-04"
+  published_at: "2020-09-09T06:54:48Z"
+  language: "Japanese"
+  track: "#rubykaigiA"
+  video_provider: "youtube"
+  video_id: "yDUmMuPdSUA"
+  description: |-
+    Opal is a compiler convert from Ruby to JavaScript. JavaScript has async/await syntax for asynchronous processing. But Opal hasn't implemented it yet. The Opal community had been discussed mapping Fiber semantics to JavaScript async/await. The conclusion was it is impossible to map coroutine such as Fiber because async/await is just a syntax sugar that expresses nested callbacks into flat statements. I'm going to talk about the idea I'm trying to incorporate easy-to-use asynchronous processing into Opal.
+  speakers:
+    - Yoh Osaki
+
+- id: "ufuk-kayserilioglu-rubykaigi-2020"
+  title: "Reflecting on Ruby Reflection for Rendering RBIs"
+  raw_title: "[EN] Reflecting on Ruby Reflection for Rendering RBIs / Ufuk Kayserilioglu @paracycle"
+  event_name: "RubyKaigi Takeout 2020"
+  date: "2020-09-04"
+  published_at: "2020-09-09T06:55:02Z"
+  language: "English"
+  track: "#rubykaigiB"
+  video_provider: "youtube"
+  video_id: "OJRQAn6BfpE"
+  description: |-
+    As part of our adoption process of Sorbet at Shopify, we needed an automated way to teach Sorbet about our ~400 gem dependencies. We decided to tackle this problem by generating interface files (RBI) for each gem via runtime reflection.
+
+    However, this turns out to not be as simple as it sounds; the flexible nature of Ruby allows gem authors to do many wild things that make this Hard. Come and hear about all the lessons that we learnt about runtime reflection in Ruby while building "tapioca".
+  speakers:
+    - Ufuk Kayserilioglu
+
+- id: "sutou-kouhei-rubykaigi-2020"
+  title: "Goodbye fat gem"
+  raw_title: "[JA] Goodbye fat gem / Sutou Kouhei @ktou"
+  event_name: "RubyKaigi Takeout 2020"
+  date: "2020-09-04"
+  published_at: "2020-09-09T06:54:35Z"
+  language: "Japanese"
+  track: "#rubykaigiA"
+  video_provider: "youtube"
+  video_id: "tGZiCqyMU_g"
+  description: |-
+    Fat gem mechanism is useful to install extension library without any compiler. Fat gem mechanism is especially helpful for Windows rubyists because Windows rubyists don't have compiler. But there are some downsides. For example, fat gem users can't use Ruby 2.7 (the latest Ruby) until fat gem developers release a new gem for Ruby 2.7. As of 2020, pros of fat gem mechanism is decreasing and cons of it is increasing. This talk describes the details of pros and cons of it then says thanks and goodbye to fat gem.
+  speakers:
+    - Sutou Kouhei
 
 - id: "vladimir-dementyev-rubykaigi-2020"
   title: "The whys and hows of transpiling Ruby"
@@ -25,6 +135,7 @@
   date: "2020-09-04"
   published_at: "2020-09-09T06:54:46Z"
   language: "English"
+  track: "#rubykaigiB"
   slides_url: "https://speakerdeck.com/palkan/rubykaigi-2020-the-whys-and-hows-of-transpiling-ruby"
   video_provider: "youtube"
   video_id: "zLInIisYlDo"
@@ -37,35 +148,20 @@
   speakers:
     - Vladimir Dementyev
 
-- id: "ufuk-kayserilioglu-rubykaigi-2020"
-  title: "Reflecting on Ruby Reflection for Rendering RBIs"
-  raw_title: "[EN] Reflecting on Ruby Reflection for Rendering RBIs / Ufuk Kayserilioglu @paracycle"
+- id: "samuel-williams-rubykaigi-2020"
+  title: "Don't Wait For Me! Scalable Concurrency for Ruby 3!"
+  raw_title: "[EN] Don't Wait For Me! Scalable Concurrency for Ruby 3! / Samuel Williams @ioquatix"
   event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
-  published_at: "2020-09-09T06:55:02Z"
+  published_at: "2020-09-09T06:54:51Z"
   language: "English"
+  track: "#rubykaigiA"
   video_provider: "youtube"
-  video_id: "OJRQAn6BfpE"
+  video_id: "Y29SSOS4UOc"
   description: |-
-    As part of our adoption process of Sorbet at Shopify, we needed an automated way to teach Sorbet about our ~400 gem dependencies. We decided to tackle this problem by generating interface files (RBI) for each gem via runtime reflection.
-
-    However, this turns out to not be as simple as it sounds; the flexible nature of Ruby allows gem authors to do many wild things that make this Hard. Come and hear about all the lessons that we learnt about runtime reflection in Ruby while building "tapioca".
+    We have proven that fibers are useful for building scalable systems. In order to develop this further, we need to add hooks into the various Ruby VMs so that we can improve the concurrency of existing code without changes. There is an outstanding PR for this work, but additional effort is required to bring this to completion and show its effectiveness in real world situations. We will discuss the implementation of this PR, the implementation of the corresponding Async Scheduler, and how they work together to improve the scalability of Ruby applications.
   speakers:
-    - Ufuk Kayserilioglu
-
-- id: "elct9620-rubykaigi-2020"
-  title: "Is it time run Ruby on Web via WebAssembly?"
-  raw_title: "[EN] Is it time run Ruby on Web via WebAssembly? / 蒼時弦也 @elct9620"
-  event_name: "RubyKaigi Takeout 2020"
-  date: "2020-09-04"
-  published_at: "2020-09-09T06:54:35Z"
-  language: "English"
-  video_provider: "youtube"
-  video_id: "PJLWoz6K7w4"
-  description: |-
-    The W3C is starting to recommend to use WebAssembly, and we can compile mruby to WebAssembly very easy in now day. But we have Opal and it works well, we really need to use WebAssembly? Let me share my experience about trying to add mruby to HTML5 game, and discuss the pros and cons when we use Ruby in WebAssembly way in Web.
-  speakers:
-    - elct9620
+    - Samuel Williams
 
 - id: "hasumi-hitoshi-rubykaigi-2020"
   title: "mruby machine: An Operating System for Microcontoller"
@@ -74,6 +170,7 @@
   date: "2020-09-04"
   published_at: "2020-09-09T06:54:35Z"
   language: "English"
+  track: "#rubykaigiB"
   video_provider: "youtube"
   video_id: "kDOf_tZKlLU"
   description: |-
@@ -83,27 +180,231 @@
   speakers:
     - HASUMI Hitoshi
 
-- id: "jeremy-evans-rubykaigi-2020"
-  title: "Keyword Arguments: Past, Present, and Future"
-  raw_title: "[EN] Keyword Arguments: Past, Present, and Future / Jeremy Evans @jeremyevans0"
+- id: "koichi-ito-rubykaigi-2020"
+  title: "Road to RuboCop 1.0"
+  raw_title: "[JA] Road to RuboCop 1.0 / Koichi ITO @koic"
   event_name: "RubyKaigi Takeout 2020"
   date: "2020-09-04"
-  published_at: "2020-09-09T06:54:58Z"
-  language: "English"
+  published_at: "2020-09-09T06:54:35Z"
+  language: "Japanese"
+  track: "#rubykaigiA"
   video_provider: "youtube"
-  video_id: "rxJRrccXRfg"
+  video_id: "jkY7J9k6mHs"
   description: |-
-    Ruby 3 will separate keyword arguments from positional arguments, which causes the biggest backwards compatibility issues in Ruby since Ruby 1.9. This presentation will discuss the history of keyword arguments, how keyword arguments are handled internally, how keyword arguments were separated from positional arguments internally, and possible future improvements in the handling of keyword arguments.
+    RuboCop 1.0 is coming soon.
+
+    RuboCop 1.0 introduces several new features and breaking changes to go to the stable major version 1.0! In this presentation, I will talk about how the milestones for RuboCop 1.0 has been implemented. For examples, gemified departments, safe annotate, new cop status, and others.
+
+    RuboCop 1.0 will provide the safest static analysis in the all‐time previous releases. The pragmatic meaning of them has emerged during the implementation process. This talk will help you ride on RuboCop 1.0.
   speakers:
-    - Jeremy Evans
+    - Koichi ITO
+
+- id: "soutaro-matsumoto-rubykaigi-2020"
+  title: "The State of Ruby 3 Typing"
+  raw_title: "[EN] The State of Ruby 3 Typing / Soutaro Matsumoto @soutaro"
+  event_name: "RubyKaigi Takeout 2020"
+  date: "2020-09-04"
+  published_at: "2020-09-09T06:54:35Z"
+  language: "English"
+  track: "#rubykaigiB"
+  video_provider: "youtube"
+  video_id: "PvkpW1OEaP8"
+  description: |-
+    Ruby 3 will ship with a new feature for type checking, RBS. It provides a language to describe types of Ruby programs, the type declarations for standard library classes, and a set of features to support using and developing type checkers. In this talk, I will introduce the feature and how the Ruby programming will be with RBS.
+  speakers:
+    - Soutaro Matsumoto
+
+- id: "masatoshi-seki-rubykaigi-2020"
+  title: "Rinda in the real-world embedded systems"
+  raw_title: "[JA] Rinda in the real-world embedded systems / Masatoshi SEKI @m_seki"
+  event_name: "RubyKaigi Takeout 2020"
+  date: "2020-09-04"
+  published_at: "2020-09-09T06:54:35Z"
+  language: "Japanese"
+  track: "#rubykaigiA"
+  video_provider: "youtube"
+  video_id: "qwe6qmtxHbk"
+  description: |-
+    Okayama Astrophysical Observatory Wide-Field Camera (OAOWFC), is an autonomous wide-field near-infrared camera and has been in operation since 2015. A distributed control system is operated via control software using Rinda. I report the implementation of the robot telescope 🤖🔭.
+  speakers:
+    - Masatoshi SEKI
+
+- id: "benoit-daloze-rubykaigi-2020"
+  title: "Running Rack and Rails Faster with TruffleRuby"
+  raw_title: "[EN] Running Rack and Rails Faster with TruffleRuby / Benoit Daloze @eregontp"
+  event_name: "RubyKaigi Takeout 2020"
+  date: "2020-09-04"
+  published_at: "2020-09-09T06:54:49Z"
+  language: "English"
+  track: "#rubykaigiB"
+  video_provider: "youtube"
+  video_id: "281YdMYRAsk"
+  description: |-
+    Optimizing Rack and Rails applications with a just-in-time (JIT) compiler is a challenge. For example, MJIT does not speed up Rails currently. TruffleRuby tackles this challenge. We have been running the Rails Simpler Benchmarks with TruffleRuby and now achieve higher performance than any other Ruby implementation.
+
+    In this talk we’ll show how we got there and what TruffleRuby optimizations are useful for Rack and Rails applications. TruffleRuby is getting ready to speed up your applications, will you try it?
+  speakers:
+    - Benoit Daloze
+
+- id: "ruby-committers-vs-the-world-day-1-rubykaigi-2020"
+  title: "Ruby Committers vs the World - Day 1"
+  raw_title: "Ruby committers vs the World - Day 1 (extended)"
+  kind: "q_and_a"
+  event_name: "RubyKaigi Takeout 2020"
+  date: "2020-09-04"
+  published_at: "2020-09-15T13:27:49Z"
+  language: "Japanese"
+  track: "#rubykaigiA"
+  video_provider: "youtube"
+  video_id: "D-AK1x4vuRU"
+  description: |-
+    https://rubykaigi.org/2020-takeout/presentations/rubylangorg.html#sep04
+  speakers:
+    - Ruby Committers # TODO: list each person
+
+- id: "ruby-committers-vs-the-world-day-2-rubykaigi-2020"
+  title: "Ruby Committers vs the World - Day 2"
+  raw_title: "Ruby committers vs the World - Day 2"
+  kind: "q_and_a"
+  event_name: "RubyKaigi Takeout 2020"
+  date: "2020-09-05"
+  published_at: "2020-10-10T10:16:10Z"
+  language: "Japanese" # + English
+  track: "#rubykaigiA"
+  video_provider: "youtube"
+  video_id: "20VDvtpjGn0"
+  description: |-
+    https://rubykaigi.org/2020-takeout/presentations/rubylangorg.html#sep05
+
+    Ruby core all stars on stage!
+  speakers:
+    - Ruby Committers
+
+- id: "shugo-maeda-rubykaigi-2020"
+  title: "Magic is organizing chaos"
+  raw_title: "[JA] Magic is organizing chaos / Shugo Maeda @shugomaeda"
+  event_name: "RubyKaigi Takeout 2020"
+  date: "2020-09-05"
+  published_at: "2020-09-09T06:54:38Z"
+  language: "Japanese"
+  track: "#rubykaigiA"
+  video_provider: "youtube"
+  video_id: "QKiQiK7gSHQ"
+  description: |-
+    The power of Law (e.g., type signatures, type checkers, type profilers) is growing toward Ruby 3. We need the power of Chaos for the Cosmic Balance.
+
+    In this talk, I propose Proc#using to extend area where Refinements can be used.
+  speakers:
+    - Shugo Maeda
+
+- id: "yuji-yokoo-rubykaigi-2020"
+  title: "Developing your Dreamcast apps and games with mruby"
+  raw_title: "[EN] Developing your Dreamcast apps and games with mruby / Yuji Yokoo @yuji_yokoo"
+  event_name: "RubyKaigi Takeout 2020"
+  date: "2020-09-05"
+  published_at: "2020-09-09T06:54:49Z"
+  language: "English"
+  track: "#rubykaigiB"
+  video_provider: "youtube"
+  video_id: "oqBTlYUkGXk"
+  description: |-
+    What would you make, if you can run your Ruby code on Dreamcast?
+
+    Well, now you can! I have been working on my development setup for running mruby code on Dreamcast. I would like to show you what I have developed so far and how you can get started. I would also like to tell you why development on Dreamcast is a great idea and share a few things I learned along the way.
+  speakers:
+    - Yuji Yokoo
+
+- id: "oda-hirohito-rubykaigi-2020"
+  title: "msgraph: Microsoft Graph API Client with Ruby"
+  raw_title: "[JA] msgraph: Microsoft Graph API Client with Ruby / ODA Hirohito @jimlock"
+  event_name: "RubyKaigi Takeout 2020"
+  date: "2020-09-05"
+  published_at: "2020-09-09T06:54:35Z"
+  language: "Japanese"
+  track: "#rubykaigiA"
+  video_provider: "youtube"
+  video_id: "TrVhnrTPtoI"
+  description: |-
+    msgraph is the unofficial Microsoft Graph API Client with Ruby. The official Microsoft Graph Client Library for Ruby is microsoft_graph. However, since its release on August 1, 2016, the preview version has been continued and has not been maintained. So, I created an API client that I can maintain on my own.
+
+    In this talk, I will talk about why I created the unofficial API Client.
+  speakers:
+    - ODA Hirohito
+
+- id: "elct9620-rubykaigi-2020"
+  title: "Is it time run Ruby on Web via WebAssembly?"
+  raw_title: "[EN] Is it time run Ruby on Web via WebAssembly? / 蒼時弦也 @elct9620"
+  event_name: "RubyKaigi Takeout 2020"
+  date: "2020-09-05"
+  published_at: "2020-09-09T06:54:35Z"
+  language: "English"
+  track: "#rubykaigiB"
+  video_provider: "youtube"
+  video_id: "PJLWoz6K7w4"
+  description: |-
+    The W3C is starting to recommend to use WebAssembly, and we can compile mruby to WebAssembly very easy in now day. But we have Opal and it works well, we really need to use WebAssembly? Let me share my experience about trying to add mruby to HTML5 game, and discuss the pros and cons when we use Ruby in WebAssembly way in Web.
+  speakers:
+    - elct9620
+
+- id: "don-t-me-instance-variable-performance-in-ruby-1-rubykaigi-2020"
+  title: "Don't @ me! Instance Variable Performance in Ruby"
+  raw_title: "[EN] Don't @ me! Instance Variable Performance in Ruby / Aaron Patterson @tenderlove"
+  event_name: "RubyKaigi Takeout 2020"
+  date: "2020-09-05"
+  published_at: "2020-09-09T06:54:57Z"
+  language: "English"
+  track: "#rubykaigiA"
+  video_provider: "youtube"
+  video_id: "4ysxA8DDplQ"
+  description: |-
+    Japanese version: https://youtu.be/iDW93fAp2I8
+
+    How do instance variables work? We've all used instance variables in our programs, but how do they actually work? In this presentation we'll look at how instance variables are implemented in Ruby. We'll start with a very strange benchmark, then dive in to Ruby internals to understand why the code behaves the way it does. Once we've figured out this strange behavior, we'll follow up with a patch to increase instance variable performance. Be prepared for a deep dive in to a weird area of Ruby, and remember: don't @ me!
+  speakers:
+    - Aaron Patterson
+
+- id: "lin-yu-hsiang-rubykaigi-2020"
+  title: "mruby-rr: Time Traveling Debugger For mruby Using rr"
+  raw_title: "[EN] mruby-rr: Time Traveling Debugger For mruby Using rr / Lin Yu Hsiang @johnlinvc"
+  event_name: "RubyKaigi Takeout 2020"
+  date: "2020-09-05"
+  published_at: "2020-09-09T06:54:35Z"
+  language: "English"
+  track: "#rubykaigiB"
+  video_provider: "youtube"
+  video_id: "E5ifh9yZCKk"
+  description: |-
+    Debugging bugs that don't happen every time is painful. It needs both technique and luck. When dealing with these, a mistyped continue command is irreversible and will take us a whole afternoon just to reproduce the issue again.
+
+    mruby-rr comes to rescue! It's a Time Traveling Debugger for mruby that based on Mozilla's rr. mruby-rr supports record and replay of mruby program execution. We can record the tough bug using mruby-rr for just once. Afterwards we can playback the execution as many times as we want. mruby-rr can also do time traveling operations like reverse-next and evaluating expressions.
+  speakers:
+    - Lin Yu Hsiang
+
+- id: "hiroshi-shibata-rubykaigi-2020"
+  title: "Dependency Resolution with Standard Libraries"
+  raw_title: "[JA] Dependency Resolution with Standard Libraries"
+  event_name: "RubyKaigi Takeout 2020"
+  date: "2020-09-05"
+  published_at: "2020-09-09T06:54:35Z"
+  language: "Japanese"
+  track: "#rubykaigiA"
+  video_provider: "youtube"
+  video_id: "wvayhyTEL_k"
+  description: |-
+    I maintain the RubyGems, Bundler and the standard libraries of the Ruby language. So, I have a plan to make all of the standard libraries to default gems at Ruby 3. In the past, I described the detail of default gems and bundled gems at RubyKaigi and the Ruby conferences in the world. But the users still confused the differences standard libraries and default/bundled gems.
+
+    After releasing Ruby 3, We need to learn about the dependency is not only "Versioning" with default gems. It caused by the between library and library over the versioning. For that reason, I need to describe the motivation of "Promoting/Demoting the Default Gems or Bundle Gems" continuously. You will learn the resolution mechanism on RubyGems/Bundler and the standard libraries of the Ruby language with my talk.
+  speakers:
+    - Hiroshi Shibata
 
 - id: "jonatas-davi-paganini-rubykaigi-2020"
   title: "Live coding: Grepping Ruby code like a boss"
   raw_title: "[EN] Live coding: Grepping Ruby code like a boss / Jônatas Davi Paganini @jonatas"
   event_name: "RubyKaigi Takeout 2020"
-  date: "2020-09-04"
+  date: "2020-09-05"
   published_at: "2020-09-09T06:54:35Z"
   language: "English"
+  track: "#rubykaigiB"
   video_provider: "youtube"
   video_id: "YczrZQC9aP8"
   description: |-
@@ -117,13 +418,29 @@
   speakers:
     - Jônatas Davi Paganini
 
+- id: "itoyanagi-sakura-rubykaigi-2020"
+  title: "The Complex Nightmare of the Asian Cultural Area"
+  raw_title: "[EN] The Complex Nightmare of the Asian Cultural Area / ITOYANAGI Sakura @aycabta"
+  event_name: "RubyKaigi Takeout 2020"
+  date: "2020-09-05"
+  published_at: "2020-09-09T06:54:35Z"
+  language: "English"
+  track: "#rubykaigiA"
+  video_provider: "youtube"
+  video_id: "s7Zc7VJMBv8"
+  description: |-
+    There are many different cultures in Asia that seem odd to the rest of the world. This session introduces the complexities of the current situation and the various technologies that have been created to achieve their goals.
+  speakers:
+    - ITOYANAGI Sakura
+
 - id: "katsuhiko-kageyama-rubykaigi-2020"
   title: "Now is the time to create your own (m)Ruby computer"
   raw_title: "[EN] Now is the time to create your own (m)Ruby computer / Katsuhiko Kageyama @kishima"
   event_name: "RubyKaigi Takeout 2020"
-  date: "2020-09-04"
+  date: "2020-09-05"
   published_at: "2020-09-09T06:54:35Z"
   language: "English"
+  track: "#rubykaigiB"
   video_provider: "youtube"
   video_id: "N24gfQJMXfs"
   description: |-
@@ -131,89 +448,59 @@
   speakers:
     - Katsuhiko Kageyama
 
-- id: "yoh-osaki-rubykaigi-2020"
-  title: "Asynchronous Opal"
-  raw_title: "[JA] Asynchronous Opal / Yoh Osaki @youchan"
+- id: "hideki-miura-rubykaigi-2020"
+  title: "Ruby to C Translator by AI"
+  raw_title: "[JA] Ruby to C Translator by AI / Hideki Miura @miura1729"
   event_name: "RubyKaigi Takeout 2020"
-  date: "2020-09-04"
-  published_at: "2020-09-09T06:54:48Z"
+  date: "2020-09-05"
+  published_at: "2020-09-09T06:54:59Z"
   language: "Japanese"
+  track: "#rubykaigiA"
   video_provider: "youtube"
-  video_id: "yDUmMuPdSUA"
+  video_id: "kr2RXLoiLNA"
   description: |-
-    Opal is a compiler convert from Ruby to JavaScript. JavaScript has async/await syntax for asynchronous processing. But Opal hasn't implemented it yet. The Opal community had been discussed mapping Fiber semantics to JavaScript async/await. The conclusion was it is impossible to map coroutine such as Fiber because async/await is just a syntax sugar that expresses nested callbacks into flat statements. I'm going to talk about the idea I'm trying to incorporate easy-to-use asynchronous processing into Opal.
+    I am developing Ruby to C Translator "MMC". This uses AI (i.e. Abstract Interpretation) for Type Profiling and Escape Analysis. MMC generates very efficient C code by AI. For example , MMC gains about 50 times faster than CRuby for ao-bench (faster than C version). I will presentation the technical detail of MMC especially escape analysis.
   speakers:
-    - Yoh Osaki
+    - Hideki Miura
 
-- id: "masatoshi-seki-rubykaigi-2020"
-  title: "Rinda in the real-world embedded systems"
-  raw_title: "[JA] Rinda in the real-world embedded systems / Masatoshi SEKI @m_seki"
+- id: "jeremy-evans-rubykaigi-2020"
+  title: "Keyword Arguments: Past, Present, and Future"
+  raw_title: "[EN] Keyword Arguments: Past, Present, and Future / Jeremy Evans @jeremyevans0"
   event_name: "RubyKaigi Takeout 2020"
-  date: "2020-09-04"
-  published_at: "2020-09-09T06:54:35Z"
+  date: "2020-09-05"
+  published_at: "2020-09-09T06:54:58Z"
+  language: "English"
+  track: "#rubykaigiB"
+  video_provider: "youtube"
+  video_id: "rxJRrccXRfg"
+  description: |-
+    Ruby 3 will separate keyword arguments from positional arguments, which causes the biggest backwards compatibility issues in Ruby since Ruby 1.9. This presentation will discuss the history of keyword arguments, how keyword arguments are handled internally, how keyword arguments were separated from positional arguments internally, and possible future improvements in the handling of keyword arguments.
+  speakers:
+    - Jeremy Evans
+
+- id: "yukihiro-matz-matsumoto-rubykaigi-2020"
+  title: "Keynote: Ruby 3 and Beyond"
+  raw_title: '[JA Keynote] Ruby3 and Beyond / Yukihiro "Matz" Matsumoto @yukihiro_matz'
+  kind: "keynote"
+  event_name: "RubyKaigi Takeout 2020"
+  date: "2020-09-05"
+  published_at: "2020-09-09T06:22:24Z"
   language: "Japanese"
+  track: "#rubykaigiA"
   video_provider: "youtube"
-  video_id: "qwe6qmtxHbk"
-  description: |-
-    Okayama Astrophysical Observatory Wide-Field Camera (OAOWFC), is an autonomous wide-field near-infrared camera and has been in operation since 2015. A distributed control system is operated via control software using Rinda. I report the implementation of the robot telescope 🤖🔭.
+  video_id: "wVrJZReHlM8"
+  description: ""
   speakers:
-    - Masatoshi SEKI
-
-- id: "lin-yu-hsiang-rubykaigi-2020"
-  title: "mruby-rr: Time Traveling Debugger For mruby Using rr"
-  raw_title: "[EN] mruby-rr: Time Traveling Debugger For mruby Using rr / Lin Yu Hsiang @johnlinvc"
-  event_name: "RubyKaigi Takeout 2020"
-  date: "2020-09-04"
-  published_at: "2020-09-09T06:54:35Z"
-  language: "English"
-  video_provider: "youtube"
-  video_id: "E5ifh9yZCKk"
-  description: |-
-    Debugging bugs that don't happen every time is painful. It needs both technique and luck. When dealing with these, a mistyped continue command is irreversible and will take us a whole afternoon just to reproduce the issue again.
-
-    mruby-rr comes to rescue! It's a Time Traveling Debugger for mruby that based on Mozilla's rr. mruby-rr supports record and replay of mruby program execution. We can record the tough bug using mruby-rr for just once. Afterwards we can playback the execution as many times as we want. mruby-rr can also do time traveling operations like reverse-next and evaluating expressions.
-  speakers:
-    - Lin Yu Hsiang
-
-- id: "yuji-yokoo-rubykaigi-2020"
-  title: "Developing your Dreamcast apps and games with mruby"
-  raw_title: "[EN] Developing your Dreamcast apps and games with mruby / Yuji Yokoo @yuji_yokoo"
-  event_name: "RubyKaigi Takeout 2020"
-  date: "2020-09-04"
-  published_at: "2020-09-09T06:54:49Z"
-  language: "English"
-  video_provider: "youtube"
-  video_id: "oqBTlYUkGXk"
-  description: |-
-    What would you make, if you can run your Ruby code on Dreamcast?
-
-    Well, now you can! I have been working on my development setup for running mruby code on Dreamcast. I would like to show you what I have developed so far and how you can get started. I would also like to tell you why development on Dreamcast is a great idea and share a few things I learned along the way.
-  speakers:
-    - Yuji Yokoo
-
-- id: "don-t-me-instance-variable-performance-in-ruby-1-rubykaigi-2020"
-  title: "Don't @ me! Instance Variable Performance in Ruby"
-  raw_title: "[EN] Don't @ me! Instance Variable Performance in Ruby / Aaron Patterson @tenderlove"
-  event_name: "RubyKaigi Takeout 2020"
-  date: "2020-09-04"
-  published_at: "2020-09-09T06:54:57Z"
-  language: "English"
-  video_provider: "youtube"
-  video_id: "4ysxA8DDplQ"
-  description: |-
-    Japanese version: https://youtu.be/iDW93fAp2I8
-
-    How do instance variables work? We've all used instance variables in our programs, but how do they actually work? In this presentation we'll look at how instance variables are implemented in Ruby. We'll start with a very strange benchmark, then dive in to Ruby internals to understand why the code behaves the way it does. Once we've figured out this strange behavior, we'll follow up with a patch to increase instance variable performance. Be prepared for a deep dive in to a weird area of Ruby, and remember: don't @ me!
-  speakers:
-    - Aaron Patterson
+    - "Yukihiro \"Matz\" Matsumoto"
 
 - id: "don-t-me-instance-variable-performance-in-ruby-2-rubykaigi-2020"
   title: "Don't @ me! Instance Variable Performance in Ruby"
   raw_title: "[JA] Don't @ me! Instance Variable Performance in Ruby / Aaron Patterson @tenderlove"
   event_name: "RubyKaigi Takeout 2020"
-  date: "2020-09-04"
+  date: "2020-09-05"
   published_at: "2020-09-09T06:55:05Z"
   language: "Japanese"
+  track: "#rubykaigiA"
   video_provider: "youtube"
   video_id: "iDW93fAp2I8"
   description: |-
@@ -222,264 +509,3 @@
     How do instance variables work? We've all used instance variables in our programs, but how do they actually work? In this presentation we'll look at how instance variables are implemented in Ruby. We'll start with a very strange benchmark, then dive in to Ruby internals to understand why the code behaves the way it does. Once we've figured out this strange behavior, we'll follow up with a patch to increase instance variable performance. Be prepared for a deep dive in to a weird area of Ruby, and remember: don't @ me!
   speakers:
     - Aaron Patterson
-
-- id: "hideki-miura-rubykaigi-2020"
-  title: "Ruby to C Translator by AI"
-  raw_title: "[JA] Ruby to C Translator by AI / Hideki Miura @miura1729"
-  event_name: "RubyKaigi Takeout 2020"
-  date: "2020-09-04"
-  published_at: "2020-09-09T06:54:59Z"
-  language: "Japanese"
-  video_provider: "youtube"
-  video_id: "kr2RXLoiLNA"
-  description: |-
-    I am developing Ruby to C Translator "MMC". This uses AI (i.e. Abstract Interpretation) for Type Profiling and Escape Analysis. MMC generates very efficient C code by AI. For example , MMC gains about 50 times faster than CRuby for ao-bench (faster than C version). I will presentation the technical detail of MMC especially escape analysis.
-  speakers:
-    - Hideki Miura
-
-- id: "itoyanagi-sakura-rubykaigi-2020"
-  title: "The Complex Nightmare of the Asian Cultural Area"
-  raw_title: "[EN] The Complex Nightmare of the Asian Cultural Area / ITOYANAGI Sakura @aycabta"
-  event_name: "RubyKaigi Takeout 2020"
-  date: "2020-09-04"
-  published_at: "2020-09-09T06:54:35Z"
-  language: "English"
-  video_provider: "youtube"
-  video_id: "s7Zc7VJMBv8"
-  description: |-
-    There are many different cultures in Asia that seem odd to the rest of the world. This session introduces the complexities of the current situation and the various technologies that have been created to achieve their goals.
-  speakers:
-    - ITOYANAGI Sakura
-
-- id: "hiroshi-shibata-rubykaigi-2020"
-  title: "Dependency Resolution with Standard Libraries"
-  raw_title: "[JA] Dependency Resolution with Standard Libraries"
-  event_name: "RubyKaigi Takeout 2020"
-  date: "2020-09-04"
-  published_at: "2020-09-09T06:54:35Z"
-  language: "Japanese"
-  video_provider: "youtube"
-  video_id: "wvayhyTEL_k"
-  description: |-
-    I maintain the RubyGems, Bundler and the standard libraries of the Ruby language. So, I have a plan to make all of the standard libraries to default gems at Ruby 3. In the past, I described the detail of default gems and bundled gems at RubyKaigi and the Ruby conferences in the world. But the users still confused the differences standard libraries and default/bundled gems.
-
-    After releasing Ruby 3, We need to learn about the dependency is not only "Versioning" with default gems. It caused by the between library and library over the versioning. For that reason, I need to describe the motivation of "Promoting/Demoting the Default Gems or Bundle Gems" continuously. You will learn the resolution mechanism on RubyGems/Bundler and the standard libraries of the Ruby language with my talk.
-  speakers:
-    - Hiroshi Shibata
-
-- id: "oda-hirohito-rubykaigi-2020"
-  title: "msgraph: Microsoft Graph API Client with Ruby"
-  raw_title: "[JA] msgraph: Microsoft Graph API Client with Ruby / ODA Hirohito @jimlock"
-  event_name: "RubyKaigi Takeout 2020"
-  date: "2020-09-04"
-  published_at: "2020-09-09T06:54:35Z"
-  language: "Japanese"
-  video_provider: "youtube"
-  video_id: "TrVhnrTPtoI"
-  description: |-
-    msgraph is the unofficial Microsoft Graph API Client with Ruby. The official Microsoft Graph Client Library for Ruby is microsoft_graph. However, since its release on August 1, 2016, the preview version has been continued and has not been maintained. So, I created an API client that I can maintain on my own.
-
-    In this talk, I will talk about why I created the unofficial API Client.
-  speakers:
-    - ODA Hirohito
-
-- id: "shugo-maeda-rubykaigi-2020"
-  title: "Magic is organizing chaos"
-  raw_title: "[JA] Magic is organizing chaos / Shugo Maeda @shugomaeda"
-  event_name: "RubyKaigi Takeout 2020"
-  date: "2020-09-04"
-  published_at: "2020-09-09T06:54:38Z"
-  language: "Japanese"
-  video_provider: "youtube"
-  video_id: "QKiQiK7gSHQ"
-  description: |-
-    The power of Law (e.g., type signatures, type checkers, type profilers) is growing toward Ruby 3. We need the power of Chaos for the Cosmic Balance.
-
-    In this talk, I propose Proc#using to extend area where Refinements can be used.
-  speakers:
-    - Shugo Maeda
-
-- id: "yukihiro-matz-matsumoto-rubykaigi-2020"
-  title: "Keynote: Ruby 3 and Beyond"
-  raw_title: '[JA Keynote] Ruby3 and Beyond / Yukihiro "Matz" Matsumoto @yukihiro_matz'
-  kind: "keynote"
-  event_name: "RubyKaigi Takeout 2020"
-  date: "2020-09-04"
-  published_at: "2020-09-09T06:22:24Z"
-  language: "Japanese"
-  video_provider: "youtube"
-  video_id: "wVrJZReHlM8"
-  description: ""
-  speakers:
-    - "Yukihiro \"Matz\" Matsumoto"
-
-- id: "koichi-ito-rubykaigi-2020"
-  title: "Road to RuboCop 1.0"
-  raw_title: "[JA] Road to RuboCop 1.0 / Koichi ITO @koic"
-  event_name: "RubyKaigi Takeout 2020"
-  date: "2020-09-04"
-  published_at: "2020-09-09T06:54:35Z"
-  language: "Japanese"
-  video_provider: "youtube"
-  video_id: "jkY7J9k6mHs"
-  description: |-
-    RuboCop 1.0 is coming soon.
-
-    RuboCop 1.0 introduces several new features and breaking changes to go to the stable major version 1.0! In this presentation, I will talk about how the milestones for RuboCop 1.0 has been implemented. For examples, gemified departments, safe annotate, new cop status, and others.
-
-    RuboCop 1.0 will provide the safest static analysis in the all‐time previous releases. The pragmatic meaning of them has emerged during the implementation process. This talk will help you ride on RuboCop 1.0.
-  speakers:
-    - Koichi ITO
-
-- id: "sutou-kouhei-rubykaigi-2020"
-  title: "Goodbye fat gem"
-  raw_title: "[JA] Goodbye fat gem / Sutou Kouhei @ktou"
-  event_name: "RubyKaigi Takeout 2020"
-  date: "2020-09-04"
-  published_at: "2020-09-09T06:54:35Z"
-  language: "Japanese"
-  video_provider: "youtube"
-  video_id: "tGZiCqyMU_g"
-  description: |-
-    Fat gem mechanism is useful to install extension library without any compiler. Fat gem mechanism is especially helpful for Windows rubyists because Windows rubyists don't have compiler. But there are some downsides. For example, fat gem users can't use Ruby 2.7 (the latest Ruby) until fat gem developers release a new gem for Ruby 2.7. As of 2020, pros of fat gem mechanism is decreasing and cons of it is increasing. This talk describes the details of pros and cons of it then says thanks and goodbye to fat gem.
-  speakers:
-    - Sutou Kouhei
-
-- id: "shyouhei-urabe-rubykaigi-2020"
-  title: "On sending methods"
-  raw_title: "[JA] On sending methods / Urabe, Shyouhei @shyouhei"
-  event_name: "RubyKaigi Takeout 2020"
-  date: "2020-09-04"
-  published_at: "2020-09-09T06:54:35Z"
-  language: "Japanese"
-  video_provider: "youtube"
-  video_id: "IAkrGf9XJi0"
-  description: |-
-    As you have noticed 2.7 is faster than older ruby versions. One of the main reason for this is my optimisation around method invocations. Let me share what was suboptimal, and how was that fixed.
-  speakers:
-    - Shyouhei Urabe
-
-- id: "yusuke-endoh-rubykaigi-2020"
-  title: "Type Profiler: a Progress Report of a Ruby 3 Type Analyzer"
-  raw_title: "[JA] Type Profiler: a Progress Report of a Ruby 3 Type Analyzer / Yusuke Endoh @mametter"
-  event_name: "RubyKaigi Takeout 2020"
-  date: "2020-09-04"
-  published_at: "2020-09-09T06:54:35Z"
-  language: "Japanese"
-  video_provider: "youtube"
-  video_id: "6KcFdQWp8W0"
-  description: |-
-    Type Profiler is a type inference tool for plain Ruby code. It analyzes Ruby code that has no type information and guesses a type of the modules and methods in the code. The output will serve as a signature for external type checkers like Sorbet and Steep. Since 2019, we have been developing the tool as one of the key features for Ruby 3 static analysis, and now it works with some practical applications. In this talk, we briefly explain what and how Type Profiler works, present a roadmap and progress of the development, and discuss how useful it is for practical applications with some demos.
-  speakers:
-    - Yusuke Endoh
-
-- id: "koichi-sasada-rubykaigi-2020"
-  title: "Ractor report"
-  raw_title: "[JA] Ractor report / Koichi Sasada @ko1"
-  event_name: "RubyKaigi Takeout 2020"
-  date: "2020-09-04"
-  published_at: "2020-09-09T06:55:03Z"
-  language: "Japanese"
-  video_provider: "youtube"
-  video_id: "40t8EPpnujg"
-  description: |-
-    This talk will introduce Ractor, the concurrency system for Ruby 3 based on actual implementation.
-
-    At RubyKaigi 2016, I proposed Guild (A proposal of new concurrency model for Ruby 3, http://rubykaigi.org/2016/presentations/ko1.html) and at RubyKaigi 2018, I introduced prototype of it (Guild Prototype - RubyKaigi 2018, https://rubykaigi.org/2018/presentations/ko1.html). For Ruby 3, we renamed Guild to Ractor and finished the first implementation. This talk will introduce Ractor API with current implementation.
-  speakers:
-    - Koichi Sasada
-
-- id: "benoit-daloze-rubykaigi-2020"
-  title: "Running Rack and Rails Faster with TruffleRuby"
-  raw_title: "[EN] Running Rack and Rails Faster with TruffleRuby / Benoit Daloze @eregontp"
-  event_name: "RubyKaigi Takeout 2020"
-  date: "2020-09-04"
-  published_at: "2020-09-09T06:54:49Z"
-  language: "English"
-  video_provider: "youtube"
-  video_id: "281YdMYRAsk"
-  description: |-
-    Optimizing Rack and Rails applications with a just-in-time (JIT) compiler is a challenge. For example, MJIT does not speed up Rails currently. TruffleRuby tackles this challenge. We have been running the Rails Simpler Benchmarks with TruffleRuby and now achieve higher performance than any other Ruby implementation.
-
-    In this talk we’ll show how we got there and what TruffleRuby optimizations are useful for Rack and Rails applications. TruffleRuby is getting ready to speed up your applications, will you try it?
-  speakers:
-    - Benoit Daloze
-
-- id: "ernesto-tagwerker-rubykaigi-2020"
-  title: "RubyMem: The Leaky Gems Database for Bundler"
-  raw_title: "[EN] RubyMem: The Leaky Gems Database for Bundler / Ernesto Tagwerker @etagwerker"
-  event_name: "RubyKaigi Takeout 2020"
-  date: "2020-09-04"
-  published_at: "2020-09-09T06:54:35Z"
-  language: "English"
-  slides_url: "https://speakerdeck.com/etagwerker/rubymem-the-leaky-gems-database-for-bundler-at-ruby-kaigi-takeout-2020"
-  video_provider: "youtube"
-  video_id: "ghaA6LD5OEo"
-  description: |-
-    Out of memory errors are quite tricky. Our first reaction is always the same: "It can't be my code, it must be one of my dependencies!" What if you could quickly check that with bundler?
-
-    In this talk you will learn about memory leaks, out of memory errors, and leaky dependencies. You will learn how to use bundler-leak, a community-driven, open source tool that will make your life easier when debugging memory leaks.
-  speakers:
-    - Ernesto Tagwerker
-
-- id: "kevin-newton-rubykaigi-2020"
-  title: "Prettier Ruby"
-  raw_title: "[EN] Prettier Ruby / Kevin Deisz @kddeisz"
-  event_name: "RubyKaigi Takeout 2020"
-  date: "2020-09-04"
-  published_at: "2020-09-09T06:54:35Z"
-  language: "English"
-  video_provider: "youtube"
-  video_id: "3945FmGGHhw"
-  description: |-
-    Prettier was created in 2017 and has since seen a meteoric rise within the JavaScript community. It differentiated itself from other code formatters and linters by supporting minimal configuration, eliminating the need for long discussions and arguments by enforcing an opinionated style on its users. That enforcement ended up resonating well, as it allowed developers to get back to work on the more important aspects of their job.
-
-    Since then, it has expanded to support other languages and markup, including Ruby. The Ruby plugin is now in use in dozens of applications around the world, and better formatting is being worked on daily. This talk will give you a high-level overview of prettier and how to wield it in your project. It will also dive into the nitty gritty, showing how the plugin was made and how you can help contribute to its growth. You’ll come away with a better understanding of Ruby syntax, knowledge of a new tool and how it can be used to help your team.
-  speakers:
-    - Kevin Newton
-
-- id: "samuel-williams-rubykaigi-2020"
-  title: "Don't Wait For Me! Scalable Concurrency for Ruby 3!"
-  raw_title: "[EN] Don't Wait For Me! Scalable Concurrency for Ruby 3! / Samuel Williams @ioquatix"
-  event_name: "RubyKaigi Takeout 2020"
-  date: "2020-09-04"
-  published_at: "2020-09-09T06:54:51Z"
-  language: "English"
-  video_provider: "youtube"
-  video_id: "Y29SSOS4UOc"
-  description: |-
-    We have proven that fibers are useful for building scalable systems. In order to develop this further, we need to add hooks into the various Ruby VMs so that we can improve the concurrency of existing code without changes. There is an outstanding PR for this work, but additional effort is required to bring this to completion and show its effectiveness in real world situations. We will discuss the implementation of this PR, the implementation of the corresponding Async Scheduler, and how they work together to improve the scalability of Ruby applications.
-  speakers:
-    - Samuel Williams
-
-- id: "ruby-committers-vs-the-world-day-1-rubykaigi-2020"
-  title: "Ruby Committers vs the World - Day 1"
-  raw_title: "Ruby committers vs the World - Day 1 (extended)"
-  kind: "q_and_a"
-  event_name: "RubyKaigi Takeout 2020"
-  date: "2020-09-04"
-  published_at: "2020-09-15T13:27:49Z"
-  language: "Japanese"
-  video_provider: "youtube"
-  video_id: "D-AK1x4vuRU"
-  description: |-
-    https://rubykaigi.org/2020-takeout/presentations/rubylangorg.html#sep04
-  speakers:
-    - Ruby Committers # TODO: list each person
-
-- id: "ruby-committers-vs-the-world-day-2-rubykaigi-2020"
-  title: "Ruby Committers vs the World - Day 2"
-  raw_title: "Ruby committers vs the World - Day 2"
-  kind: "q_and_a"
-  event_name: "RubyKaigi Takeout 2020"
-  date: "2020-09-04"
-  published_at: "2020-10-10T10:16:10Z"
-  language: "Japanese" # + English
-  video_provider: "youtube"
-  video_id: "20VDvtpjGn0"
-  description: |-
-    https://rubykaigi.org/2020-takeout/presentations/rubylangorg.html#sep05
-
-    Ruby core all stars on stage!
-  speakers:
-    - Ruby Committers # TODO: list each person


### PR DESCRIPTION
## Description

Add the schedule for **RubyKaigi Takeout 2020** — the online event held September 4–5, 2020 (the "Takeout" edition run after the in‑person conference was cancelled).

- **New `schedule.yml`** — two days, two tracks (`#rubykaigiA` / `#rubykaigiB`), with Opening / Lunch Break / Closing blocks. Transcribed from the official schedule.
- **Reordered `videos.yml`** so the schedule grid fills correctly (grid slots are filled from `videos.yml` in file order): the 30 scheduled talks are ordered day → row → track A then B, each talk gets a `track:`, and Day 2 talks get `date: "2020-09-05"`.
- **Kept both "Don't @ me! Instance Variable Performance in Ruby" recordings** (English and Japanese). The talk was scheduled once, so the Japanese recording is placed last in `videos.yml`: the 30 scheduled talks map to the grid cleanly while both recordings remain available on the Talks page.
- Removed resolved TODO comments (running order / dates / websites); kept the "Ruby Committers — list each person" note.

No `venue.yml` or `cfp.yml` were added: the event was online‑only (no physical venue) and had no Takeout‑specific call for proposals. Only the display title is "RubyKaigi Takeout 2020"; the event slug stays `rubykaigi-2020`.

## Screenshots

**Day 1 — Friday (Sep 04, 2020)**

![Schedule Day 1](https://raw.githubusercontent.com/yahonda/rubyevents/rubykaigi-takeout-2020-screenshots/pr-screenshots/rk2020-schedule-day1.png)

**Day 2 — Saturday (Sep 05, 2020)**

![Schedule Day 2](https://raw.githubusercontent.com/yahonda/rubyevents/rubykaigi-takeout-2020-screenshots/pr-screenshots/rk2020-schedule-day2.png)

## Testing Steps

Content PR — affected pages (seed the series first, then browse locally):

- Schedule, Day 1: `/events/rubykaigi-2020/schedule`
- Schedule, Day 2: `/events/rubykaigi-2020/schedule/day/2020-09-05`
- Talks (both English & Japanese "Don't @ me!"): `/events/rubykaigi-2020/talks`

Verified locally:

- `bin/rails db:seed:event_series[rubykaigi]` seeds without errors.
- `Event.find_by_slug("rubykaigi-2020").schedule.talk_offsets` ⇒ `[16, 14]`; running order = 31 (30 scheduled + trailing Japanese "Don't @ me!").
- `yerba check` and `validate:events`, `validate:videos`, `validate:data_files`, `validate:unique_video_ids`, `validate:speakers_in_videos` all pass.

## References

- https://rubykaigi.org/2020-takeout/schedule/
- https://rubykaigi.org/2020-takeout/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
