### PR TITLE
Note which Debian packages also need to be installed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,17 @@ If the ruby version is updated, or you start running into issues, feel free to t
 
 - Ruby 4.0.1
 - Node.js 22.15.1
+- Yarn >= 1.22.22 (`npm install -g yarn`)
+
+##### Debian
+
+Dependencies of the application will require some operating system development packages to be installed.
+
+On Debian, you can install these packages by running the following command:
+
+```shell
+apt-get install -y libssl-dev libyaml-dev
+```
 
 #### Setup
 


### PR DESCRIPTION
## Description

At RubyConf 2026's hack day, I found that my basically vanilla development environment (WSL2 Debian, RV-installed Ruby) would not successfully run bin/setup. This was because I have the libraries installed but not the headers, so bundle install fails to locate headers.

This PR adds a subsection to tell folks to do this.