### PR TITLE
Add RubyKaigi Takeout 2021 schedule and CFP

### DIFF
--- a/data/rubykaigi/rubykaigi-2021/cfp.yml
+++ b/data/rubykaigi/rubykaigi-2021/cfp.yml
@@ -1,0 +1,5 @@
+---
+- name: "Call for Proposals"
+  link: "https://cfp.rubykaigi.org/events/2021"
+  open_date: "2021-06-02"
+  close_date: "2021-06-30"

--- a/data/rubykaigi/rubykaigi-2021/event.yml
+++ b/data/rubykaigi/rubykaigi-2021/event.yml
@@ -4,7 +4,8 @@ title: "RubyKaigi Takeout 2021"
 location: "online"
 timezone: "Asia/Tokyo"
 kind: "conference"
-description: ""
+description: |-
+  The in-person RubyKaigi 2021, planned for Mie Prefecture, was cancelled due to COVID-19. RubyKaigi Takeout 2021 is the alternate online conference held in its place.
 start_date: "2021-09-09"
 end_date: "2021-09-11"
 recordings_published_date: "2021-09-12"

--- a/data/rubykaigi/rubykaigi-2021/schedule.yml
+++ b/data/rubykaigi/rubykaigi-2021/schedule.yml
@@ -1,0 +1,122 @@
+---
+# https://rubykaigi.org/2021-takeout/schedule/
+days:
+  - name: "Day 1"
+    date: "2021-09-09"
+    grid:
+      - start_time: "10:00"
+        end_time: "10:55"
+        slots: 1
+
+      - start_time: "11:00"
+        end_time: "11:25"
+        slots: 1
+
+      - start_time: "11:55"
+        end_time: "13:00"
+        slots: 1
+        items:
+          - "Lunch Break"
+
+      - start_time: "13:00"
+        end_time: "13:25"
+        slots: 2
+
+      - start_time: "14:00"
+        end_time: "14:25"
+        slots: 2
+
+      - start_time: "14:30"
+        end_time: "14:55"
+        slots: 2
+
+      - start_time: "15:00"
+        end_time: "15:25"
+        slots: 2
+
+      - start_time: "15:30"
+        end_time: "15:55"
+        slots: 2
+
+      - start_time: "16:00"
+        end_time: "16:25"
+        slots: 2
+
+  - name: "Day 2"
+    date: "2021-09-10"
+    grid:
+      - start_time: "10:00"
+        end_time: "10:55"
+        slots: 1
+
+      - start_time: "11:00"
+        end_time: "11:25"
+        slots: 2
+
+      - start_time: "11:30"
+        end_time: "11:55"
+        slots: 2
+
+      - start_time: "11:55"
+        end_time: "13:00"
+        slots: 1
+        items:
+          - "Lunch Break"
+
+      - start_time: "13:00"
+        end_time: "13:25"
+        slots: 2
+
+      - start_time: "13:30"
+        end_time: "13:55"
+        slots: 2
+
+      - start_time: "14:00"
+        end_time: "14:55"
+        slots: 1
+
+  - name: "Day 3"
+    date: "2021-09-11"
+    grid:
+      - start_time: "10:00"
+        end_time: "10:25"
+        slots: 2
+
+      - start_time: "10:30"
+        end_time: "10:55"
+        slots: 2
+
+      - start_time: "11:00"
+        end_time: "11:25"
+        slots: 2
+
+      - start_time: "11:30"
+        end_time: "11:55"
+        slots: 2
+
+      - start_time: "11:55"
+        end_time: "13:00"
+        slots: 1
+        items:
+          - "Lunch Break"
+
+      - start_time: "13:00"
+        end_time: "13:25"
+        slots: 2
+
+      - start_time: "13:30"
+        end_time: "13:55"
+        slots: 2
+
+      - start_time: "14:00"
+        end_time: "15:00"
+        slots: 1
+
+tracks:
+  - name: "#rubykaigiA"
+    color: "#0B374D"
+    text_color: "#FFFFFF"
+
+  - name: "#rubykaigiB"
+    color: "#2B2B2B"
+    text_color: "#FFFFFF"

--- a/data/rubykaigi/rubykaigi-2021/videos.yml
+++ b/data/rubykaigi/rubykaigi-2021/videos.yml
@@ -1,217 +1,23 @@
 ---
-# TODO: talks running order
-# TODO: talk dates
-# TODO: conference website
-# TODO: schedule website
 
-- id: "hiroshi-shibata-rubykaigi-2021"
-  title: "How to develop the Standard Libraries of Ruby?"
-  raw_title: "[JA] How to develop the Standard Libraries of Ruby? / Hiroshi SHIBATA @hsbt"
+- id: "yusuke-endoh-rubykaigi-2021"
+  title: "Keynote: TypeProf for IDE: Enrich Dev-Experience without Annotations"
+  raw_title: "[JA][Keynote] TypeProf for IDE: Enrich Dev-Experience without Annotations / Yusuke Endoh @mame"
+  kind: "keynote"
   event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11T12:17:23Z"
   language: "Japanese"
-  slides_url: "https://www.slideshare.net/hsbt/how-to-develop-the-standard-libraries-of-ruby"
+  track: "#rubykaigiA"
+  slides_url: "https://www.slideshare.net/mametter/typeprof-for-ide-enrich-development-experience-without-annotations"
   video_provider: "youtube"
-  video_id: "0yZ2fle1zTo"
+  video_id: "uNttp63ELoE"
   description: |-
-    I maintain the RubyGems, Bundler and the standard libraries of the Ruby language. So, I've been extract many of the standard libraries to default gems and GitHub at Ruby 3.0. But the some of libraries still remains in only Ruby repository. I will describe these situation.
+    Ruby 3.0 comes bundled with TypeProf, a code analysis tool that doesn't require so many type annotations. Its primary goal is to create type signatures for existing Ruby programs and help users to apply some external type checkers like Steep. Since the release, we have made an effort to adapt TypeProf to an integrated development environment (IDE), which allows users to enjoy many features supported in an IDE, such as browsing method type signatures inferred on the fly, find definition, find references, error checking, etc. We demonstrate TypeProf for IDE, and present its roadmap.
 
-    So, Rubyists can submit a pull-request for the default gems like net-http, irb or etc after Ruby 3.0. We need to learn about the mechanism of the default gems. and also learn the bundled gems. I will describe a technic for developing the standard libraries with GitHub..
-
-    RubyKaigi Takeout: https://rubykaigi.org/2021-takeout/presentations/hsbt.html
+    RubyKaigi Takeout: https://rubykaigi.org/2021-takeout/presentations/mametter.html
   speakers:
-    - Hiroshi SHIBATA
-
-- id: "misaki-shioi-rubykaigi-2021"
-  title: "Toycol: Define your own application protocol"
-  raw_title: "[JA] Toycol: Define your own application protocol / Misaki Shioi @shioimm"
-  event_name: "RubyKaigi Takeout 2021"
-  date: "2021-09-09"
-  published_at: "2021-09-11T12:17:23Z"
-  language: "Japanese"
-  slides_url: "https://speakerdeck.com/coe401_/toycol-define-your-own-application-protocol"
-  video_provider: "youtube"
-  video_id: "zfuYguzvlbg"
-  description: |-
-    TCP/IP is the protocol stack where each layer is independent.
-
-    So what is a protocol? - It is a set of rules for communication between network nodes. What if you could change these rules at will? For example, why not change our familiar HTTP/1.x to a different communication style?
-
-    I’ve created a minimal framework that translates the custom toy application protocol for the Web into HTTP/1.x, with which you can define the protocol that clients and servers understand. In this talk, I'd like to show the flexibility of this framework with some examples of both nodes that speak in given protocols.
-
-    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/coe401_.html
-  speakers:
-    - Misaki Shioi
-
-- id: "daniel-magliola-rubykaigi-2021"
-  title: "Do regex dream of Turing Completeness?"
-  raw_title: "[EN] Do regex dream of Turing Completeness? / Daniel Magliola @dmagliola"
-  event_name: "RubyKaigi Takeout 2021"
-  date: "2021-09-09"
-  published_at: "2021-09-11T12:17:23Z"
-  language: "English"
-  slides_url: "https://github.com/dmagliola/regex_game_of_life/blob/main/Slides.pdf"
-  video_provider: "youtube"
-  video_id: "hkDZCFBlD5Q"
-  description: |-
-    We're used to using Regular Expressions every day for pattern matching and text replacement, but... What can Regexes actually do? How far can we push them? Can we implement actual logic with them?
-
-    What if I told you... You can actually implement Conway's Game of Life with just a Regex? What if I told you... You can actually implement ANYTHING with just a Regex?
-
-    Join me on a wild ride exploring amazing Game of Life patterns, unusual Regex techniques, Turing Completeness, programatically generating complex Regexes with Ruby, and what all this means for our understanding of what a Regex can do.
-
-    RubyKaigi 2021: https://rubykaigi.org/2021-takeout/presentations/dmagliola.html
-  speakers:
-    - Daniel Magliola
-
-- id: "jeremy-evans-rubykaigi-2021"
-  title: "Optimizing Partial Backtraces in Ruby 3"
-  raw_title: "[EN] Optimizing Partial Backtraces in Ruby 3 / Jeremy Evans @jeremyevans"
-  event_name: "RubyKaigi Takeout 2021"
-  date: "2021-09-09"
-  published_at: "2021-09-11T12:17:23Z"
-  language: "English"
-  slides_url: "http://code.jeremyevans.net/presentations/rubykaigi2021/index.html"
-  video_provider: "youtube"
-  video_id: "QDbj4Y0E5xo"
-  description: |-
-    Backtraces are very useful tools when debugging problems in Ruby programs. Unfortunately, backtrace generation is expensive for deep callstacks. In older versions of Ruby, this is true even if you only want a partial backtrace, such as a single backtrace frame. Thankfully, Ruby 3 has been optimized so that it no longer processes unnecessary backtrace frames, which can greatly speed up the generation of partial backtraces. Join me for an interesting look a Ruby backtraces, how they are generated, how we optimized partial backtraces in Ruby 3, and how we fixed bugs in the optimization in 3.0.1.
-
-    RubyKaigi Takeout: https://rubykaigi.org/2021-takeout/presentations/jeremyevans0.html
-  speakers:
-    - Jeremy Evans
-
-- id: "masatoshi-seki-tatsuya-sonokawa-rubykaigi-2021"
-  title: "dRuby in the real-world embedded systems."
-  raw_title: "[JA] dRuby in the real-world embedded systems. / @seki and @t-sono1809"
-  event_name: "RubyKaigi Takeout 2021"
-  date: "2021-09-09"
-  published_at: "2021-09-11T12:17:23Z"
-  language: "Japanese"
-  slides_url: "https://www.druby.org/seki-RK2021.pdf"
-  video_provider: "youtube"
-  video_id: "kkXKHPRxeyM"
-  description: |-
-    Masatoshi SEKI @seki
-    Tatsuya Sonokawa @t-sono1809
-
-    We will report an example of using dRuby and CRuby (not mruby) in embedded software for small medical devices. In this talk, we will discuss the architecture of our products.
-
-    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/m_seki.html
-  speakers:
-    - Masatoshi SEKI
-    - Tatsuya Sonokawa
-
-- id: "elct9620-rubykaigi-2021"
-  title: "It is time to build your mruby VM on the microcontroller?"
-  raw_title: "[EN] It is time to build your mruby VM on the microcontroller? / 蒼時弦也 @elct9620"
-  event_name: "RubyKaigi Takeout 2021"
-  date: "2021-09-09"
-  published_at: "2021-09-11T12:17:23Z"
-  language: "English"
-  slides_url: "https://speakerdeck.com/elct9620/2021-rubykaigi-it-is-time-to-build-your-mruby-vm-on-the-microcontroller"
-  video_provider: "youtube"
-  video_id: "IqZW3i7HbmY"
-  description: |-
-    In 2020, I find a mini-arcade maker product that uses ESP8622 and MicroPython. Since I know the mruby/c can run on the ESP32 but it doesn't support running on the ESP8622. Is it possible to implement our own mruby VM and execute Ruby on any microcontroller we want to use it? This talk will show my progress to run a simple mruby script on the ESP8622 by implementing my own small mruby VM.
-
-    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/elct9620.html
-  speakers:
-    - elct9620
-
-- id: "martin-j-duerst-rubykaigi-2021"
-  title: "Regular Expressions: Amazing and Dangerous"
-  raw_title: "[EN] Regular Expressions: Amazing and Dangerous / Martin J. Dürst @duerst"
-  event_name: "RubyKaigi Takeout 2021"
-  date: "2021-09-09"
-  published_at: "2021-09-11T12:17:23Z"
-  language: "English"
-  slides_url: "https://www.sw.it.aoyama.ac.jp/2021/pub/RubyKaigi/"
-  video_provider: "youtube"
-  video_id: "bLzUiOm97Ps"
-  description: |-
-    Many Ruby programmers use regular expressions frequently. They are an amazingly powerful tool for many different kinds of text processing. However, if not used carefully, they can also be dangerous: They may not exactly match what their writer thinks they match, and they may execute very slowly on certain inputs. This talk will help you understand regular expressions better, so that you can make good use of their amazing power while avoiding their dangerous sides. It will also discuss recent changes to Ruby in the area of regular expressions.
-
-    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/duerst.html
-  speakers:
-    - Martin J. Dürst
-
-- id: "peter-zhu-matt-valentine-house-rubykaigi-2021"
-  title: "Variable Width Allocation: Optimizing Ruby's Memory Layout"
-  raw_title: "[EN] Variable Width Allocation: Optimizing Ruby's Memory Layout / @peterzhu2118 and @eightbitraptor"
-  event_name: "RubyKaigi Takeout 2021"
-  date: "2021-09-09"
-  published_at: "2021-09-11T12:17:23Z"
-  language: "English"
-  slides_url: "https://blog.peterzhu.ca/assets/rubykaigi_2021_slides.pdf"
-  video_provider: "youtube"
-  video_id: "7C3bdT6Ri2Q"
-  description: |-
-    Peter Zhu @peterzhu2118
-    Matt Valentine-House @eightbitraptor
-
-    Ruby’s current memory model assumes all objects live in fixed size slots. This means that object data is often stored outside of the Ruby heap, which has implications: an object's data can be scattered across many locations, increasing complexity and causing poor locality resulting in reduced efficiency of CPU caches.
-
-    Join us as we explore how our Variable Width Allocation project will move system heap memory into Ruby heap memory, reducing system heap allocations and giving us finer control of the memory layout to optimize for performance.
-  speakers:
-    - Peter Zhu
-    - Matt Valentine-House
-
-- id: "mat-schaffer-rubykaigi-2021"
-  title: "10 years of Ruby-powered citizen science"
-  raw_title: "[EN] 10 years of Ruby-powered citizen science / Mat Schaffer @matschaffer"
-  event_name: "RubyKaigi Takeout 2021"
-  date: "2021-09-09"
-  published_at: "2021-09-11T12:17:23Z"
-  language: "English"
-  slides_url: "https://www.dropbox.com/s/948r8vazc7ie5y4/RubyKaigi2021-10yrs-ruby-powered-citizen-science.pdf?dl=0"
-  video_provider: "youtube"
-  video_id: "Jg8PY00HDnA"
-  description: |-
-    In the wake of the 2011 Tohoku earthquake and tsunami, people were worried for their safety. Safecast answered that call and went on to the largest open radiation database in the world.
-
-    10 years later our science project continues, with Ruby at its heart. Our radiation measurements span the globe and are freely available for anyone to use. And now with projects like Airnote we’re using that expertise to tackle new environmental challenges such as the California wildfires.
-
-    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/matschaffer.html
-  speakers:
-    - Mat Schaffer
-
-- id: "maxime-chevalier-boisvert-rubykaigi-2021"
-  title: "YJIT - Building a new JIT Compiler inside CRuby"
-  raw_title: "[EN] YJIT - Building a new JIT Compiler inside CRuby / Maxime Chevalier-Boisvert @maximecb"
-  event_name: "RubyKaigi Takeout 2021"
-  date: "2021-09-09"
-  published_at: "2021-09-11T12:17:23Z"
-  language: "English"
-  slides_url: "https://rubykaigi.org/2021-takeout/data/slides/Maxime-YJIT-RubyKaigi-2021-slides.pdf"
-  video_provider: "youtube"
-  video_id: "PBVLf3yfMs8"
-  description: |-
-    YJIT, an open source project led by a small team of developers at Shopify to incrementally build a new JIT compiler inside CRuby. Key advantages are that our compiler delivers very fast warm up, and we have complete, fine-grained control over the entire code generation pipeline. In this talk, I present the approach we are taking to implement YJIT and discuss early performance results. The talk will conclude with a discussion of what steps can be taken to unlock higher levels of performance for all JIT compilers built inside CRuby, be it YJIT, MJIT or any future JIT compiler efforts.
-
-    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/maximecb.html
-  speakers:
-    - Maxime Chevalier-Boisvert
-
-- id: "itoyanagi-sakura-rubykaigi-2021"
-  title: "Graphical Terminal User Interface of Ruby 3.1"
-  raw_title: "[EN] Graphical Terminal User Interface of Ruby 3.1 / ITOYANAGI Sakura @aycabta"
-  event_name: "RubyKaigi Takeout 2021"
-  date: "2021-09-09"
-  published_at: "2021-09-11T12:17:24Z"
-  language: "English"
-  slides_url: "https://gist.github.com/aycabta/6057f7edc7f8790c7d1ea38fb663a971"
-  video_provider: "youtube"
-  video_id: "xLeLW-p43bc"
-  description: |-
-    The IRB shipped with Ruby 3.1 provides a dialog window feature on the terminal to achieve autocomplete. This is implemented as a new feature in Reline, which displays a dialog in an interactive user input interface at any time you want.
-
-    In this article, I will show you how to utilize this dialog display feature of Reline, with IRB and the Ruby debugger which is a new feature in Ruby 3.1.
-
-    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/aycabta.html
-  speakers:
-    - ITOYANAGI Sakura
+    - Yusuke Endoh
 
 - id: "why-ruby-s-jit-was-slow-1-rubykaigi-2021"
   title: "Why Ruby's JIT was slow"
@@ -220,6 +26,7 @@
   date: "2021-09-09"
   published_at: "2021-09-11T12:17:23Z"
   language: "English"
+  track: "#rubykaigiA"
   slides_url: "https://speakerdeck.com/k0kubun/rubykaigi-takeout-2021"
   video_provider: "youtube"
   video_id: "db3GHHllRyQ"
@@ -234,26 +41,71 @@
   speakers:
     - Takashi Kokubun
 
-- id: "why-ruby-s-jit-was-slow-2-rubykaigi-2021"
-  title: "Why Ruby's JIT was slow"
-  raw_title: "[JA] Why Ruby's JIT was slow / Takashi Kokubun @k0kubun"
+- id: "jeremy-evans-rubykaigi-2021"
+  title: "Optimizing Partial Backtraces in Ruby 3"
+  raw_title: "[EN] Optimizing Partial Backtraces in Ruby 3 / Jeremy Evans @jeremyevans"
+  event_name: "RubyKaigi Takeout 2021"
+  date: "2021-09-09"
+  published_at: "2021-09-11T12:17:23Z"
+  language: "English"
+  track: "#rubykaigiA"
+  slides_url: "http://code.jeremyevans.net/presentations/rubykaigi2021/index.html"
+  video_provider: "youtube"
+  video_id: "QDbj4Y0E5xo"
+  description: |-
+    Backtraces are very useful tools when debugging problems in Ruby programs. Unfortunately, backtrace generation is expensive for deep callstacks. In older versions of Ruby, this is true even if you only want a partial backtrace, such as a single backtrace frame. Thankfully, Ruby 3 has been optimized so that it no longer processes unnecessary backtrace frames, which can greatly speed up the generation of partial backtraces. Join me for an interesting look a Ruby backtraces, how they are generated, how we optimized partial backtraces in Ruby 3, and how we fixed bugs in the optimization in 3.0.1.
+
+    RubyKaigi Takeout: https://rubykaigi.org/2021-takeout/presentations/jeremyevans0.html
+  speakers:
+    - Jeremy Evans
+
+- id: "koichi-ito-rubykaigi-2021"
+  title: "RuboCop in 2021: Stable and Beyond"
+  raw_title: "[JA] RuboCop in 2021: Stable and Beyond / Koichi ITO @koic"
   event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11T12:17:23Z"
   language: "Japanese"
-  slides_url: "https://speakerdeck.com/k0kubun/rubykaigi-takeout-2021"
+  track: "#rubykaigiB"
+  slides_url: "https://speakerdeck.com/koic/rubocop-in-2021-stable-and-beyond"
   video_provider: "youtube"
-  video_id: "rE5OucBHm18"
+  video_id: "yJF5EKM_zPw"
   description: |-
-    English: https://youtu.be/db3GHHllRyQ
+    RuboCop 1.0 stable version was released last year.
 
-    In Ruby 2.6, we started to use a JIT compiler architecture called "MJIT", which uses a C compiler to generate native code. While it achieved Ruby 3x3 in one benchmark, we had struggled to optimize web application workloads like Rails with MJIT. The good news is we recently figured out why.
+    Well, ​RuboCop v1 provided a background to stable upgrade. On the other hand, RuboCop supports various coding styles and the development is a struggle against false positives and false negatives. So, the improvement must go on. This presentation shows behind the scenes of development to make RuboCop and environment surrounding it better. Finally, I will show several ideas for future RuboCop.
 
-    In this talk, you will hear how JIT architectures impact various benchmarks differently, and why it matters for you. You may or may not benefit from Ruby's JIT, depending on what JIT architecture we'll choose beyond the current MJIT. Let's discuss which direction we'd like to go.
+    Through this talk, you will know about benefits and considerations for upgrading RuboCop.
 
-    https://rubykaigi.org/2021-takeout/presentations/k0kubun.html
+    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/koic.html
   speakers:
-    - Takashi Kokubun
+    - Koichi ITO
+
+- id: "nick-schwaderer-rubykaigi-2021"
+  title: "Ruby Archaeology"
+  raw_title: "[EN] Ruby Archaeology / Nick Schwaderer @schwad"
+  event_name: "RubyKaigi Takeout 2021"
+  date: "2021-09-09"
+  published_at: "2021-09-11T12:17:24Z"
+  language: "English"
+  track: "#rubykaigiA"
+  slides_url: "https://schwaderer-kaigi-2021.herokuapp.com/#2"
+  video_provider: "youtube"
+  video_id: "qv4XniFPapQ"
+  description: |-
+    In 2009 _why tweeted: "programming is rather thankless. you see your works become replaced by superior works in a year. unable to run at all in a few more."
+
+    I take this as a call to action to run old code. In this talk we dig, together, through historical Ruby. We will have fun excavating interesting gems from the past.
+
+    Further, I will answer the following questions:
+
+    - What code greater than 12 years old still runs in Ruby 3.0?
+    - What idioms have changed?
+    -  And for the brave: how can you set up an environment to run Ruby 1.8 code from ~2008 on a modern machine?
+
+    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/schwad4hd14.html
+  speakers:
+    - Nick Schwaderer
 
 - id: "koichi-sasada-rubykaigi-2021"
   title: "The Art of Execution Control for Ruby's Debugger"
@@ -262,6 +114,7 @@
   date: "2021-09-09"
   published_at: "2021-09-11T12:17:24Z"
   language: "Japanese"
+  track: "#rubykaigiB"
   slides_url: "https://www.atdot.net/~ko1/activities/2021_rubykaigi_takeout.pdf"
   video_provider: "youtube"
   video_id: "tfXiL5wDA6Q"
@@ -282,121 +135,49 @@
   speakers:
     - Koichi Sasada
 
-- id: "yusuke-endoh-rubykaigi-2021"
-  title: "Keynote: TypeProf for IDE: Enrich Dev-Experience without Annotations"
-  raw_title: "[JA][Keynote] TypeProf for IDE: Enrich Dev-Experience without Annotations / Yusuke Endoh @mame"
-  kind: "keynote"
+- id: "peter-zhu-matt-valentine-house-rubykaigi-2021"
+  title: "Variable Width Allocation: Optimizing Ruby's Memory Layout"
+  raw_title: "[EN] Variable Width Allocation: Optimizing Ruby's Memory Layout / @peterzhu2118 and @eightbitraptor"
+  event_name: "RubyKaigi Takeout 2021"
+  date: "2021-09-09"
+  published_at: "2021-09-11T12:17:23Z"
+  language: "English"
+  track: "#rubykaigiA"
+  slides_url: "https://blog.peterzhu.ca/assets/rubykaigi_2021_slides.pdf"
+  video_provider: "youtube"
+  video_id: "7C3bdT6Ri2Q"
+  description: |-
+    Peter Zhu @peterzhu2118
+    Matt Valentine-House @eightbitraptor
+
+    Ruby’s current memory model assumes all objects live in fixed size slots. This means that object data is often stored outside of the Ruby heap, which has implications: an object's data can be scattered across many locations, increasing complexity and causing poor locality resulting in reduced efficiency of CPU caches.
+
+    Join us as we explore how our Variable Width Allocation project will move system heap memory into Ruby heap memory, reducing system heap allocations and giving us finer control of the memory layout to optimize for performance.
+  speakers:
+    - Peter Zhu
+    - Matt Valentine-House
+
+- id: "misaki-shioi-rubykaigi-2021"
+  title: "Toycol: Define your own application protocol"
+  raw_title: "[JA] Toycol: Define your own application protocol / Misaki Shioi @shioimm"
   event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11T12:17:23Z"
   language: "Japanese"
-  slides_url: "https://www.slideshare.net/mametter/typeprof-for-ide-enrich-development-experience-without-annotations"
+  track: "#rubykaigiB"
+  slides_url: "https://speakerdeck.com/coe401_/toycol-define-your-own-application-protocol"
   video_provider: "youtube"
-  video_id: "uNttp63ELoE"
+  video_id: "zfuYguzvlbg"
   description: |-
-    Ruby 3.0 comes bundled with TypeProf, a code analysis tool that doesn't require so many type annotations. Its primary goal is to create type signatures for existing Ruby programs and help users to apply some external type checkers like Steep. Since the release, we have made an effort to adapt TypeProf to an integrated development environment (IDE), which allows users to enjoy many features supported in an IDE, such as browsing method type signatures inferred on the fly, find definition, find references, error checking, etc. We demonstrate TypeProf for IDE, and present its roadmap.
+    TCP/IP is the protocol stack where each layer is independent.
 
-    RubyKaigi Takeout: https://rubykaigi.org/2021-takeout/presentations/mametter.html
+    So what is a protocol? - It is a set of rules for communication between network nodes. What if you could change these rules at will? For example, why not change our familiar HTTP/1.x to a different communication style?
+
+    I’ve created a minimal framework that translates the custom toy application protocol for the Web into HTTP/1.x, with which you can define the protocol that clients and servers understand. In this talk, I'd like to show the flexibility of this framework with some examples of both nodes that speak in given protocols.
+
+    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/coe401_.html
   speakers:
-    - Yusuke Endoh
-
-- id: "mike-dalessio-rubykaigi-2021"
-  title: "Building Native Extensions. This Could Take A While..."
-  raw_title: "[EN] Building Native Extensions. This Could Take A While... / Mike Dalessio @flavorjones"
-  event_name: "RubyKaigi Takeout 2021"
-  date: "2021-09-09"
-  published_at: "2021-09-11T12:17:23Z"
-  language: "English"
-  slides_url: "https://docs.google.com/presentation/d/1litUWFDOfIiMRiM39B-eSG5IcJPUG5aKYAAOZ8rWLT0/preview"
-  video_provider: "youtube"
-  video_id: "oktN_CbOJKc"
-  description: |-
-    "Native gems" contain pre-compiled libraries for a specific machine architecture, removing the need to compile the C extension or to install other system dependencies. This leads to a much faster and more reliable installation experience for programmers.
-
-    This talk will provide a deep look at the techniques and toolchain used to ship native versions of Nokogiri and other rubygems with C extensions. Gem maintainers will learn how to build native versions of their own gems, and developers will learn how to use and deploy pre-compiled packages.
-
-    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/flavorjones.html
-  speakers:
-    - Mike Dalessio
-
-- id: "kevin-newton-rubykaigi-2021"
-  title: "Parsing Ruby"
-  raw_title: "[EN] Parsing Ruby / Kevin Newton @kddnewton"
-  event_name: "RubyKaigi Takeout 2021"
-  date: "2021-09-09"
-  published_at: "2021-09-11T12:17:23Z"
-  language: "English"
-  slides_url: "https://speakerdeck.com/kddnewton/parsing-ruby"
-  video_provider: "youtube"
-  video_id: "ijPE7k7iW8I"
-  description: |-
-    Since Ruby's inception, there have been many different projects that parse Ruby code. This includes everything from development tools to Ruby implementations themselves. This talk dives into the technical details and tradeoffs of how each of these tools parses and subsequently understands your applications. After, we'll discuss how you can do the same with your own projects using the Ripper standard library. You'll see just how far we can take this library toward building useful development tools.
-
-    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/kddnewton.html
-  speakers:
-    - Kevin Newton
-
-- id: "nick-schwaderer-rubykaigi-2021"
-  title: "Ruby Archaeology"
-  raw_title: "[EN] Ruby Archaeology / Nick Schwaderer @schwad"
-  event_name: "RubyKaigi Takeout 2021"
-  date: "2021-09-09"
-  published_at: "2021-09-11T12:17:24Z"
-  language: "English"
-  slides_url: "https://schwaderer-kaigi-2021.herokuapp.com/#2"
-  video_provider: "youtube"
-  video_id: "qv4XniFPapQ"
-  description: |-
-    In 2009 _why tweeted: "programming is rather thankless. you see your works become replaced by superior works in a year. unable to run at all in a few more."
-
-    I take this as a call to action to run old code. In this talk we dig, together, through historical Ruby. We will have fun excavating interesting gems from the past.
-
-    Further, I will answer the following questions:
-
-    - What code greater than 12 years old still runs in Ruby 3.0?
-    - What idioms have changed?
-    -  And for the brave: how can you set up an environment to run Ruby 1.8 code from ~2008 on a modern machine?
-
-    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/schwad4hd14.html
-  speakers:
-    - Nick Schwaderer
-
-- id: "chris-seaton-rubykaigi-2021"
-  title: "Keynote: The Future Shape of Ruby Objects"
-  raw_title: "[EN][Keynote] The Future Shape of Ruby Objects / Chris Seaton @chrisseaton"
-  kind: "keynote"
-  event_name: "RubyKaigi Takeout 2021"
-  date: "2021-09-09"
-  published_at: "2021-09-11T12:17:23Z"
-  language: "English"
-  slides_url: "https://www.slideshare.net/ChrisSeaton1/the-future-shape-of-ruby-objects"
-  video_provider: "youtube"
-  video_id: "RqwVEw-Rd5c"
-  description: |-
-    TruffleRuby uses an optimisation called object shapes to optimise Ruby. It automatically learns and understands the layout and types, or the shape, of your objects as your code is running and optimises code to work better with those shapes. As the community tries to make MRI faster, it could be time to adopt object shapes there as well. We’ll talk about what TruffleRuby does, how it does it, and the benefits it achieves in practice.
-
-    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/chrisgseaton.html
-  speakers:
-    - Chris Seaton
-
-- id: "ufuk-kayserilioglu-rubykaigi-2021"
-  title: "Demystifying DSLs for better analysis and understanding"
-  raw_title: "[EN] Demystifying DSLs for better analysis and understanding / Ufuk Kayserilioglu @paracycle"
-  event_name: "RubyKaigi Takeout 2021"
-  date: "2021-09-09"
-  published_at: "2021-09-11T12:17:23Z"
-  language: "English"
-  slides_url: "https://speakerdeck.com/ufuk/demystifying-dsls-for-better-analysis-and-understanding"
-  video_provider: "youtube"
-  video_id: "Ms7_PrryvMM"
-  description: |-
-    The ability to create DSLs is one of the biggest strengths of Ruby. They allow us to write easy to use interfaces and reduce the need for boilerplate code. On the flip side, DSLs encapsulate complex logic which makes it hard for developers to understand what's happening under the covers.
-
-    Surfacing DSLs as static artifacts makes working with them much easier. Generating RBI/RBS files that declare the methods which are dynamically created at runtime, allows static analyzers like Sorbet or Steep to work with DSLs. This also allows for better developers tooling and as some kind of "DSL linter".
-
-    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/paracycle.html
-  speakers:
-    - Ufuk Kayserilioglu
+    - Misaki Shioi
 
 - id: "vinicius-stock-rubykaigi-2021"
   title: "Parallel testing with Ractors: putting CPUs to work"
@@ -405,6 +186,7 @@
   date: "2021-09-09"
   published_at: "2021-09-11T12:17:23Z"
   language: "English"
+  track: "#rubykaigiA"
   slides_url: "https://speakerdeck.com/vinistock/parallel-testing-with-ractors-putting-cpus-to-work"
   video_provider: "youtube"
   video_id: "bvFj6_dulSo"
@@ -417,49 +199,137 @@
   speakers:
     - Vinicius Stock
 
-- id: "masataka-kuwabara-rubykaigi-2021"
-  title: "The newsletter of RBS updates"
-  raw_title: "[JA] The newsletter of RBS updates / Masataka Kuwabara @pocke"
+- id: "masatoshi-seki-tatsuya-sonokawa-rubykaigi-2021"
+  title: "dRuby in the real-world embedded systems."
+  raw_title: "[JA] dRuby in the real-world embedded systems. / @seki and @t-sono1809"
   event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
-  published_at: "2021-09-11T12:17:24Z"
+  published_at: "2021-09-11T12:17:23Z"
   language: "Japanese"
-  slides_url: "https://speakerdeck.com/pocke/the-newsletter-of-rbs-updates"
+  track: "#rubykaigiB"
+  slides_url: "https://www.druby.org/seki-RK2021.pdf"
   video_provider: "youtube"
-  video_id: "AwuSHC6j-48"
+  video_id: "kkXKHPRxeyM"
   description: |-
-    I talk about the RBS updates between Ruby 3.0 and 3.1 in this talk.
+    Masatoshi SEKI @seki
+    Tatsuya Sonokawa @t-sono1809
 
-    RBS for Ruby 3.1 will be released with many changes. I'll pick up and describe some features for this talk.
+    We will report an example of using dRuby and CRuby (not mruby) in embedded software for small medical devices. In this talk, we will discuss the architecture of our products.
 
-    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/p_ck_.html
+    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/m_seki.html
   speakers:
-    - Masataka Kuwabara
+    - Masatoshi SEKI
+    - Tatsuya Sonokawa
 
-- id: "satoshi-moris-tagomori-rubykaigi-2021"
-  title: "Ractor's speed is not light-speed"
-  raw_title: '[EN] Ractor''s speed is not light-speed / Satoshi "moris" Tagomori @tagomoris'
+- id: "martin-j-duerst-rubykaigi-2021"
+  title: "Regular Expressions: Amazing and Dangerous"
+  raw_title: "[EN] Regular Expressions: Amazing and Dangerous / Martin J. Dürst @duerst"
   event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
   published_at: "2021-09-11T12:17:23Z"
   language: "English"
-  slides_url: "https://www.slideshare.net/tagomoris/ractors-speed-is-not-lightspeed"
+  track: "#rubykaigiA"
+  slides_url: "https://www.sw.it.aoyama.ac.jp/2021/pub/RubyKaigi/"
   video_provider: "youtube"
-  video_id: "TR_3xFPCGO8"
+  video_id: "bLzUiOm97Ps"
   description: |-
-    Ractor is the new feature, introduced in Ruby 3.0, to run Ruby code on multiple CPU cores. But unfortunately, Ruby 3.0 is not fully ready for actual workloads. This session will show how we can improve web-app performance by Ractor, and what we have to do to run our web apps on Ractor.
+    Many Ruby programmers use regular expressions frequently. They are an amazingly powerful tool for many different kinds of text processing. However, if not used carefully, they can also be dangerous: They may not exactly match what their writer thinks they match, and they may execute very slowly on certain inputs. This talk will help you understand regular expressions better, so that you can make good use of their amazing power while avoiding their dangerous sides. It will also discuss recent changes to Ruby in the area of regular expressions.
 
-    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/tagomoris.html
+    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/duerst.html
   speakers:
-    - "Satoshi \"moris\" Tagomori"
+    - Martin J. Dürst
+
+- id: "uchio-kondo-rubykaigi-2021"
+  title: "Story of Rucy - How to compile a BPF binary from Ruby"
+  raw_title: '[EN] Story of Rucy - How to "compile" a BPF binary from Ruby / Uchio KONDO @udzura'
+  event_name: "RubyKaigi Takeout 2021"
+  date: "2021-09-09"
+  published_at: "2021-09-12T08:49:34Z"
+  language: "English"
+  track: "#rubykaigiB"
+  slides_url: "https://speakerdeck.com/udzura/story-of-rucy-on-rubykaigi-takeout-2021"
+  video_provider: "youtube"
+  video_id: "qvaXv8exFFQ"
+  description: |-
+    BPF is a technology used in Linux for packet filtering, tracing or access auditing. BPF has its own VM and set of opcodes.
+
+    If you want to write a program that loads and uses BPF binary, you can write it in any language including Ruby.
+
+    However, to prepare a "BPF binary" itself, you generally need to write a bit weird C, and pass it to clang compiler using bpf target.
+
+    Wouldn't it be great if we could make these BPF binaries entirely in Ruby?
+
+    Rucy is intended to allow programmers to write their whole BPF programs in Ruby. I'll discuss how to "compile" BPF binaries from Ruby in this talk.
+
+    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/udzura.html
+  speakers:
+    - Uchio KONDO
+
+- id: "ufuk-kayserilioglu-rubykaigi-2021"
+  title: "Demystifying DSLs for better analysis and understanding"
+  raw_title: "[EN] Demystifying DSLs for better analysis and understanding / Ufuk Kayserilioglu @paracycle"
+  event_name: "RubyKaigi Takeout 2021"
+  date: "2021-09-09"
+  published_at: "2021-09-11T12:17:23Z"
+  language: "English"
+  track: "#rubykaigiA"
+  slides_url: "https://speakerdeck.com/ufuk/demystifying-dsls-for-better-analysis-and-understanding"
+  video_provider: "youtube"
+  video_id: "Ms7_PrryvMM"
+  description: |-
+    The ability to create DSLs is one of the biggest strengths of Ruby. They allow us to write easy to use interfaces and reduce the need for boilerplate code. On the flip side, DSLs encapsulate complex logic which makes it hard for developers to understand what's happening under the covers.
+
+    Surfacing DSLs as static artifacts makes working with them much easier. Generating RBI/RBS files that declare the methods which are dynamically created at runtime, allows static analyzers like Sorbet or Steep to work with DSLs. This also allows for better developers tooling and as some kind of "DSL linter".
+
+    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/paracycle.html
+  speakers:
+    - Ufuk Kayserilioglu
+
+- id: "yamori813-rubykaigi-2021"
+  title: "Falling down from FreeBSD"
+  raw_title: "[JA] Falling down from FreeBSD / やもり @yamori813"
+  event_name: "RubyKaigi Takeout 2021"
+  date: "2021-09-09"
+  published_at: "2021-09-12T08:51:25Z"
+  language: "Japanese"
+  track: "#rubykaigiB"
+  slides_url: "https://rubykaigi.org/2021-takeout/data/slides/Falling.pdf"
+  video_provider: "youtube"
+  video_id: "JvFCljZeF1w"
+  description: |-
+    Why I started mruby on YABM(Yet Another Bare Metal). I describe inside of mruby and how to use it. Also I talked about IoT use case.
+
+    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/yamori813.html
+  speakers:
+    - yamori813
+
+- id: "chris-seaton-rubykaigi-2021"
+  title: "Keynote: The Future Shape of Ruby Objects"
+  raw_title: "[EN][Keynote] The Future Shape of Ruby Objects / Chris Seaton @chrisseaton"
+  kind: "keynote"
+  event_name: "RubyKaigi Takeout 2021"
+  date: "2021-09-10"
+  published_at: "2021-09-11T12:17:23Z"
+  language: "English"
+  track: "#rubykaigiA"
+  slides_url: "https://www.slideshare.net/ChrisSeaton1/the-future-shape-of-ruby-objects"
+  video_provider: "youtube"
+  video_id: "RqwVEw-Rd5c"
+  description: |-
+    TruffleRuby uses an optimisation called object shapes to optimise Ruby. It automatically learns and understands the layout and types, or the shape, of your objects as your code is running and optimises code to work better with those shapes. As the community tries to make MRI faster, it could be time to adopt object shapes there as well. We’ll talk about what TruffleRuby does, how it does it, and the benefits it achieves in practice.
+
+    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/chrisgseaton.html
+  speakers:
+    - Chris Seaton
 
 - id: "benoit-daloze-josef-haider-rubykaigi-2021"
   title: "Just-in-Time Compiling Ruby Regexps on TruffleRuby"
   raw_title: "[EN] Just-in-Time Compiling Ruby Regexps on TruffleRuby / @eregon and @djoooooe"
   event_name: "RubyKaigi Takeout 2021"
-  date: "2021-09-09"
+  date: "2021-09-10"
   published_at: "2021-09-11T12:17:23Z"
   language: "English"
+  track: "#rubykaigiA"
   slides_url: "https://eregon.me/blog/assets/research/just-in-time-compiling-ruby-regexps-on-truffleruby.pdf"
   video_provider: "youtube"
   video_id: "DYPCkR7Ngx8"
@@ -474,13 +344,389 @@
     - Benoit Daloze
     - Josef Haider
 
+- id: "hasumi-hitoshi-rubykaigi-2021"
+  title: "PRK Firmware: Keyboard is Essentially Ruby"
+  raw_title: "[JA] PRK Firmware: Keyboard is Essentially Ruby / Hitoshi HASUMI @hasumikin"
+  event_name: "RubyKaigi Takeout 2021"
+  date: "2021-09-10"
+  published_at: "2021-09-12T08:57:45Z"
+  language: "Japanese"
+  track: "#rubykaigiB"
+  slides_url: "https://slide.rabbit-shocker.org/authors/hasumikin/RubyKaigiTakeout2021/"
+  video_provider: "youtube"
+  video_id: "5unMW_BAd4A"
+  description: |-
+    PRK Firmware is the world's first keyboard firmware framework in Ruby. You can write not only your own "keymap" in Ruby but also additional behavior by features of Ruby like open class system and Proc object.
+
+    Plus, your keyboard itself interprets a Ruby script on the fly. Essentially, your keyboard can become Ruby.
+
+    The ultimate goal is certainly not a small one --- let's make Ruby comparable to projects such as MicroPython, CircuitPython or Lua in terms of viability as a scripting language for microcontrollers.
+
+    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/hasumikin.html
+  speakers:
+    - HASUMI Hitoshi
+
+- id: "maxime-chevalier-boisvert-rubykaigi-2021"
+  title: "YJIT - Building a new JIT Compiler inside CRuby"
+  raw_title: "[EN] YJIT - Building a new JIT Compiler inside CRuby / Maxime Chevalier-Boisvert @maximecb"
+  event_name: "RubyKaigi Takeout 2021"
+  date: "2021-09-10"
+  published_at: "2021-09-11T12:17:23Z"
+  language: "English"
+  track: "#rubykaigiA"
+  slides_url: "https://rubykaigi.org/2021-takeout/data/slides/Maxime-YJIT-RubyKaigi-2021-slides.pdf"
+  video_provider: "youtube"
+  video_id: "PBVLf3yfMs8"
+  description: |-
+    YJIT, an open source project led by a small team of developers at Shopify to incrementally build a new JIT compiler inside CRuby. Key advantages are that our compiler delivers very fast warm up, and we have complete, fine-grained control over the entire code generation pipeline. In this talk, I present the approach we are taking to implement YJIT and discuss early performance results. The talk will conclude with a discussion of what steps can be taken to unlock higher levels of performance for all JIT compilers built inside CRuby, be it YJIT, MJIT or any future JIT compiler efforts.
+
+    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/maximecb.html
+  speakers:
+    - Maxime Chevalier-Boisvert
+
+- id: "masataka-kuwabara-rubykaigi-2021"
+  title: "The newsletter of RBS updates"
+  raw_title: "[JA] The newsletter of RBS updates / Masataka Kuwabara @pocke"
+  event_name: "RubyKaigi Takeout 2021"
+  date: "2021-09-10"
+  published_at: "2021-09-11T12:17:24Z"
+  language: "Japanese"
+  track: "#rubykaigiB"
+  slides_url: "https://speakerdeck.com/pocke/the-newsletter-of-rbs-updates"
+  video_provider: "youtube"
+  video_id: "AwuSHC6j-48"
+  description: |-
+    I talk about the RBS updates between Ruby 3.0 and 3.1 in this talk.
+
+    RBS for Ruby 3.1 will be released with many changes. I'll pick up and describe some features for this talk.
+
+    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/p_ck_.html
+  speakers:
+    - Masataka Kuwabara
+
+- id: "kevin-newton-rubykaigi-2021"
+  title: "Parsing Ruby"
+  raw_title: "[EN] Parsing Ruby / Kevin Newton @kddnewton"
+  event_name: "RubyKaigi Takeout 2021"
+  date: "2021-09-10"
+  published_at: "2021-09-11T12:17:23Z"
+  language: "English"
+  track: "#rubykaigiA"
+  slides_url: "https://speakerdeck.com/kddnewton/parsing-ruby"
+  video_provider: "youtube"
+  video_id: "ijPE7k7iW8I"
+  description: |-
+    Since Ruby's inception, there have been many different projects that parse Ruby code. This includes everything from development tools to Ruby implementations themselves. This talk dives into the technical details and tradeoffs of how each of these tools parses and subsequently understands your applications. After, we'll discuss how you can do the same with your own projects using the Ripper standard library. You'll see just how far we can take this library toward building useful development tools.
+
+    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/kddnewton.html
+  speakers:
+    - Kevin Newton
+
+- id: "shugo-maeda-rubykaigi-2021"
+  title: "include/prepend in refinements should be prohibited"
+  raw_title: "[JA] include/prepend in refinements should be prohibited / Shugo Maeda @shugo"
+  event_name: "RubyKaigi Takeout 2021"
+  date: "2021-09-10"
+  published_at: "2021-09-12T09:00:07Z"
+  language: "Japanese"
+  track: "#rubykaigiB"
+  slides_url: "https://github.com/shugo/RubyKaigiTakeout2021"
+  video_provider: "youtube"
+  video_id: "b4ls7Y_vZMg"
+  description: |-
+    include/prepend in refinements are often used to define the same set of methods in multiple refinements. However it should be prohibited because it has implementation difficulties such as https://bugs.ruby-lang.org/issues/17007 and https://bugs.ruby-lang.org/issues/17379, and tends to be misleading like https://bugs.ruby-lang.org/issues/17374.
+
+    In this talk, I propose a new feature instead of include/prepend in refinements.
+
+    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/shugomaeda.html
+  speakers:
+    - Shugo Maeda
+
+- id: "satoshi-moris-tagomori-rubykaigi-2021"
+  title: "Ractor's speed is not light-speed"
+  raw_title: '[EN] Ractor''s speed is not light-speed / Satoshi "moris" Tagomori @tagomoris'
+  event_name: "RubyKaigi Takeout 2021"
+  date: "2021-09-10"
+  published_at: "2021-09-11T12:17:23Z"
+  language: "English"
+  track: "#rubykaigiA"
+  slides_url: "https://www.slideshare.net/tagomoris/ractors-speed-is-not-lightspeed"
+  video_provider: "youtube"
+  video_id: "TR_3xFPCGO8"
+  description: |-
+    Ractor is the new feature, introduced in Ruby 3.0, to run Ruby code on multiple CPU cores. But unfortunately, Ruby 3.0 is not fully ready for actual workloads. This session will show how we can improve web-app performance by Ractor, and what we have to do to run our web apps on Ractor.
+
+    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/tagomoris.html
+  speakers:
+    - "Satoshi \"moris\" Tagomori"
+
+- id: "itoyanagi-sakura-rubykaigi-2021"
+  title: "Graphical Terminal User Interface of Ruby 3.1"
+  raw_title: "[EN] Graphical Terminal User Interface of Ruby 3.1 / ITOYANAGI Sakura @aycabta"
+  event_name: "RubyKaigi Takeout 2021"
+  date: "2021-09-10"
+  published_at: "2021-09-11T12:17:24Z"
+  language: "English"
+  track: "#rubykaigiB"
+  slides_url: "https://gist.github.com/aycabta/6057f7edc7f8790c7d1ea38fb663a971"
+  video_provider: "youtube"
+  video_id: "xLeLW-p43bc"
+  description: |-
+    The IRB shipped with Ruby 3.1 provides a dialog window feature on the terminal to achieve autocomplete. This is implemented as a new feature in Reline, which displays a dialog in an interactive user input interface at any time you want.
+
+    In this article, I will show you how to utilize this dialog display feature of Reline, with IRB and the Ruby debugger which is a new feature in Ruby 3.1.
+
+    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/aycabta.html
+  speakers:
+    - ITOYANAGI Sakura
+
+- id: "ruby-committers-rubykaigi-2021"
+  title: "Ruby Committers vs the World"
+  raw_title: "Ruby Committers vs the World / CRuby Committers @rubylangorg"
+  kind: "q_and_a"
+  event_name: "RubyKaigi Takeout 2021"
+  date: "2021-09-10"
+  published_at: "2021-09-12T08:55:36Z"
+  language: "Japanese"
+  track: "#rubykaigiA"
+  slides_url: "https://docs.google.com/presentation/d/1vOlNnRppAKvzm9NXXX8OfnXMP52Du2M3aVttqiq9TJo/preview"
+  video_provider: "youtube"
+  video_id: "zQnN1pqK4FQ"
+  description: |-
+    Ruby core committers on stage!
+
+    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/rubylangorg.html
+  speakers:
+    - Ruby Committers # TODO: list each person
+
+- id: "daniel-magliola-rubykaigi-2021"
+  title: "Do regex dream of Turing Completeness?"
+  raw_title: "[EN] Do regex dream of Turing Completeness? / Daniel Magliola @dmagliola"
+  event_name: "RubyKaigi Takeout 2021"
+  date: "2021-09-11"
+  published_at: "2021-09-11T12:17:23Z"
+  language: "English"
+  track: "#rubykaigiA"
+  slides_url: "https://github.com/dmagliola/regex_game_of_life/blob/main/Slides.pdf"
+  video_provider: "youtube"
+  video_id: "hkDZCFBlD5Q"
+  description: |-
+    We're used to using Regular Expressions every day for pattern matching and text replacement, but... What can Regexes actually do? How far can we push them? Can we implement actual logic with them?
+
+    What if I told you... You can actually implement Conway's Game of Life with just a Regex? What if I told you... You can actually implement ANYTHING with just a Regex?
+
+    Join me on a wild ride exploring amazing Game of Life patterns, unusual Regex techniques, Turing Completeness, programatically generating complex Regexes with Ruby, and what all this means for our understanding of what a Regex can do.
+
+    RubyKaigi 2021: https://rubykaigi.org/2021-takeout/presentations/dmagliola.html
+  speakers:
+    - Daniel Magliola
+
+- id: "osyo-manga-rubykaigi-2021"
+  title: "Use Macro all the time ~ マクロを使いまくろ ~"
+  raw_title: "[JA] Use Macro all the time ~ マクロを使いまくろ ~ / osyo @osyo-manga"
+  event_name: "RubyKaigi Takeout 2021"
+  date: "2021-09-11"
+  published_at: "2021-09-12T09:05:55Z"
+  language: "Japanese"
+  track: "#rubykaigiB"
+  slides_url: "https://speakerdeck.com/osyo/use-macro-all-the-time-makurowoshi-imakuro-english"
+  video_provider: "youtube"
+  video_id: "w2B99qYrkX8"
+  description: |-
+    Ruby can get AST with RubyVM::AbstractSyntaxTree. I have implemented to convert AST into Ruby code. This will allow you to modify and execute Ruby code at AST level.
+
+    Ruby code → Convert to AST → Convert to another AST → Convert AST to Ruby code → Run Ruby code
+
+    In this session, I will discuss "Implementations for converting AST to Ruby code" and "Implementations for converting AST to another AST". This feature of "converting to another AST" is similar to what is called a "Macro" in other languages. Let's think together about what happens when we implement "Macro" in Ruby.
+
+    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/pink_bangbi.html
+  speakers:
+    - osyo-manga
+
+- id: "mauro-eldritch-rubykaigi-2021"
+  title: "Crafting exploits, tools and havoc with Ruby"
+  raw_title: "[EN] Crafting exploits, tools and havoc with Ruby / Mauro Eldritch @MauroEldritch"
+  event_name: "RubyKaigi Takeout 2021"
+  date: "2021-09-11"
+  published_at: "2021-09-12T08:52:56Z"
+  language: "English"
+  track: "#rubykaigiA"
+  slides_url: "https://docs.google.com/presentation/d/1Rnqma2C2G4ubAw6SHv7qDBALUYIk8V1sc3p9Y0NcgX4/preview?slide=id.p3"
+  video_provider: "youtube"
+  video_id: "LIECErdtTDc"
+  description: |-
+    Can I use ruby to ...? Create Websites? Yes Create Applications? Yes Wreak havoc, write exploits, and hack stuff? Of course!
+
+    During this session we will analyze different exploits and tools written in Ruby by the author: from scanners and bruteforcers to C2 servers and complex exploits.
+
+    Each exploit will be explained in a simple and friendly way for newcomers, and different samples and libraries will be shared so that anyone interested can start building its ruby-powered hacking toolbox.
+
+    There will also be a short lab demo of these tools. Take a seat, grab an exploit, hack stuff.
+
+    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/MauroEldritch.html
+  speakers:
+    - Mauro Eldritch
+
+- id: "kenta-murata-rubykaigi-2021"
+  title: "Charty: Statistical data visualization in Ruby"
+  raw_title: "[JA] Charty: Statistical data visualization in Ruby / Kenta Murata @mrkn"
+  event_name: "RubyKaigi Takeout 2021"
+  date: "2021-09-11"
+  published_at: "2021-09-11T12:17:23Z"
+  language: "Japanese"
+  track: "#rubykaigiB"
+  slides_url: "https://nbviewer.jupyter.org/github/mrkn/talks/blob/master/2021/rubykaigi2021-takeout/rubykaigi2021-takeout.ipynb"
+  video_provider: "youtube"
+  video_id: "iHOWyQt4y-Q"
+  description: |-
+    Have you ever thought it would be better to make stylish charts by Ruby for daily data visualization tasks that sometimes occur? I will make that wish come true! Using Charty, you can do it by Ruby.
+
+    Charty makes statistical data visualization easier. If you want to put error bars in a bar plot, you must calculate the mean and the 95% confidence interval before plotting. Charty performs these calculations instead of you. Moreover, Charty can recognize many data types as table data and supports files, Jupyter Notebook, JupyerLab, VSCode, and a terminal emulator as the output destination.
+
+    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/mrkn.html
+  speakers:
+    - Kenta Murata
+
+- id: "mike-dalessio-rubykaigi-2021"
+  title: "Building Native Extensions. This Could Take A While..."
+  raw_title: "[EN] Building Native Extensions. This Could Take A While... / Mike Dalessio @flavorjones"
+  event_name: "RubyKaigi Takeout 2021"
+  date: "2021-09-11"
+  published_at: "2021-09-11T12:17:23Z"
+  language: "English"
+  track: "#rubykaigiA"
+  slides_url: "https://docs.google.com/presentation/d/1litUWFDOfIiMRiM39B-eSG5IcJPUG5aKYAAOZ8rWLT0/preview"
+  video_provider: "youtube"
+  video_id: "oktN_CbOJKc"
+  description: |-
+    "Native gems" contain pre-compiled libraries for a specific machine architecture, removing the need to compile the C extension or to install other system dependencies. This leads to a much faster and more reliable installation experience for programmers.
+
+    This talk will provide a deep look at the techniques and toolchain used to ship native versions of Nokogiri and other rubygems with C extensions. Gem maintainers will learn how to build native versions of their own gems, and developers will learn how to use and deploy pre-compiled packages.
+
+    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/flavorjones.html
+  speakers:
+    - Mike Dalessio
+
+- id: "mari-imaizumi-rubykaigi-2021"
+  title: "Dive into Encoding"
+  raw_title: "[JA] Dive into Encoding / Mari Imaizumi @ima1zumi"
+  event_name: "RubyKaigi Takeout 2021"
+  date: "2021-09-11"
+  published_at: "2021-09-12T09:03:36Z"
+  language: "Japanese"
+  track: "#rubykaigiB"
+  slides_url: "https://speakerdeck.com/ima1zumi/dive-into-encoding"
+  video_provider: "youtube"
+  video_id: "9PA6twS9Oq4"
+  description: |-
+    Each Ruby String object has an encoding internally. Therefore, it can use a different encoding in the same application. It's very convenient. So, how does Ruby encode a String? What does it mean to have an encoding for each String? As they say, practice makes perfect, so I figured I could understand it by adding self-made encoding. This talk would like to try to add self-made encoding in Ruby and see how Ruby handles encodings.
+
+    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/ima1zumi.html
+  speakers:
+    - Mari Imaizumi
+
+- id: "richard-schneeman-rubykaigi-2021"
+  title: "Beware the Dead End!!"
+  raw_title: "[EN] Beware the Dead End!! / Richard Schneeman @schneems"
+  event_name: "RubyKaigi Takeout 2021"
+  date: "2021-09-11"
+  published_at: "2021-09-11T12:17:23Z"
+  language: "English"
+  track: "#rubykaigiA"
+  slides_url: "https://speakerdeck.com/schneems/beware-the-dead-end"
+  video_provider: "youtube"
+  video_id: "oL_yxJN8534"
+  description: |-
+    Nothing stops a program from executing quite as fast as a syntax error. After years of “unexpected end” in my dev life, I decided to “do” something about it. In this talk we'll cover lexing, parsing, and indentation informed syntax tree search that power that dead_end Ruby library.
+
+    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/schneems.html
+  speakers:
+    - Richard Schneeman
+
+- id: "hiroshi-shibata-rubykaigi-2021"
+  title: "How to develop the Standard Libraries of Ruby?"
+  raw_title: "[JA] How to develop the Standard Libraries of Ruby? / Hiroshi SHIBATA @hsbt"
+  event_name: "RubyKaigi Takeout 2021"
+  date: "2021-09-11"
+  published_at: "2021-09-11T12:17:23Z"
+  language: "Japanese"
+  track: "#rubykaigiB"
+  slides_url: "https://www.slideshare.net/hsbt/how-to-develop-the-standard-libraries-of-ruby"
+  video_provider: "youtube"
+  video_id: "0yZ2fle1zTo"
+  description: |-
+    I maintain the RubyGems, Bundler and the standard libraries of the Ruby language. So, I've been extract many of the standard libraries to default gems and GitHub at Ruby 3.0. But the some of libraries still remains in only Ruby repository. I will describe these situation.
+
+    So, Rubyists can submit a pull-request for the default gems like net-http, irb or etc after Ruby 3.0. We need to learn about the mechanism of the default gems. and also learn the bundled gems. I will describe a technic for developing the standard libraries with GitHub..
+
+    RubyKaigi Takeout: https://rubykaigi.org/2021-takeout/presentations/hsbt.html
+  speakers:
+    - Hiroshi SHIBATA
+
+- id: "elct9620-rubykaigi-2021"
+  title: "It is time to build your mruby VM on the microcontroller?"
+  raw_title: "[EN] It is time to build your mruby VM on the microcontroller? / 蒼時弦也 @elct9620"
+  event_name: "RubyKaigi Takeout 2021"
+  date: "2021-09-11"
+  published_at: "2021-09-11T12:17:23Z"
+  language: "English"
+  track: "#rubykaigiA"
+  slides_url: "https://speakerdeck.com/elct9620/2021-rubykaigi-it-is-time-to-build-your-mruby-vm-on-the-microcontroller"
+  video_provider: "youtube"
+  video_id: "IqZW3i7HbmY"
+  description: |-
+    In 2020, I find a mini-arcade maker product that uses ESP8622 and MicroPython. Since I know the mruby/c can run on the ESP32 but it doesn't support running on the ESP8622. Is it possible to implement our own mruby VM and execute Ruby on any microcontroller we want to use it? This talk will show my progress to run a simple mruby script on the ESP8622 by implementing my own small mruby VM.
+
+    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/elct9620.html
+  speakers:
+    - elct9620
+
+- id: "yusuke-nakamura-rubykaigi-2021"
+  title: "Ruby, Ractor, QUIC"
+  raw_title: "[JA] Ruby, Ractor, QUIC / Yusuke Nakamura @unasuke"
+  event_name: "RubyKaigi Takeout 2021"
+  date: "2021-09-11"
+  published_at: "2021-09-12T09:07:32Z"
+  language: "Japanese"
+  track: "#rubykaigiB"
+  slides_url: "https://slide.rabbit-shocker.org/authors/unasuke/rubykaigi-takeout-2021/"
+  video_provider: "youtube"
+  video_id: "9da7QccHXV4"
+  description: |-
+    From Ruby 3, a parallel processing mechanism called Ractor has been introduced. This has made it easy to implement safe parallel processing in Ruby. In addition, QUIC, which was announced by Google in 2013, standardized in May 2021, and will be used more and more in the future. In this presentation, I will explain what QUIC is, whether it is possible to implement a QUIC server and client with Ractor introduced in Ruby 3, and if so, why it is difficult or impossible.
+
+    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/yu_suke1994.html
+  speakers:
+    - Yusuke Nakamura
+
+- id: "mat-schaffer-rubykaigi-2021"
+  title: "10 years of Ruby-powered citizen science"
+  raw_title: "[EN] 10 years of Ruby-powered citizen science / Mat Schaffer @matschaffer"
+  event_name: "RubyKaigi Takeout 2021"
+  date: "2021-09-11"
+  published_at: "2021-09-11T12:17:23Z"
+  language: "English"
+  track: "#rubykaigiA"
+  slides_url: "https://www.dropbox.com/s/948r8vazc7ie5y4/RubyKaigi2021-10yrs-ruby-powered-citizen-science.pdf?dl=0"
+  video_provider: "youtube"
+  video_id: "Jg8PY00HDnA"
+  description: |-
+    In the wake of the 2011 Tohoku earthquake and tsunami, people were worried for their safety. Safecast answered that call and went on to the largest open radiation database in the world.
+
+    10 years later our science project continues, with Ruby at its heart. Our radiation measurements span the globe and are freely available for anyone to use. And now with projects like Airnote we’re using that expertise to tackle new environmental challenges such as the California wildfires.
+
+    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/matschaffer.html
+  speakers:
+    - Mat Schaffer
+
 - id: "sutou-kouhei-rubykaigi-2021"
   title: "Red Arrow - Ruby and Apache Arrow"
   raw_title: "[JA] Red Arrow - Ruby and Apache Arrow / Sutou Kouhei @kou"
   event_name: "RubyKaigi Takeout 2021"
-  date: "2021-09-09"
+  date: "2021-09-11"
   published_at: "2021-09-11T12:17:23Z"
   language: "Japanese"
+  track: "#rubykaigiB"
   slides_url: "https://slide.rabbit-shocker.org/authors/kou/rubykaigi-takeout-2021/"
   video_provider: "youtube"
   video_id: "okXiuYiP2C4"
@@ -503,88 +749,15 @@
   speakers:
     - Sutou Kouhei
 
-- id: "kenta-murata-rubykaigi-2021"
-  title: "Charty: Statistical data visualization in Ruby"
-  raw_title: "[JA] Charty: Statistical data visualization in Ruby / Kenta Murata @mrkn"
-  event_name: "RubyKaigi Takeout 2021"
-  date: "2021-09-09"
-  published_at: "2021-09-11T12:17:23Z"
-  language: "Japanese"
-  slides_url: "https://nbviewer.jupyter.org/github/mrkn/talks/blob/master/2021/rubykaigi2021-takeout/rubykaigi2021-takeout.ipynb"
-  video_provider: "youtube"
-  video_id: "iHOWyQt4y-Q"
-  description: |-
-    Have you ever thought it would be better to make stylish charts by Ruby for daily data visualization tasks that sometimes occur? I will make that wish come true! Using Charty, you can do it by Ruby.
-
-    Charty makes statistical data visualization easier. If you want to put error bars in a bar plot, you must calculate the mean and the 95% confidence interval before plotting. Charty performs these calculations instead of you. Moreover, Charty can recognize many data types as table data and supports files, Jupyter Notebook, JupyerLab, VSCode, and a terminal emulator as the output destination.
-
-    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/mrkn.html
-  speakers:
-    - Kenta Murata
-
-- id: "koichi-ito-rubykaigi-2021"
-  title: "RuboCop in 2021: Stable and Beyond"
-  raw_title: "[JA] RuboCop in 2021: Stable and Beyond / Koichi ITO @koic"
-  event_name: "RubyKaigi Takeout 2021"
-  date: "2021-09-09"
-  published_at: "2021-09-11T12:17:23Z"
-  language: "Japanese"
-  slides_url: "https://speakerdeck.com/koic/rubocop-in-2021-stable-and-beyond"
-  video_provider: "youtube"
-  video_id: "yJF5EKM_zPw"
-  description: |-
-    RuboCop 1.0 stable version was released last year.
-
-    Well, ​RuboCop v1 provided a background to stable upgrade. On the other hand, RuboCop supports various coding styles and the development is a struggle against false positives and false negatives. So, the improvement must go on. This presentation shows behind the scenes of development to make RuboCop and environment surrounding it better. Finally, I will show several ideas for future RuboCop.
-
-    Through this talk, you will know about benefits and considerations for upgrading RuboCop.
-
-    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/koic.html
-  speakers:
-    - Koichi ITO
-
-- id: "richard-schneeman-rubykaigi-2021"
-  title: "Beware the Dead End!!"
-  raw_title: "[EN] Beware the Dead End!! / Richard Schneeman @schneems"
-  event_name: "RubyKaigi Takeout 2021"
-  date: "2021-09-09"
-  published_at: "2021-09-11T12:17:23Z"
-  language: "English"
-  slides_url: "https://speakerdeck.com/schneems/beware-the-dead-end"
-  video_provider: "youtube"
-  video_id: "oL_yxJN8534"
-  description: |-
-    Nothing stops a program from executing quite as fast as a syntax error. After years of “unexpected end” in my dev life, I decided to “do” something about it. In this talk we'll cover lexing, parsing, and indentation informed syntax tree search that power that dead_end Ruby library.
-
-    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/schneems.html
-  speakers:
-    - Richard Schneeman
-
-- id: "yamori813-rubykaigi-2021"
-  title: "Falling down from FreeBSD"
-  raw_title: "[JA] Falling down from FreeBSD / やもり @yamori813"
-  event_name: "RubyKaigi Takeout 2021"
-  date: "2021-09-09"
-  published_at: "2021-09-12T08:51:25Z"
-  language: "Japanese"
-  slides_url: "https://rubykaigi.org/2021-takeout/data/slides/Falling.pdf"
-  video_provider: "youtube"
-  video_id: "JvFCljZeF1w"
-  description: |-
-    Why I started mruby on YABM(Yet Another Bare Metal). I describe inside of mruby and how to use it. Also I talked about IoT use case.
-
-    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/yamori813.html
-  speakers:
-    - yamori813
-
 - id: "yukihiro-matz-matsumoto-rubykaigi-2021"
   title: "Keynote: Beyond Ruby 3.0"
   raw_title: '[JA] Matz Keynote / Yukihiro "Matz" Matsumoto @matz'
   kind: "keynote"
   event_name: "RubyKaigi Takeout 2021"
-  date: "2021-09-09"
+  date: "2021-09-11"
   published_at: "2021-09-12T09:01:44Z"
   language: "Japanese"
+  track: "#rubykaigiA"
   slides_url: "https://drive.google.com/file/d/1goaSTy5M58m-odqlZHpQVCme9hvUAkRw/view"
   video_provider: "youtube"
   video_id: "QQASprf5EGw"
@@ -593,163 +766,24 @@
   speakers:
     - "Yukihiro \"Matz\" Matsumoto"
 
-- id: "hasumi-hitoshi-rubykaigi-2021"
-  title: "PRK Firmware: Keyboard is Essentially Ruby"
-  raw_title: "[JA] PRK Firmware: Keyboard is Essentially Ruby / Hitoshi HASUMI @hasumikin"
+- id: "why-ruby-s-jit-was-slow-2-rubykaigi-2021"
+  title: "Why Ruby's JIT was slow"
+  raw_title: "[JA] Why Ruby's JIT was slow / Takashi Kokubun @k0kubun"
   event_name: "RubyKaigi Takeout 2021"
   date: "2021-09-09"
-  published_at: "2021-09-12T08:57:45Z"
+  published_at: "2021-09-11T12:17:23Z"
   language: "Japanese"
-  slides_url: "https://slide.rabbit-shocker.org/authors/hasumikin/RubyKaigiTakeout2021/"
+  track: "#rubykaigiA"
+  slides_url: "https://speakerdeck.com/k0kubun/rubykaigi-takeout-2021"
   video_provider: "youtube"
-  video_id: "5unMW_BAd4A"
+  video_id: "rE5OucBHm18"
   description: |-
-    PRK Firmware is the world's first keyboard firmware framework in Ruby. You can write not only your own "keymap" in Ruby but also additional behavior by features of Ruby like open class system and Proc object.
+    English: https://youtu.be/db3GHHllRyQ
 
-    Plus, your keyboard itself interprets a Ruby script on the fly. Essentially, your keyboard can become Ruby.
+    In Ruby 2.6, we started to use a JIT compiler architecture called "MJIT", which uses a C compiler to generate native code. While it achieved Ruby 3x3 in one benchmark, we had struggled to optimize web application workloads like Rails with MJIT. The good news is we recently figured out why.
 
-    The ultimate goal is certainly not a small one --- let's make Ruby comparable to projects such as MicroPython, CircuitPython or Lua in terms of viability as a scripting language for microcontrollers.
+    In this talk, you will hear how JIT architectures impact various benchmarks differently, and why it matters for you. You may or may not benefit from Ruby's JIT, depending on what JIT architecture we'll choose beyond the current MJIT. Let's discuss which direction we'd like to go.
 
-    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/hasumikin.html
+    https://rubykaigi.org/2021-takeout/presentations/k0kubun.html
   speakers:
-    - HASUMI Hitoshi
-
-- id: "ruby-committers-rubykaigi-2021"
-  title: "Ruby Committers vs the World"
-  raw_title: "Ruby Committers vs the World / CRuby Committers @rubylangorg"
-  kind: "q_and_a"
-  event_name: "RubyKaigi Takeout 2021"
-  date: "2021-09-09"
-  published_at: "2021-09-12T08:55:36Z"
-  language: "Japanese"
-  slides_url: "https://docs.google.com/presentation/d/1vOlNnRppAKvzm9NXXX8OfnXMP52Du2M3aVttqiq9TJo/preview"
-  video_provider: "youtube"
-  video_id: "zQnN1pqK4FQ"
-  description: |-
-    Ruby core committers on stage!
-
-    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/rubylangorg.html
-  speakers:
-    - Ruby Committers # TODO: list each person
-
-- id: "yusuke-nakamura-rubykaigi-2021"
-  title: "Ruby, Ractor, QUIC"
-  raw_title: "[JA] Ruby, Ractor, QUIC / Yusuke Nakamura @unasuke"
-  event_name: "RubyKaigi Takeout 2021"
-  date: "2021-09-09"
-  published_at: "2021-09-12T09:07:32Z"
-  language: "Japanese"
-  slides_url: "https://slide.rabbit-shocker.org/authors/unasuke/rubykaigi-takeout-2021/"
-  video_provider: "youtube"
-  video_id: "9da7QccHXV4"
-  description: |-
-    From Ruby 3, a parallel processing mechanism called Ractor has been introduced. This has made it easy to implement safe parallel processing in Ruby. In addition, QUIC, which was announced by Google in 2013, standardized in May 2021, and will be used more and more in the future. In this presentation, I will explain what QUIC is, whether it is possible to implement a QUIC server and client with Ractor introduced in Ruby 3, and if so, why it is difficult or impossible.
-
-    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/yu_suke1994.html
-  speakers:
-    - Yusuke Nakamura
-
-- id: "mari-imaizumi-rubykaigi-2021"
-  title: "Dive into Encoding"
-  raw_title: "[JA] Dive into Encoding / Mari Imaizumi @ima1zumi"
-  event_name: "RubyKaigi Takeout 2021"
-  date: "2021-09-09"
-  published_at: "2021-09-12T09:03:36Z"
-  language: "Japanese"
-  slides_url: "https://speakerdeck.com/ima1zumi/dive-into-encoding"
-  video_provider: "youtube"
-  video_id: "9PA6twS9Oq4"
-  description: |-
-    Each Ruby String object has an encoding internally. Therefore, it can use a different encoding in the same application. It's very convenient. So, how does Ruby encode a String? What does it mean to have an encoding for each String? As they say, practice makes perfect, so I figured I could understand it by adding self-made encoding. This talk would like to try to add self-made encoding in Ruby and see how Ruby handles encodings.
-
-    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/ima1zumi.html
-  speakers:
-    - Mari Imaizumi
-
-- id: "mauro-eldritch-rubykaigi-2021"
-  title: "Crafting exploits, tools and havoc with Ruby"
-  raw_title: "[EN] Crafting exploits, tools and havoc with Ruby / Mauro Eldritch @MauroEldritch"
-  event_name: "RubyKaigi Takeout 2021"
-  date: "2021-09-09"
-  published_at: "2021-09-12T08:52:56Z"
-  language: "English"
-  slides_url: "https://docs.google.com/presentation/d/1Rnqma2C2G4ubAw6SHv7qDBALUYIk8V1sc3p9Y0NcgX4/preview?slide=id.p3"
-  video_provider: "youtube"
-  video_id: "LIECErdtTDc"
-  description: |-
-    Can I use ruby to ...? Create Websites? Yes Create Applications? Yes Wreak havoc, write exploits, and hack stuff? Of course!
-
-    During this session we will analyze different exploits and tools written in Ruby by the author: from scanners and bruteforcers to C2 servers and complex exploits.
-
-    Each exploit will be explained in a simple and friendly way for newcomers, and different samples and libraries will be shared so that anyone interested can start building its ruby-powered hacking toolbox.
-
-    There will also be a short lab demo of these tools. Take a seat, grab an exploit, hack stuff.
-
-    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/MauroEldritch.html
-  speakers:
-    - Mauro Eldritch
-
-- id: "uchio-kondo-rubykaigi-2021"
-  title: "Story of Rucy - How to compile a BPF binary from Ruby"
-  raw_title: '[EN] Story of Rucy - How to "compile" a BPF binary from Ruby / Uchio KONDO @udzura'
-  event_name: "RubyKaigi Takeout 2021"
-  date: "2021-09-09"
-  published_at: "2021-09-12T08:49:34Z"
-  language: "English"
-  slides_url: "https://speakerdeck.com/udzura/story-of-rucy-on-rubykaigi-takeout-2021"
-  video_provider: "youtube"
-  video_id: "qvaXv8exFFQ"
-  description: |-
-    BPF is a technology used in Linux for packet filtering, tracing or access auditing. BPF has its own VM and set of opcodes.
-
-    If you want to write a program that loads and uses BPF binary, you can write it in any language including Ruby.
-
-    However, to prepare a "BPF binary" itself, you generally need to write a bit weird C, and pass it to clang compiler using bpf target.
-
-    Wouldn't it be great if we could make these BPF binaries entirely in Ruby?
-
-    Rucy is intended to allow programmers to write their whole BPF programs in Ruby. I'll discuss how to "compile" BPF binaries from Ruby in this talk.
-
-    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/udzura.html
-  speakers:
-    - Uchio KONDO
-
-- id: "osyo-manga-rubykaigi-2021"
-  title: "Use Macro all the time ~ マクロを使いまくろ ~"
-  raw_title: "[JA] Use Macro all the time ~ マクロを使いまくろ ~ / osyo @osyo-manga"
-  event_name: "RubyKaigi Takeout 2021"
-  date: "2021-09-09"
-  published_at: "2021-09-12T09:05:55Z"
-  language: "Japanese"
-  slides_url: "https://speakerdeck.com/osyo/use-macro-all-the-time-makurowoshi-imakuro-english"
-  video_provider: "youtube"
-  video_id: "w2B99qYrkX8"
-  description: |-
-    Ruby can get AST with RubyVM::AbstractSyntaxTree. I have implemented to convert AST into Ruby code. This will allow you to modify and execute Ruby code at AST level.
-
-    Ruby code → Convert to AST → Convert to another AST → Convert AST to Ruby code → Run Ruby code
-
-    In this session, I will discuss "Implementations for converting AST to Ruby code" and "Implementations for converting AST to another AST". This feature of "converting to another AST" is similar to what is called a "Macro" in other languages. Let's think together about what happens when we implement "Macro" in Ruby.
-
-    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/pink_bangbi.html
-  speakers:
-    - osyo-manga
-
-- id: "shugo-maeda-rubykaigi-2021"
-  title: "include/prepend in refinements should be prohibited"
-  raw_title: "[JA] include/prepend in refinements should be prohibited / Shugo Maeda @shugo"
-  event_name: "RubyKaigi Takeout 2021"
-  date: "2021-09-09"
-  published_at: "2021-09-12T09:00:07Z"
-  language: "Japanese"
-  slides_url: "https://github.com/shugo/RubyKaigiTakeout2021"
-  video_provider: "youtube"
-  video_id: "b4ls7Y_vZMg"
-  description: |-
-    include/prepend in refinements are often used to define the same set of methods in multiple refinements. However it should be prohibited because it has implementation difficulties such as https://bugs.ruby-lang.org/issues/17007 and https://bugs.ruby-lang.org/issues/17379, and tends to be misleading like https://bugs.ruby-lang.org/issues/17374.
-
-    In this talk, I propose a new feature instead of include/prepend in refinements.
-
-    RubyKaigi Takeout 2021: https://rubykaigi.org/2021-takeout/presentations/shugomaeda.html
-  speakers:
-    - Shugo Maeda
+    - Takashi Kokubun


### PR DESCRIPTION
## Description

Add the schedule and CFP for **RubyKaigi Takeout 2021** — the online event held September 9–11, 2021, in place of the cancelled in-person RubyKaigi 2021.

- **New `schedule.yml`** — three days, two tracks (`#rubykaigiA` / `#rubykaigiB`), with Lunch Break blocks. Transcribed from the official schedule. Track colors use the event's brand palette (`#0B374D` / `#2B2B2B`).
- **New `cfp.yml`** — the CFP opened on 2021-06-02 ([announcement tweet](https://x.com/rubykaigi/status/1400060997868474371)) and closed on 2021-06-30 23:59 JST ([CFP page](https://cfp.rubykaigi.org/events/2021)).
- **Reordered `videos.yml`** so the schedule grid fills correctly (grid slots are filled from `videos.yml` in file order): the 37 scheduled talks are ordered day → row → track A then B, each talk gets a `track:`, and talks get their actual `date:` (Day 1: 14, Day 2: 10, Day 3: 13).
- **Kept both "Why Ruby's JIT was slow" recordings** (English and Japanese — the schedule shows the slot as "EN & JA"). The talk was scheduled once, so the Japanese recording is placed last in `videos.yml`: the 37 scheduled talks map to the grid cleanly while both recordings remain available on the Talks page. Same approach as the "Don't @ me!" recordings in RubyKaigi Takeout 2020 (#1927).
- **Added a `description` to `event.yml`** clarifying that the in-person RubyKaigi 2021 (planned for Mie Prefecture) was cancelled due to COVID-19 and Takeout 2021 was the alternate online conference held in its place. Note this is data-only for now: `event.yml` descriptions aren't currently rendered — the page shows a sentence generated from the series name (reported separately in #1930).
- Removed resolved TODO comments (running order / dates / websites); kept the "Ruby Committers — list each person" note.

No `venue.yml` was added: the event was online-only (no physical venue).

## Screenshots

**Day 1 — Thursday (Sep 09, 2021)**

![Schedule Day 1](https://raw.githubusercontent.com/yahonda/rubyevents/rubykaigi-takeout-2021-screenshots/pr-screenshots/rk2021-schedule-day1.png)

**Day 2 — Friday (Sep 10, 2021)**

![Schedule Day 2](https://raw.githubusercontent.com/yahonda/rubyevents/rubykaigi-takeout-2021-screenshots/pr-screenshots/rk2021-schedule-day2.png)

**Day 3 — Saturday (Sep 11, 2021)**

![Schedule Day 3](https://raw.githubusercontent.com/yahonda/rubyevents/rubykaigi-takeout-2021-screenshots/pr-screenshots/rk2021-schedule-day3.png)

## Testing Steps

Content PR — affected pages (seed the series first, then browse locally):

- Schedule, Day 1: `/events/rubykaigi-2021/schedule`
- Schedule, Day 2: `/events/rubykaigi-2021/schedule/day/2021-09-10`
- Schedule, Day 3: `/events/rubykaigi-2021/schedule/day/2021-09-11`
- Talks (both English & Japanese "Why Ruby's JIT was slow"): `/events/rubykaigi-2021/talks`

Verified locally:

- `bin/rails db:seed:event_series[rubykaigi]` seeds without errors.
- `Event.find_by_slug("rubykaigi-2021").schedule.talk_offsets` ⇒ `[14, 10, 13]`; running order = 38 (37 scheduled + trailing Japanese "Why Ruby's JIT was slow"); every slot matches the official schedule.
- `yerba check` and `validate:events`, `validate:videos`, `validate:data_files`, `validate:unique_video_ids`, `validate:speakers_in_videos` all pass.

## References

- https://rubykaigi.org/2021-takeout/schedule/
- https://rubykaigi.org/2021-takeout/
- https://cfp.rubykaigi.org/events/2021
- https://x.com/rubykaigi/status/1400060997868474371 (CFP opening announcement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
