### PR TITLE
Ignore editor swap files in data validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,5 +85,9 @@ service_account.json
 # IDE files
 /.idea
 
+# Editor swap and backup files
+.*.sw?
+*~
+
 # Coverage reports
 /coverage

--- a/lib/tasks/validate.rake
+++ b/lib/tasks/validate.rake
@@ -289,9 +289,25 @@ namespace :validate do
     exit 1 unless validate_speakerdeck_urls
   end
 
+  def reject_git_ignored(files)
+    return files if files.empty?
+
+    ignored = IO.popen(["git", "check-ignore", "--stdin"], "r+") do |io|
+      io.write(files.join("\n"))
+      io.close_write
+      io.read.split("\n")
+    end.to_set
+
+    files.reject { |file| ignored.include?(file.to_s) }
+  rescue
+    files
+  end
+
   def validate_data_files
+    files = Dir.glob(Rails.root.join("data/**/*"), File::FNM_DOTMATCH).select { |file| File.file?(file) }
+
     validate_files(
-      files: Dir.glob(Rails.root.join("data/**/*"), File::FNM_DOTMATCH).select { |file| File.file?(file) },
+      files: reject_git_ignored(files),
       validators: [
         Static::Validators::ExpectedDataFiles
       ],

--- a/lib/tasks/validate.rake
+++ b/lib/tasks/validate.rake
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "gum"
+require "open3"
 require "parallel"
 
 namespace :validate do
@@ -292,13 +293,10 @@ namespace :validate do
   def reject_git_ignored(files)
     return files if files.empty?
 
-    ignored = IO.popen(["git", "check-ignore", "--stdin"], "r+") do |io|
-      io.write(files.join("\n"))
-      io.close_write
-      io.read.split("\n")
-    end.to_set
+    output, status = Open3.capture2("git", "check-ignore", "--stdin", stdin_data: files.join("\n"))
+    return files unless [0, 1].include?(status.exitstatus)
 
-    files.reject { |file| ignored.include?(file.to_s) }
+    files - output.split("\n")
   rescue
     files
   end


### PR DESCRIPTION
## Description

This pull request updates `bin/lint` so it no longer flags editor swap files while you're mid-edit. `validate:data_files` globs `data/**/*` with `File::FNM_DOTMATCH`, so a Vim swap file like `data/.speakers.yml.swp` gets picked up and reported as an unexpected data file. 

This pull request changes this so it now filters git-ignored paths out of that glob using `git check-ignore`, so any editor's temp files are skipped without the repo enumerating every pattern. Also, `.*.sw?` and `*~` to `.gitignore` so the swap files are actually ignored for everyone rather than only developers with a global ignore configured.

## Screenshots
\-

## Testing Steps
\-


## References

Closes #1949 