### PR TITLE
Respect PORT environment variable for development environment assets and mailer URLs

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,11 +35,10 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  # Enable serving of images with full URLs
-  config.asset_host = "http://localhost:3000"
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+  port = ENV.fetch("PORT") { 3000 }
   config.asset_host = lambda { |source, request = nil|
-    request&.host&.include?("localhost") ? "http://localhost:3000" : "#{request&.protocol}#{request&.host_with_port}"
+    request&.host&.include?("localhost") ? "http://localhost:#{port}" : "#{request&.protocol}#{request&.host_with_port}"
   }
 
   # Don't care if the mailer can't send.
@@ -49,7 +48,7 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   # Set localhost to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = {host: "localhost", port: 3000}
+  config.action_mailer.default_url_options = {host: "localhost", port: port}
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log


### PR DESCRIPTION
## Description

The Rails server itself does respect the PORT environment variable but the assets don't load.

Also, I deleted something that seemed like a duplicate configuration. Let me know if there's some Rails magic going on and its not a duplicate.

## Screenshots

Before

<img width="1280" height="766" alt="Screenshot 2026-07-15 at 5 43 22 PM" src="https://github.com/user-attachments/assets/f93b1811-4402-4e2d-819b-239cb6dad9f0" />


## Testing Steps
<!-- List steps to test your changes. -->
<!-- If this is a content PR, link to the affected pages -->

Run this on the main branch to reproduce

```shell
PORT=2999 ./bin/dev
```

## References
<!-- Link to related issues, discussions, other PRs, or references you used to write the PR. -->
- closes #<!-- issue number -->
