### PR TITLE
Add CFP calendar subscription

### DIFF
--- a/app/controllers/cfp_controller.rb
+++ b/app/controllers/cfp_controller.rb
@@ -9,6 +9,19 @@ class CFPController < ApplicationController
       cfps = cfps.joins(:event).where(events: {kind: params[:kind]})
     end
 
-    @events = cfps.map(&:event).group_by(&:kind).values.flatten
+    respond_to do |format|
+      format.html do
+        @events = cfps.map(&:event).group_by(&:kind).values.flatten
+      end
+      format.ics do
+        calendar = Icalendar::Calendar.new
+
+        cfps.with_dates.each do |cfp|
+          calendar.add_event(cfp.to_ical)
+        end
+
+        render plain: calendar.to_ical
+      end
+    end
   end
 end

--- a/app/models/cfp.rb
+++ b/app/models/cfp.rb
@@ -25,6 +25,7 @@ class CFP < ApplicationRecord
 
   scope :open, -> { where("close_date IS NULL OR close_date >= ?", Date.today) }
   scope :closed, -> { where("close_date < ?", Date.today) }
+  scope :with_dates, -> { where.not(open_date: nil).where.not(close_date: nil) }
 
   def open?
     return false if closed?

--- a/app/models/cfp.rb
+++ b/app/models/cfp.rb
@@ -94,4 +94,15 @@ class CFP < ApplicationRecord
   def formatted_close_date
     I18n.l(close_date, default: "unknown")
   end
+
+  def to_ical
+    Icalendar::Event.new.tap do |cal_event|
+      cal_event.uid = "RUBYEVENTS-CFP-#{id}"
+      cal_event.last_modified = updated_at
+      cal_event.dtstart = Icalendar::Values::Date.new(open_date)
+      cal_event.dtend = Icalendar::Values::Date.new(close_date + 1.day)
+      cal_event.summary = "#{event.name} - #{name.presence || "Call for Proposals"}"
+      cal_event.url = link
+    end
+  end
 end

--- a/app/views/cfp/index.html.erb
+++ b/app/views/cfp/index.html.erb
@@ -4,10 +4,14 @@
       <%= title "Open Call for Proposals" %>
     </h1>
 
-    <div class="tabs tabs-boxed mt-4 md:mt-0">
-      <%= link_to "All", cfp_index_path(kind: "all"), class: "tab #{"tab-active" if params[:kind].blank? || params[:kind] == "all"}" %>
-      <%= link_to "Conferences", cfp_index_path(kind: "conference"), class: "tab #{"tab-active" if params[:kind] == "conference"}" %>
-      <%= link_to "Meetups", cfp_index_path(kind: "meetup"), class: "tab #{"tab-active" if params[:kind] == "meetup"}" %>
+    <div class="flex items-center gap-4 mt-4 md:mt-0">
+      <div class="tabs tabs-boxed">
+        <%= link_to "All", cfp_index_path(kind: "all"), class: "tab #{"tab-active" if params[:kind].blank? || params[:kind] == "all"}" %>
+        <%= link_to "Conferences", cfp_index_path(kind: "conference"), class: "tab #{"tab-active" if params[:kind] == "conference"}" %>
+        <%= link_to "Meetups", cfp_index_path(kind: "meetup"), class: "tab #{"tab-active" if params[:kind] == "meetup"}" %>
+      </div>
+
+      <%= render "shared/subscribe_to_calendar", url: cfp_index_url(format: :ics), modal_id: "cfp-calendar-modal" %>
     </div>
   </div>
 

--- a/app/views/events/years/_header.html.erb
+++ b/app/views/events/years/_header.html.erb
@@ -23,34 +23,7 @@
           <% end %>
         </span>
 
-        <%= ui_button "Subscribe to calendar", size: :sm, kind: :link, data: {toggle: "modal", target: "modal-middle"} %>
-        <%= ui_modal position: :middle, id: "modal-middle" do %>
-          <h1>Subscribe to calendar</h1>
-          <div class="flex flex-col gap-3">
-            <p>Copy the URL below and add it to your calendar application as an external calendar.</p>
-            <div
-              class="flex justify-between items-center"
-              data-controller="copy-to-clipboard"
-              data-copy-to-clipboard-success-class="scale-95">
-              <pre
-                class="text-sm font-mono text-gray-800 whitespace-pre-wrap break-words"
-                data-copy-to-clipboard-target="source"><%= events_url(format: :ics) %></pre>
-              <button
-                class="btn btn-sm btn-outline transition-transform duration-150 ease-in-out"
-                data-action="click->copy-to-clipboard#copy"
-                data-copy-to-clipboard-target="button">
-                Copy
-              </button>
-            </div>
-            <p>Instructions for your device can be found here:</p>
-            <ul>
-              <li><%= external_link_to "Google Calendar / Android", "https://support.google.com/calendar/answer/37100?co=GENIE.Platform%3DDesktop&amp;hl=en&amp;oco=1" %></li>
-              <li><%= external_link_to "Microsoft Outlook", "https://support.microsoft.com/en-us/office/import-calendars-into-outlook-8e8364e1-400e-4c0f-a573-fe76b5a2d379" %></li>
-              <li><%= external_link_to "Mac", "https://support.apple.com/kb/ph11523?locale=en_US" %></li>
-              <li><%= external_link_to "iPhone (iCloud)", "https://support.apple.com/en-us/HT202361" %></li>
-            </ul>
-          </div>
-        <% end %>
+        <%= render "shared/subscribe_to_calendar", url: events_url(format: :ics), modal_id: "modal-middle" %>
       </p>
     </div>
 

--- a/app/views/shared/_subscribe_to_calendar.html.erb
+++ b/app/views/shared/_subscribe_to_calendar.html.erb
@@ -1,0 +1,29 @@
+<%# locals: (url:, modal_id:) %>
+<%= ui_button "Subscribe to calendar", size: :sm, kind: :link, data: {toggle: "modal", target: modal_id} %>
+<%= ui_modal position: :middle, id: modal_id do %>
+  <h1>Subscribe to calendar</h1>
+  <div class="flex flex-col gap-3">
+    <p>Copy the URL below and add it to your calendar application as an external calendar.</p>
+    <div
+      class="flex justify-between items-center"
+      data-controller="copy-to-clipboard"
+      data-copy-to-clipboard-success-class="scale-95">
+      <pre
+        class="text-sm font-mono text-gray-800 whitespace-pre-wrap break-words"
+        data-copy-to-clipboard-target="source"><%= url %></pre>
+      <button
+        class="btn btn-sm btn-outline transition-transform duration-150 ease-in-out"
+        data-action="click->copy-to-clipboard#copy"
+        data-copy-to-clipboard-target="button">
+        Copy
+      </button>
+    </div>
+    <p>Instructions for your device can be found here:</p>
+    <ul>
+      <li><%= external_link_to "Google Calendar / Android", "https://support.google.com/calendar/answer/37100?co=GENIE.Platform%3DDesktop&amp;hl=en&amp;oco=1" %></li>
+      <li><%= external_link_to "Microsoft Outlook", "https://support.microsoft.com/en-us/office/import-calendars-into-outlook-8e8364e1-400e-4c0f-a573-fe76b5a2d379" %></li>
+      <li><%= external_link_to "Mac", "https://support.apple.com/kb/ph11523?locale=en_US" %></li>
+      <li><%= external_link_to "iPhone (iCloud)", "https://support.apple.com/en-us/HT202361" %></li>
+    </ul>
+  </div>
+<% end %>

--- a/test/controllers/cfp_controller_test.rb
+++ b/test/controllers/cfp_controller_test.rb
@@ -27,4 +27,14 @@ class CFPControllerTest < ActionDispatch::IntegrationTest
     get cfp_index_path
     assert_select "div", /closes on/i
   end
+
+  test "should get index as ics" do
+    @event.cfps.first.update(open_date: 1.week.ago, close_date: 1.week.from_now)
+
+    get cfp_index_url(format: :ics)
+    assert_response :success
+    assert_equal "text/calendar; charset=utf-8", response.content_type
+    assert_includes response.body, "BEGIN:VCALENDAR"
+    assert_includes response.body, "RUBYEVENTS-CFP-#{@event.cfps.first.id}"
+  end
 end

--- a/test/controllers/cfp_controller_test.rb
+++ b/test/controllers/cfp_controller_test.rb
@@ -28,6 +28,11 @@ class CFPControllerTest < ActionDispatch::IntegrationTest
     assert_select "div", /closes on/i
   end
 
+  test "should show subscribe to calendar button" do
+    get cfp_index_path
+    assert_select "button", /Subscribe to calendar/i
+  end
+
   test "should get index as ics" do
     @event.cfps.first.update(open_date: 1.week.ago, close_date: 1.week.from_now)
 

--- a/test/models/cfp_test.rb
+++ b/test/models/cfp_test.rb
@@ -1,7 +1,23 @@
 require "test_helper"
 
 class CFPTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    @cfp = cfps(:one)
+  end
+
+  test "with_dates scope includes cfps with both open and close dates" do
+    assert_includes CFP.with_dates, @cfp
+  end
+
+  test "with_dates scope excludes cfps missing open_date" do
+    @cfp.update_column(:open_date, nil)
+
+    assert_not_includes CFP.with_dates, @cfp
+  end
+
+  test "with_dates scope excludes cfps missing close_date" do
+    @cfp.update_column(:close_date, nil)
+
+    assert_not_includes CFP.with_dates, @cfp
+  end
 end

--- a/test/models/cfp_test.rb
+++ b/test/models/cfp_test.rb
@@ -5,6 +5,35 @@ class CFPTest < ActiveSupport::TestCase
     @cfp = cfps(:one)
   end
 
+  test "to_ical returns an Icalendar::Event" do
+    assert_kind_of Icalendar::Event, @cfp.to_ical
+  end
+
+  test "to_ical sets uid with CFP prefix" do
+    assert_equal "RUBYEVENTS-CFP-#{@cfp.id}", @cfp.to_ical.uid.to_s
+  end
+
+  test "to_ical sets summary with event name and cfp name" do
+    assert_equal "Future Conference - Future Conference 2024 CFP", @cfp.to_ical.summary.to_s
+  end
+
+  test "to_ical uses generic summary when cfp has no name" do
+    @cfp.update!(name: nil)
+
+    assert_equal "Future Conference - Call for Proposals", @cfp.to_ical.summary.to_s
+  end
+
+  test "to_ical sets dtstart to open_date and dtend to close_date plus one day" do
+    ical = @cfp.to_ical.to_ical
+
+    assert_includes ical, "DTSTART;VALUE=DATE:#{@cfp.open_date.strftime("%Y%m%d")}"
+    assert_includes ical, "DTEND;VALUE=DATE:#{(@cfp.close_date + 1.day).strftime("%Y%m%d")}"
+  end
+
+  test "to_ical sets url to cfp link" do
+    assert_equal "https://www.futureconference.com/cfp", @cfp.to_ical.url.to_s
+  end
+
   test "with_dates scope includes cfps with both open and close dates" do
     assert_includes CFP.with_dates, @cfp
   end


### PR DESCRIPTION
## Description

CFPs deserve their own calendar subscription, too!

## Screenshots

<img width="2650" height="1478" alt="CleanShot 2026-07-15 at 12 39 02@2x" src="https://github.com/user-attachments/assets/daee25b1-ea4f-45ec-8b0c-203d174e0d78" />

## Testing Steps

`/events/2026` still has the modal open

<img width="800" height="464" alt="CleanShot 2026-07-15 at 12 36 21" src="https://github.com/user-attachments/assets/903d02d3-4c01-4e65-8a5c-18b5aef63671" />

`/cfp` now has the url!

<img width="800" height="442" alt="CleanShot 2026-07-15 at 12 37 50" src="https://github.com/user-attachments/assets/37bd50eb-1899-4f64-b2e0-78c23382ea02" />

## References

- closes https://github.com/rubyevents/rubyevents/issues/1939
