### PR TITLE
Add more slide decks for blastoff rails

### DIFF
--- a/data/blastoffrails/blastoffrails-2026/videos.yml
+++ b/data/blastoffrails/blastoffrails-2026/videos.yml
@@ -19,6 +19,7 @@
   event_name: "Blastoff Rails 2026"
   date: "2026-06-11"
   published_at: "2026-06-25T15:00:35Z"
+  slides_url: "https://startups-on-rails-2026.netlify.app/"
   video_provider: "youtube"
   video_id: "dFpq07u0sK0"
   description: |-
@@ -104,6 +105,7 @@
   event_name: "Blastoff Rails 2026"
   date: "2026-06-12"
   published_at: "2026-06-28T15:00:17Z"
+  slides_url: "https://powerusers.nikkysoutherland.com/assets/pdf/Blastoff.pdf"
   video_provider: "youtube"
   video_id: "9Q4J35dbYbM"
   description: |-


### PR DESCRIPTION
## Description
Add more slide decks to blastoff rails talks

## Screenshots
<img width="1139" height="336" alt="Screenshot 2026-07-15 at 2 38 52 PM" src="https://github.com/user-attachments/assets/d3c3539e-15be-4d2a-a873-e2cba5e51ec3" />
<img width="1146" height="344" alt="Screenshot 2026-07-15 at 2 39 05 PM" src="https://github.com/user-attachments/assets/79eebcac-0c78-4c55-a478-88edf751f84e" />


## Testing Steps
<!-- If this is a content PR, link to the affected pages -->
[Irina's Keynote](https://www.rubyevents.org/talks/keynote-startups-on-rails)
[Nikky's Talk](https://www.rubyevents.org/talks/spaceships-radiation-therapy-and-power-users)

