### PR TITLE
Add RubyEvents MCP server to opencode.

### DIFF
--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "rubyevents": {
+      "type": "local",
+      "command": [
+        "bin/mcp_server"
+      ],
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
## Description
<!-- Please describe your changes. -->

opencode can't use .mcp.json. It has its own [special format](https://opencode.ai/docs/mcp-servers/). Setup the mcp tools so opencode users can access the mcp server.

## Screenshots
<!-- Add screenshots or GIFs if applicable. -->

<img width="435" height="161" alt="Screenshot 2026-07-19 at 8 43 44 PM" src="https://github.com/user-attachments/assets/c240e861-7af0-43c4-ae56-adf8244b41d9" />
<img width="218" height="223" alt="Screenshot 2026-07-19 at 8 44 40 PM" src="https://github.com/user-attachments/assets/a20b5136-3557-458f-b311-4ef90b0cc068" />

## Testing Steps
<!-- List steps to test your changes. -->
<!-- If this is a content PR, link to the affected pages -->
- Install and ope opencode
- See rubyevents mcp tools

## References
<!-- Link to related issues, discussions, other PRs, or references you used to write the PR. -->
- closes #<!-- issue number -->
