### PR TITLE
Standardize event schema timezones (by always installing tzinfo-data)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,8 +39,8 @@ gem "turbo-rails"
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 gem "bcrypt", "~> 3.1.7"
 
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: %i[windows jruby]
+# Bundle tzinfo-data on all platforms, so TZInfo::Timezone.all_identifiers is deterministic
+gem "tzinfo-data"
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -787,6 +787,8 @@ GEM
       typesense (>= 0.13.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2026.3)
+      tzinfo (>= 1.0.0)
     unaccent (0.4.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)

--- a/config/initializers/tzinfo.rb
+++ b/config/initializers/tzinfo.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# Insist on the tzinfo-data gem instead of the system zoneinfo database, so
+# TZInfo::Timezone.all_identifiers is the same on every machine. Without this,
+# TZInfo silently falls back to reading the OS's zoneinfo files if the gem
+# ever fails to load.
+TZInfo::DataSource.set(:ruby)


### PR DESCRIPTION
## Description
Always bundle tzinfo-data, instead of skipping on platforms that provide that information themselves.

This will prevent the events schema from getting diffs from bin/lint, when run on systems that have subtly different lists of timezones.

## Testing Steps
Run `bin/lint`, confirm that no diff is produced (especially, do this on a computer that was previously producing such a diff. @ChaelCodes can confirm that, I think?)

## References
closes #1893 
