### PR TITLE
Remove claude attributions.

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,7 @@
 {
+  "attribution": {
+    "commit": ""
+  },
   "enabledMcpjsonServers": [
     "rubyevents"
   ],


### PR DESCRIPTION
## Description
<!-- Please describe your changes. -->

We don't want Claude author attributions on commits. You can use whatever tool you want to generate your files as long as they seed and pass validations, but we prefer commits reflect the human that created them. Claude just gets a bit noisy in the backlog and contributor reports.

(We can't currently remove attribution from copilot, but we wish we could).

We're keeping the PR attribution though because it doesn't end up in the history or contributor reports.

## Screenshots
<!-- Add screenshots or GIFs if applicable. -->

## Testing Steps
<!-- List steps to test your changes. -->
<!-- If this is a content PR, link to the affected pages -->

## References
<!-- Link to related issues, discussions, other PRs, or references you used to write the PR. -->
- closes #<!-- issue number -->
