### PR TITLE
Provide a short description to use when wrapping Generators

### DIFF
--- a/lib/generators/cfp/cfp_generator.rb
+++ b/lib/generators/cfp/cfp_generator.rb
@@ -4,6 +4,7 @@ require "generators/event_base"
 
 class CfpGenerator < Generators::EventBase
   source_root File.expand_path("templates", __dir__)
+  TOOL_DESC = "Create or update a new cfp entry in the cfp.yml file of a given event."
 
   class_option :name, type: :string, desc: "CFP name", group: "Fields"
   class_option :link, type: :string, desc: "CFP link", group: "Fields"

--- a/lib/generators/event/event_generator.rb
+++ b/lib/generators/event/event_generator.rb
@@ -4,6 +4,8 @@ require "generators/event_base"
 
 class EventGenerator < Generators::EventBase
   source_root File.expand_path("templates", __dir__)
+  TOOL_DESC = "Create an event.yml file for an event series, and optionally generate a venue.yml file for the venue."
+
   class_option :title, type: :string, desc: "Event name", group: "Fields", required: true
   class_option :description, type: :string, desc: "Event description", group: "Fields"
   class_option :kind, type: :string, enum: Event.kinds.keys, desc: "Event kind (e.g. conference, meetup, workshop)", default: "conference", group: "Fields"

--- a/lib/generators/involvements/involvements_generator.rb
+++ b/lib/generators/involvements/involvements_generator.rb
@@ -5,6 +5,7 @@ require "generators/event_base"
 # Generator for creating a new involvement entry in the involvements.yml file of a specific event.
 class InvolvementsGenerator < Generators::EventBase
   source_root File.expand_path("templates", __dir__)
+  TOOL_DESC = "Create or update a new involvement entry in the involvements.yml file of a given event."
 
   class_option :name, type: :string, desc: "Role or involvement type (e.g., 'Organizer', 'Program Committee member')", required: true, group: "Fields"
   class_option :users, type: :array, desc: "Person names involved in this role", required: false, group: "Fields"

--- a/lib/generators/schedule/schedule_generator.rb
+++ b/lib/generators/schedule/schedule_generator.rb
@@ -4,6 +4,7 @@ require "generators/event_base"
 
 class ScheduleGenerator < Generators::EventBase
   source_root File.expand_path("templates", __dir__)
+  TOOL_DESC = "Create a schedule via schedule.yml for a given event, based on the event's start and end dates, and the number of videos to schedule."
 
   class_option :break_duration, type: :numeric, desc: "The duration of breaks between talks in minutes", default: 15, group: "Fields"
   class_option :days, type: :array, desc: "The days of the event in YYYY-MM-DD format (e.g. 2024-09-01) - calculated from event start and end dates if not provided", group: "Fields"

--- a/lib/generators/sponsors/sponsors_generator.rb
+++ b/lib/generators/sponsors/sponsors_generator.rb
@@ -5,6 +5,7 @@ require "generators/event_base"
 # Add or update a Sponsor entry in the sponsors.yml file for a given event.
 class SponsorsGenerator < Generators::EventBase
   source_root File.expand_path("templates", __dir__)
+  TOOL_DESC = "Add or update a Sponsor entry in the sponsors.yml file for a given event."
 
   class_option :name, type: :string, desc: "Sponsor name", required: false, group: "Fields"
   class_option :website, type: :string, desc: "Sponsor website", required: false, group: "Fields"

--- a/lib/generators/talk/talk_generator.rb
+++ b/lib/generators/talk/talk_generator.rb
@@ -5,6 +5,7 @@ require "generators/event_base"
 # Generator for creating a new talk entry in the videos.yml file of a specific event.
 class TalkGenerator < Generators::EventBase
   source_root File.expand_path("templates", __dir__)
+  TOOL_DESC = "Create or update a new talk entry in the videos.yml file of a given event."
 
   class_option :id, type: :string, desc: "ID of an existing talk to update. New talks always get a generated id, so omit this to append one.", required: false, group: "Fields"
   class_option :title, type: :string, desc: "Title of the talk", group: "Fields"

--- a/lib/generators/venue/venue_generator.rb
+++ b/lib/generators/venue/venue_generator.rb
@@ -4,6 +4,7 @@ require "generators/event_base"
 
 class VenueGenerator < Generators::EventBase
   source_root File.expand_path("templates", __dir__)
+  TOOL_DESC = "Create a venue.yml file for a given event and update the event.yml file with the venue's coordinates."
 
   class_option :name, type: :string, desc: "Venue name", group: "Fields"
   class_option :address, type: :string, desc: "Venue address", group: "Fields"


### PR DESCRIPTION
## Description
<!-- Please describe your changes. -->

Just add a simple constant with a short description for the MCP tool.

USAGE files are useful for injecting USAGE instructions and context when calling the CLI with AI. I can easily get it call `bin/rails g cfp --help` and then it has lots of helpful examples in its context for usage (including ongoing meetup CFPs, lightning talk CFPs, and other examples). However, this is way too long and the wrong format for MCP tools. They need a short sentence that won't take up too much context. Ideally, we'd return the long description from help and a store a short one to be pulled for the MCP, and it'd use some Thor native tooling, so other generators can be MCP-ified.

But, it's surprisingly hard to have a long set of USAGE instructions and a short description on a rails generator.

USAGE is only used when description isn't available:
https://github.com/rails/rails/blob/ffcbf6f205363f8c2fb3e9834bc86690dd59f1cb/railties/lib/rails/generators/base.rb#L41-L49

There's [some threads](https://github.com/rails/thor/blob/cb11e8e87b3cfe6bc9f6d4b092897f0dfda2476d/lib/thor.rb#L270-L279) that look like long_description and description, but I didn't find a long_desc on the rails generators.

[Banner](https://github.com/rails/thor/blob/cb11e8e87b3cfe6bc9f6d4b092897f0dfda2476d/lib/thor/group.rb#L247-L251) looks like it may actually be invoked based on documentation, so that's out.

This PR just unblocks building MCP tools for the RubyEvents generators, but another solution will be needed for generic generators.

## Screenshots
<!-- Add screenshots or GIFs if applicable. -->

## Testing Steps
<!-- List steps to test your changes. -->
<!-- If this is a content PR, link to the affected pages -->

## References
<!-- Link to related issues, discussions, other PRs, or references you used to write the PR. -->
- closes #<!-- issue number -->
