### PR TITLE
Update William Frey's GitHub

### DIFF
--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -17245,7 +17245,7 @@
   github: ""
   slug: "william-bereza"
 - name: "William Frey"
-  github: "will-frey"
+  github: "bfrey08"
   slug: "william-frey"
 - name: "William Horton"
   github: "wdhorton"


### PR DESCRIPTION
## Description
I noticed that the picture and GitHub for Billy/William Frey, who I gave a talk with a few years back, was the wrong person. Since there's only that one talk attributed to him, I think it should be a safe change especially since the current GitHub account doesn't have any past Ruby activity.

## Screenshots

<img width="1545" height="765" alt="Screenshot 2026-07-15 at 3 02 03 PM" src="https://github.com/user-attachments/assets/6d7542bd-32eb-4cce-b6e1-896bc40df334" />

<img width="1138" height="132" alt="Screenshot 2026-07-15 at 3 04 21 PM" src="https://github.com/user-attachments/assets/c9222357-d179-4ea6-bfa7-01fbfcae5800" />

## Testing Steps

I verified that the GitHub link and profile picture were correct on the speaker show page for `will-frey` and that it looked correct on the show page for the talk we gave together, too.

## References

