### PR TITLE
Add slides and resources for Andy Andrea's talks

### DIFF
--- a/data/chicagoruby/chicagoruby/videos.yml
+++ b/data/chicagoruby/chicagoruby/videos.yml
@@ -678,8 +678,11 @@
       start_cue: "07:45"
       end_cue: "36:00"
       thumbnail_cue: "07:39"
+      slides_url: "https://docs.google.com/presentation/d/1Ia3yvY_SEJ8w-3V2tSVS12T0tHmaluP9bVv-vMO9m3I/edit?usp=sharing"
       video_provider: "parent"
       video_id: "andy-andrea-chicagoruby-meetup-november-2025"
+      description: |-
+        Most Ruby developers are familiar with schemas from the Rails `schema.rb` or `structure.sql` to JSON Schemas and OpenAPI. In this talk, I cover a variety of examples in which schemas can be leveraged across many different parts of a stack in both typical and less common ways.
       speakers:
         - Andy Andrea
 

--- a/data/railsconf/railsconf-2022/videos.yml
+++ b/data/railsconf/railsconf-2022/videos.yml
@@ -1032,6 +1032,7 @@
   event_name: "RailsConf 2022"
   date: "2022-05-17"
   published_at: "2023-01-16T16:00:31Z"
+  slides_url: "https://docs.google.com/presentation/d/16NgpLYuLHyYSlMFt27bWsN3appb_BoXE/edit?usp=sharing&ouid=118349730043919212741&rtpof=true&sd=true"
   video_provider: "youtube"
   video_id: "b7R9CFAZV2E"
   description: |-

--- a/data/railsconf/railsconf-2023/videos.yml
+++ b/data/railsconf/railsconf-2023/videos.yml
@@ -500,6 +500,7 @@
   raw_title: "RailsConf 2023 - Building a more effective, bidirectional mentor-... by Andy Andrea, William Frey"
   date: "2023-04-24"
   published_at: "2023-07-14T19:15:48Z"
+  slides_url: "https://docs.google.com/presentation/d/1wNz-retETR4ePVougmPW25EQGrre6cjOhUWv8edCv3s/edit?usp=sharing"
   video_provider: "youtube"
   video_id: "Uv2I3ECnzuY"
   description: |-

--- a/data/railsconf/railsconf-2024/videos.yml
+++ b/data/railsconf/railsconf-2024/videos.yml
@@ -654,6 +654,7 @@
   event_name: "RailsConf 2024"
   date: "2024-05-09"
   published_at: "2024-07-10T20:59:32Z"
+  slides_url: "https://docs.google.com/presentation/d/1-IATp3rDmctTlXqDDdCLssMc_dl8j4MdIF5TV063EU0/edit?usp=sharing"
   video_provider: "youtube"
   video_id: "tfxJyya6P6A"
   description: |-
@@ -662,6 +663,11 @@
     In this talk, we'll take a look at groups of patterns, classes and methods often seen in Rails code that might seem similar or equivalent at first glance. We’ll see how they differ and look at any pros, cons or edge cases worth considering for each group so that we can make more informed decisions when writing our code.
   speakers:
     - Andy Andrea
+  additional_resources:
+    - name: "Companion repo"
+      title: "List of similar but different concepts in Ruby and Rails"
+      type: "repo"
+      url: "https://github.com/andycandrea/this_or_that.rb"
   alternative_recordings:
     - note: "Confreaks upload"
       video_provider: "youtube"

--- a/data/railsconf/railsconf-2025/videos.yml
+++ b/data/railsconf/railsconf-2025/videos.yml
@@ -941,6 +941,7 @@
   date: "2025-07-10"
   published_at: "2025-07-24T12:30:38Z"
   track: "Breakout 2 - Freedom"
+  slides_url: "https://docs.google.com/presentation/d/1af1OBGRspid7n1K9WIF6egs6lD6ow1eXj58pDnl0-Ak/edit?usp=sharing"
   video_provider: "youtube"
   video_id: "4JiNCgPn5HY"
   description: |-
@@ -951,6 +952,11 @@
     Whether you want to validate a JSON field in a model, ensure that an incoming API request is properly formatted, check for valid events in an event-sourced application or run a validator against a class from a third-party library without monkey-patching, this talk will help you use some of Rails’ most classic features in a new and powerful way.
   speakers:
     - Andy Andrea
+  additional_resources:
+    - name: "Companion repo"
+      title: "The flexible validator source code with various branches representing different working states"
+      type: "repo"
+      url: "https://github.com/andycandrea/flexible_validator"
   alternative_recordings:
     - note: "Confreaks upload"
       video_provider: "youtube"

--- a/data/rubyconf/rubyconf-2026/videos.yml
+++ b/data/rubyconf/rubyconf-2026/videos.yml
@@ -270,6 +270,7 @@
   date: "2026-07-14"
   language: "English"
   track: "Breakout 1 - Red Rock A&D"
+  slides_url: "https://docs.google.com/presentation/d/1-TeW8ryAJZ9c0FYHbL9_vckVINDy6b6GlFxInNo2VNs/edit?usp=sharing"
   video_provider: "scheduled"
   video_id: "andy-andrea-rubyconf-2026"
   description: |-
@@ -285,6 +286,11 @@
       - AI tooling including auto-generating tools for your AI applications to call and ways to improve the efficacy of dev tooling like BugBot and Cursor. We'll be making things DRYer than the Sahara and doing away with tons of boilerplate along the way.
   speakers:
     - Andy Andrea
+  additional_resources:
+    - name: "Companion repo"
+      title: "Working and documented code for all the examples shown in the talk"
+      type: "repo"
+      url: "https://github.com/andycandrea/rubyconf-2026"
 
 - id: "gannon-mcgibbon-rubyconf-2026"
   title: "Overengineering Ruby with Native Extensions"


### PR DESCRIPTION
## Description

Add slides and resources for all of my talks plus a description for the Chicago Ruby talk.
## Screenshots

<img width="760" height="449" alt="Screenshot 2026-07-15 at 2 51 14 PM" src="https://github.com/user-attachments/assets/e68ae974-9373-490d-8fa9-9543d3395bb4" />
<img width="1150" height="316" alt="Screenshot 2026-07-15 at 2 51 24 PM" src="https://github.com/user-attachments/assets/55b7bea4-a339-481b-9b89-a221ff46248d" />
<img width="1134" height="919" alt="Screenshot 2026-07-15 at 2 51 37 PM" src="https://github.com/user-attachments/assets/32509f16-fb89-406f-a2ba-fcba0ad56968" />


## Testing Steps
<!-- List steps to test your changes. -->
<!-- If this is a content PR, link to the affected pages -->

I visited each of the talk pages and verified that the slides were visible and linked to the correct place. I did the same with the resources for the couple of talks that had a companion repo, and I also verified the description for the Chicago Ruby one looked correct.

Affected pages:
* /talks/computer-science-you-might-not-want-to-know
* /talks/building-a-more-effective-bidirectional-mentor-mentee-relationship
* /talks/this-or-that-similar-methods-classes-in-ruby-rails
* /talks/off-the-rails-validating-non-model-classes-with-activemodel
* /talks/the-little-schema-that-could
* /talks/the-little-schema-that-could-but-should-it
