### PR TITLE
Generate RubyLLM tools from Rails generators

### DIFF
--- a/bin/mcp_server
+++ b/bin/mcp_server
@@ -5,6 +5,7 @@
 # Run with: bin/mcp_server
 
 require_relative "../config/environment"
+require_relative "../lib/generators/tool_generation"
 require "json"
 
 class MCPServer
@@ -36,11 +37,15 @@ class MCPServer
   private
 
   def discover_tools
-    Dir[Rails.root.join("app/tools/**/*_tool.rb")].each_with_object({}) do |file, tools|
+    discovered_tools = Dir[Rails.root.join("app/tools/**/*_tool.rb")].each_with_object({}) do |file, tools|
       require file
       class_name = File.basename(file, ".rb").camelize
       tool_class = class_name.constantize
       tools[tool_name(class_name)] = tool_class
+    end
+
+    ToolGeneration.generate_tools.each.with_object(discovered_tools) do |klass, tools|
+      tools[klass.name] = klass
     end
   end
 

--- a/bin/mcp_server
+++ b/bin/mcp_server
@@ -44,8 +44,13 @@ class MCPServer
       tools[tool_name(class_name)] = tool_class
     end
 
-    ToolGeneration.generate_tools.each.with_object(discovered_tools) do |klass, tools|
-      tools[klass.name] = klass
+    # Load all the generators, create a tool class associated with each one and
+    # then add them to the tools hash
+    Rails::Generators.sorted_groups
+    generators = Generators::EventBase.descendants
+    tool_classes = ToolGeneration.generate_tools(generators)
+    tool_classes.each.with_object(discovered_tools) do |klass, tools|
+      tools[tool_name(klass.name)] = klass
     end
   end
 

--- a/lib/generators/tool_generation.rb
+++ b/lib/generators/tool_generation.rb
@@ -1,22 +1,24 @@
 require "rails/generators"
 
 class ToolGeneration
-  # Generates RubyLLM tool classes for each Rails generator defined in
-  # lib/generators.
+  # Generates RubyLLM tool classes for each provided generator
   #
+  # @param generators [Array<Generators::EventBase>]
   # @return [Array<RubyLLM::Tool>]
-  def self.generate_tools
-    # Load all the generators
-    Rails::Generators.sorted_groups
-
-    Generators::EventBase.descendants.map do |klass|
+  def self.generate_tools(generators)
+    generators.map do |klass|
       # Grab the generator's options that we've defined manually so that they
       # can be provided as params to the new tool class.
       options = klass.class_options.select do |option_key, option|
         option.group == "Fields"
       end
 
+      generator_type = klass.name.gsub("Generator", "").downcase
+      description = tool_description(klass, generator_type)
+
       tool = Class.new(RubyLLM::Tool) do
+        desc description
+
         options.each do |option_key, option|
           # Document each param for the tool using what is defined on the
           # corresponding generator option
@@ -28,8 +30,6 @@ class ToolGeneration
           )
         end
       end
-
-      generator_type = klass.name.gsub("Generator", "").downcase
 
       # If an argument's value is provided, ensure that it gets passed to the
       # generator in the correct format. If it is not provided, discard it to
@@ -68,4 +68,13 @@ class ToolGeneration
     (required_params + optional_params).join(", ")
   end
   private_class_method :execute_params
+
+  # Grabs the generator's TOOL_DESC to use for the RubyLLM::Tool `desc`. If that
+  # constant is not defined, we fall back to a generic value.
+  def self.tool_description(klass, generator_type)
+    klass.const_get(:TOOL_DESC, false)
+  rescue NameError
+    "Runs the #{generator_type} generator."
+  end
+  private_class_method :tool_description
 end

--- a/lib/generators/tool_generation.rb
+++ b/lib/generators/tool_generation.rb
@@ -1,0 +1,71 @@
+require "rails/generators"
+
+class ToolGeneration
+  # Generates RubyLLM tool classes for each Rails generator defined in
+  # lib/generators.
+  #
+  # @return [Array<RubyLLM::Tool>]
+  def self.generate_tools
+    # Load all the generators
+    Rails::Generators.sorted_groups
+
+    Generators::EventBase.descendants.map do |klass|
+      # Grab the generator's options that we've defined manually so that they
+      # can be provided as params to the new tool class.
+      options = klass.class_options.select do |option_key, option|
+        option.group == "Fields"
+      end
+
+      tool = Class.new(RubyLLM::Tool) do
+        options.each do |option_key, option|
+          # Document each param for the tool using what is defined on the
+          # corresponding generator option
+          param(
+            option_key.to_sym,
+            desc: option.description,
+            required: option.required,
+            type: option.type
+          )
+        end
+      end
+
+      generator_type = klass.name.gsub("Generator", "").downcase
+
+      # If an argument's value is provided, ensure that it gets passed to the
+      # generator in the correct format. If it is not provided, discard it to
+      # ensure fallback values in the generator code are used properly.
+      argument_handling_code = options.map do |option_key, option|
+        <<~METHOD
+          if #{option_key}
+            cli_options << ["#{option.switch_name}", *Array.wrap(#{option_key})]
+          end
+        METHOD
+      end.join("\n")
+
+      execute_method = <<~RUBY
+        def execute(#{execute_params(options)})
+          cli_options = []
+          #{argument_handling_code}
+
+          Rails::Generators.invoke(
+            "#{generator_type}",
+            cli_options.flatten,
+            behavior: :invoke
+          )
+        end
+      RUBY
+
+      tool.class_eval(execute_method)
+
+      Object.const_set(:"Generate#{generator_type.camelize}Tool", tool)
+      tool
+    end
+  end
+
+  def self.execute_params(options)
+    required_params = options.select { |k, v| v.required }.keys.map { |k| "#{k}:" }
+    optional_params = options.reject { |k, v| v.required }.keys.map { |k| "#{k}: nil" }
+    (required_params + optional_params).join(", ")
+  end
+  private_class_method :execute_params
+end

--- a/test/lib/generators/tool_generation_test.rb
+++ b/test/lib/generators/tool_generation_test.rb
@@ -1,0 +1,82 @@
+require "test_helper"
+require "generators/event_base"
+require "generators/tool_generation"
+
+class ToolGenerationTest < ActiveSupport::TestCase
+  GENERATOR_NAME = "Sample"
+  GENERATED_TOOL_CONST = :"Generate#{GENERATOR_NAME}Tool"
+
+  teardown do
+    # Even though we're using an anonmyous generator class here in the test, we
+    # still want to clean up the class constant set by the method under test itself
+    if Object.const_defined?(GENERATED_TOOL_CONST)
+      Object.send(:remove_const, GENERATED_TOOL_CONST)
+    end
+  end
+
+  test "returns a RubyLLM::Tool subclass for each given generator" do
+    tools = ToolGeneration.generate_tools([build_generator])
+
+    assert_equal 1, tools.size
+    assert_operator tools.first, :<, RubyLLM::Tool
+  end
+
+  test "sets the tool's desc from the generator's TOOL_DESC constant" do
+    generator = build_generator(tool_desc: "Do the sample thing.")
+
+    tool = ToolGeneration.generate_tools([generator]).first
+
+    assert_equal "Do the sample thing.", tool.description
+  end
+
+  test "falls back to a generic desc when the generator has no TOOL_DESC" do
+    generator = build_generator(tool_desc: nil)
+
+    tool = ToolGeneration.generate_tools([generator]).first
+
+    assert_equal "Runs the sample generator.", tool.description
+  end
+
+  test "builds tool params from the generator's Fields class_options" do
+    tool = ToolGeneration.generate_tools([build_generator]).first
+
+    assert_equal %i[event_series event title tags kind], tool.parameters.keys
+
+    title_param = tool.parameters[:title]
+    assert_equal "string", title_param.type.to_s
+    assert_equal "Title of the thing", title_param.description
+    assert title_param.required
+
+    tags_param = tool.parameters[:tags]
+    assert_equal "array", tags_param.type.to_s
+    refute tags_param.required
+
+    kind_param = tool.parameters[:kind]
+    assert_equal "string", kind_param.type.to_s
+    assert_equal "Kind of the thing", kind_param.description
+    refute kind_param.required
+  end
+
+  test "registers a Generate<Type>Tool constant for the generator" do
+    tool = ToolGeneration.generate_tools([build_generator]).first
+
+    assert_equal tool, Object.const_get(GENERATED_TOOL_CONST)
+  end
+
+  private
+
+  # Builds an anonymous Generators::EventBase subclass with one string, one array
+  # and one enum field option. Sets TOOL_DESC if provided.
+  def build_generator(tool_desc: "Do the sample thing.")
+    generator = Class.new(Generators::EventBase) do
+      class_option :title, type: :string, desc: "Title of the thing", group: "Fields", required: true
+      class_option :tags, type: :array, desc: "Tags for the thing", group: "Fields"
+      class_option :kind, type: :string, enum: %w[foo bar], desc: "Kind of the thing", group: "Fields"
+    end
+
+    generator.define_singleton_method(:name) { "#{GENERATOR_NAME}Generator" }
+    generator.const_set(:TOOL_DESC, tool_desc) if tool_desc
+
+    generator
+  end
+end


### PR DESCRIPTION
## Description
Generates RubyLLM tools based on each of the generators that exists in `lib/generators/` to enable LLMs to make easy and deterministic data updates that will hopefully also cost fewer tokens than having it do so more manually.

Left as a draft until the TODO items are resolved.

## Screenshots

<img width="501" height="82" alt="Screenshot 2026-07-15 at 10 12 43 PM" src="https://github.com/user-attachments/assets/a3c0cc8c-6f67-46ca-93c2-532c296afc33" />

<img width="1476" height="88" alt="Screenshot 2026-07-15 at 10 13 04 PM" src="https://github.com/user-attachments/assets/6487b4e8-713a-4829-b399-45c4ccff0888" />


## Testing Steps

- [x] Ran the event, sponsor and CFP tools by executing the corresponding tools manually in a Rails console
- [x] Ran `bin/mcp_server` and verified that 1) it didn't raise an error and 2) logged the additional tool classes that we generated
- [x] Ran `npx @modelcontextprotocol/inspector bin/mcp_server`, verified that all new tools were listed, had it run the event generator tool and verified the output

## References
<!-- Link to related issues, discussions, other PRs, or references you used to write the PR. -->
