### PR TITLE
Add alt text to image tags

### DIFF
--- a/app/components/ui/avatar_component.html.erb
+++ b/app/components/ui/avatar_component.html.erb
@@ -6,7 +6,7 @@
       <% else %>
         <span class="<%= text_size %> <%= "hidden" if show_custom_avatar? %>"><%= initials %></span>
         <% if show_custom_avatar? %>
-          <%= image_tag avatar_url_for_size, loading: "lazy", onerror: "this.previousElementSibling.classList.remove('hidden'); this.remove()" %>
+          <%= image_tag avatar_url_for_size, loading: "lazy", alt: "#{avatarable.name} avatar", onerror: "this.previousElementSibling.classList.remove('hidden'); this.remove()" %>
         <% end %>
       <% end %>
     </div>

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -1,6 +1,6 @@
 <%= link_to event_path(event), id: dom_id(event), class: "event flex justify-between items-center" do %>
   <div class="flex items-center gap-2">
-    <%= image_tag image_path(event.avatar_image_path), style: "view-transition-name: #{dom_id(event, :logo)}", class: "size-8 rounded-full", loading: "lazy" %>
+    <%= image_tag image_path(event.avatar_image_path), style: "view-transition-name: #{dom_id(event, :logo)}", class: "size-8 rounded-full", alt: event.name.to_s, loading: "lazy" %>
     <span class="event-name"><%= event.name %></span>
   </div>
   <%= ui_badge(event.talks_count, kind: :secondary, outline: true, size: :lg, class: "min-w-10") %>

--- a/app/views/events/_header.html.erb
+++ b/app/views/events/_header.html.erb
@@ -12,7 +12,7 @@
       background: <%= event.static_metadata.banner_background %>;
     <% end %>
   ">
-  <%= image_tag image_path(event.banner_image_path), class: "w-full md:container" %>
+  <%= image_tag image_path(event.banner_image_path), alt: event.name, class: "w-full md:container" %>
 </div>
 
 <% if event.static_metadata.cancelled? %>

--- a/app/views/events/attendances/index.html.erb
+++ b/app/views/events/attendances/index.html.erb
@@ -28,7 +28,7 @@
 
               <div class="bg-white rounded-lg border shadow-sm overflow-hidden hover:shadow-md transition-shadow">
                 <div class="h-24 flex items-center justify-center overflow-hidden" style="<% if event.static_metadata.banner_background.start_with?('data:') %>background: url('<%= event.static_metadata.banner_background %>'); background-repeat: no-repeat; background-size: cover;<% else %>background: <%= event.static_metadata.banner_background %>;<% end %>">
-                  <%= image_tag image_path(event.banner_image_path), class: "h-full w-full object-cover" %>
+                  <%= image_tag image_path(event.banner_image_path), alt: event.name, class: "h-full w-full object-cover" %>
                 </div>
 
                 <div class="p-4">

--- a/app/views/events/collectibles/index.html.erb
+++ b/app/views/events/collectibles/index.html.erb
@@ -31,7 +31,7 @@
             <% @stickers.each do |sticker| %>
               <div class="group relative bg-white/10 backdrop-blur-sm rounded-lg p-4 hover:bg-white/20 transition-colors border border-white/20">
                 <div class="aspect-square flex items-center justify-center mb-2">
-                  <%= image_tag sticker.asset_path, class: "max-w-full max-h-full object-contain group-hover:scale-110 transition-transform" %>
+                  <%= image_tag sticker.asset_path, class: "max-w-full max-h-full object-contain group-hover:scale-110 transition-transform", alt: sticker.name %>
                 </div>
                 <p class="text-xs text-white text-center truncate"><%= sticker.name %></p>
               </div>

--- a/app/views/events/events/show.html.erb
+++ b/app/views/events/events/show.html.erb
@@ -34,7 +34,7 @@
             class="absolute inset-0 z-0 h-full w-full bg-[--featured-background] text-[--featured-color]"
             style="--featured-background: <%= @talk.event.static_metadata.featured_background %>; --featured-color: <%= @talk.event.static_metadata.featured_color %>; transform-origin: 0% 0%; transform: none; opacity: 1;">
             <div class="flex items-center justify-center relative aspect-image-mobile max-h-full w-full overflow-hidden sm:aspect-image-tablet md:aspect-image-desktop lg:aspect-image-desktop-lg xl:aspect-image-desktop-xl 2xl:aspect-image-desktop-2xl h-full ">
-              <%= image_tag @talk.event.featured_image_path, class: "w-1/2" %>
+              <%= image_tag @talk.event.featured_image_path, alt: @talk.event.name, class: "w-1/2" %>
             </div>
           </div>
         </div>
@@ -123,7 +123,7 @@
                   <%= link_to talk, class: "flex justify-between p-2 gap-4 bg-[#131313] hover:opacity-85" do %>
                     <div class="flex gap-6">
                       <div class="min-w-[150px] w-[150px]">
-                        <%= image_tag talk.thumbnail_lg, class: "rounded" %>
+                        <%= image_tag talk.thumbnail_lg, alt: talk.title, class: "rounded" %>
                       </div>
 
                       <div class="flex flex-col justify-center">
@@ -138,7 +138,7 @@
                           <div class="avatar placeholder">
                             <div class="w-14 h-14 rounded-full bg-primary text-neutral-content">
                               <% if speaker.custom_avatar? %>
-                                <%= image_tag speaker.avatar_url(size: 48) %>
+                                <%= image_tag speaker.avatar_url(size: 48), alt: speaker.name %>
                               <% else %>
                                 <span class="text-md"><%= speaker.name.split(" ").map(&:first).join %></span>
                               <% end %>

--- a/app/views/organizations/_header.html.erb
+++ b/app/views/organizations/_header.html.erb
@@ -11,7 +11,7 @@
     <% end %>
   ">
   <% if organization.organization_image_for("banner.webp") %>
-    <%= image_tag image_path(organization.banner_image_path), class: "w-full md:container object-cover" %>
+    <%= image_tag image_path(organization.banner_image_path), alt: organization.name, class: "w-full md:container object-cover" %>
   <% end %>
 </div>
 

--- a/app/views/organizations/_organization.html.erb
+++ b/app/views/organizations/_organization.html.erb
@@ -14,7 +14,7 @@
         </div>
       </div>
     <% elsif organization.organization_image_for("avatar.webp") %>
-      <%= image_tag image_path(organization.avatar_image_path), class: "size-8 rounded border border-[#D9DFE3]", loading: "lazy" %>
+      <%= image_tag image_path(organization.avatar_image_path), alt: organization.name, class: "size-8 rounded border border-[#D9DFE3]", loading: "lazy" %>
     <% else %>
       <div class="avatar placeholder">
         <div class="size-8 rounded bg-gray-100 text-gray-600 border border-[#D9DFE3] flex items-center justify-center">

--- a/app/views/page/_ruby_passport.html.erb
+++ b/app/views/page/_ruby_passport.html.erb
@@ -6,7 +6,7 @@
       <div class="absolute inset-0 opacity-5 overflow-hidden rounded-2xl">
         <% Stamp.country_stamps.sample(20).each_with_index do |stamp, i| %>
           <div class="absolute" style="top: <%= rand(0..90) %>%; left: <%= rand(0..90) %>%; transform: rotate(<%= rand(-30..30) %>deg); opacity: 0.4;">
-            <%= image_tag image_path("stamps/#{stamp.file_path}"), class: "w-16 h-16", loading: "lazy" %>
+            <%= image_tag image_path("stamps/#{stamp.file_path}"), alt: stamp.name, class: "w-16 h-16", loading: "lazy" %>
           </div>
         <% end %>
       </div>

--- a/app/views/page/stickers.html.erb
+++ b/app/views/page/stickers.html.erb
@@ -15,7 +15,7 @@
                 <% event.stickers.each do |sticker| %>
                   <%= link_to event, class: "group relative bg-gray-800 rounded-lg p-4 hover:bg-gray-700 transition-colors" do %>
                     <div class="aspect-square flex items-center justify-center mb-2">
-                      <%= image_tag sticker.asset_path, class: "max-w-full max-h-full object-contain group-hover:scale-110 transition-transform" %>
+                      <%= image_tag sticker.asset_path, alt: sticker.name, class: "max-w-full max-h-full object-contain group-hover:scale-110 transition-transform" %>
                     </div>
                     <p class="text-xs text-gray-300 text-center truncate"><%= event.name %></p>
                   <% end %>

--- a/app/views/profiles/connect/_friend_prompt.html.erb
+++ b/app/views/profiles/connect/_friend_prompt.html.erb
@@ -2,7 +2,7 @@
   <!-- Icon -->
   <div class="flex items-center justify-center w-20 h-20 bg-success/10 rounded-full">
     <% if found_user.present? %>
-      <%= image_tag found_user.avatar_url, class: "w-full h-full rounded-full" %>
+      <%= image_tag found_user.avatar_url, alt: found_user.name, class: "w-full h-full rounded-full" %>
     <% else %>
       <%= fa "user-group", variant: :solid, class: "w-10 h-10 text-success" %>
     <% end %>

--- a/app/views/shared/_event_row.html.erb
+++ b/app/views/shared/_event_row.html.erb
@@ -6,7 +6,7 @@
   <div class="flex gap-3 sm:gap-4 items-start">
     <% if event.avatar_image_path %>
       <div class="w-12 h-12 sm:w-16 sm:h-16 flex-shrink-0 rounded-lg overflow-hidden">
-        <%= image_tag event.avatar_image_path, class: "w-full h-full object-cover" %>
+        <%= image_tag event.avatar_image_path, alt: event.name, class: "w-full h-full object-cover" %>
       </div>
     <% end %>
 

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -13,7 +13,7 @@
 
     <div class="flex justify-start lg:justify-center items-center">
       <%= link_to root_path do %>
-        <%= image_tag image_path("logo.png"), class: "size-10 hover:opacity-80" %>
+        <%= image_tag image_path("logo.png"), class: "size-10 hover:opacity-80", alt: "RubyEvents.org" %>
       <% end %>
     </div>
 

--- a/app/views/shared/_nearby_events_section.html.erb
+++ b/app/views/shared/_nearby_events_section.html.erb
@@ -33,7 +33,7 @@
             <div class="flex gap-4 items-start">
               <% if event.avatar_image_path %>
                 <div class="w-16 h-16 flex-shrink-0 rounded-lg overflow-hidden">
-                  <%= image_tag event.avatar_image_path, class: "w-full h-full object-cover" %>
+                  <%= image_tag event.avatar_image_path, alt: event.name, class: "w-full h-full object-cover" %>
                 </div>
               <% end %>
 

--- a/app/views/shared/_stickers_display.html.erb
+++ b/app/views/shared/_stickers_display.html.erb
@@ -5,7 +5,7 @@
         <div class="grid grid-cols-3 gap-[5vw] w-full h-full p-12">
           <% stickers.shuffle.each do |sticker| %>
             <%= link_to sticker.event, class: "max-w-[10vw]", style: "transform: rotate(#{(-20...20).to_a.sample}deg) translateY(#{(0...5).to_a.sample}vw) translateX(#{(0...5).to_a.sample}vh) scale(#{100 + (-10...10).to_a.sample}%)", data: {turbo_frame: "_top"} do %>
-              <%= image_tag sticker.asset_path, class: "transition transition-transform hover:scale-105" %>
+              <%= image_tag sticker.asset_path, alt: sticker.name, class: "transition transition-transform hover:scale-105" %>
             <% end %>
           <% end %>
         </div>

--- a/app/views/spotlight/events/_event.html.erb
+++ b/app/views/spotlight/events/_event.html.erb
@@ -1,6 +1,6 @@
 <%= link_to event_path(event), target: "_top", id: dom_id(event), role: "option", class: "w-full flex items-center gap-4", style: "view-transition-name: #{dom_id(event, :search_result)}" do %>
   <div class="flex items-center gap-2">
-    <%= image_tag image_path(event.avatar_image_path), class: "size-8 rounded-full skeleton", loading: "lazy", height: 200, width: 200 %>
+    <%= image_tag image_path(event.avatar_image_path), alt: event.name, class: "size-8 rounded-full skeleton", loading: "lazy", height: 200, width: 200 %>
     <span class="event-name"><%= event.name %></span>
   </div>
 <% end %>

--- a/app/views/spotlight/talks/_talk.html.erb
+++ b/app/views/spotlight/talks/_talk.html.erb
@@ -1,6 +1,6 @@
 <%= link_to talk_path(talk), target: "_top", id: dom_id(talk), role: "option", class: "w-full flex items-center gap-4", style: "view-transition-name: #{dom_id(talk, :search_result)}" do %>
   <div class="hidden md:flex aspect-video shrink-0 relative w-20">
-    <%= image_tag talk.thumbnail_sm, srcset: ["#{talk.thumbnail_sm} 2x"], id: dom_id(talk), class: "w-full h-auto object-cover border rounded skeleton", loading: :lazy, height: 180, width: 320 %>
+    <%= image_tag talk.thumbnail_sm, srcset: ["#{talk.thumbnail_sm} 2x"], alt: "#{talk.title} thumbnail", id: dom_id(talk), class: "w-full h-auto object-cover border rounded skeleton", loading: :lazy, height: 180, width: 320 %>
   </div>
 
   <div class="flex flex-col gap-1 text-sm">

--- a/app/views/spotlight/transcripts/index.turbo_stream.erb
+++ b/app/views/spotlight/transcripts/index.turbo_stream.erb
@@ -23,7 +23,7 @@
           <div class="rounded-lg p-2 hover:bg-base-200/50">
             <%= link_to talk_path(group[:talk_slug]), target: "_top", role: "option", class: "flex items-center gap-3 group" do %>
               <% if group[:thumbnail].present? %>
-                <%= image_tag group[:thumbnail], loading: "lazy", class: "w-20 aspect-video object-cover rounded-md shrink-0" %>
+                <%= image_tag group[:thumbnail], alt: group[:talk_title], loading: "lazy", class: "w-20 aspect-video object-cover rounded-md shrink-0" %>
               <% end %>
 
               <div class="min-w-0">

--- a/app/views/talks/_card_horizontal.html.erb
+++ b/app/views/talks/_card_horizontal.html.erb
@@ -24,7 +24,7 @@
     ) do %>
 
   <div class="flex aspect-video shrink-0 relative w-20">
-    <%= image_tag talk.thumbnail_sm, srcset: ["#{talk.thumbnail_sm} 2x"], id: dom_id(talk), class: "w-full h-auto aspect-video border rounded #{talk.thumbnail_classes.presence || "object-cover"}", loading: :lazy %>
+    <%= image_tag talk.thumbnail_sm, srcset: ["#{talk.thumbnail_sm} 2x"], alt: "#{talk.title} thumbnail", id: dom_id(talk), class: "w-full h-auto aspect-video border rounded #{talk.thumbnail_classes.presence || "object-cover"}", loading: :lazy %>
 
     <div class="absolute inset-0 bg-black/50 justify-center items-center rounded hidden group-[.active]:flex">
       <%= fa("play", size: :sm, class: "fill-white") %>

--- a/app/views/talks/_event.html.erb
+++ b/app/views/talks/_event.html.erb
@@ -5,7 +5,7 @@
     <div class="avatar placeholder">
       <div class="w-12 rounded-full bg-primary text-neutral-content">
         <% if event.avatar_image_path.present? %>
-          <%= image_tag image_path(event.avatar_image_path) %>
+          <%= image_tag image_path(event.avatar_image_path), alt: event.name %>
         <% else %>
           <span class="text-lg"><%= event.name.split(" ").map(&:first).join %></span>
         <% end %>

--- a/app/views/talks/_sections.html.erb
+++ b/app/views/talks/_sections.html.erb
@@ -6,7 +6,7 @@
           <div class="flex justify-between">
             <div <% if child_talk == talk %> data-active <% end %> class="flex gap-3 text-gray-700 data-[active]:font-bold text-sm">
               <div class="flex aspect-video shrink-0 relative w-16 lg:w-24 xl:w-36">
-                <%= image_tag child_talk.thumbnail_sm, srcset: ["#{child_talk.thumbnail_sm} 2x"], id: dom_id(child_talk), class: "w-full h-auto aspect-video rounded #{child_talk.thumbnail_classes.presence || "object-cover"}", loading: :lazy %>
+                <%= image_tag child_talk.thumbnail_sm, srcset: ["#{child_talk.thumbnail_sm} 2x"], alt: "#{child_talk.title} thumbnail", id: dom_id(child_talk), class: "w-full h-auto aspect-video rounded #{child_talk.thumbnail_classes.presence || "object-cover"}", loading: :lazy %>
               </div>
 
               <div class="flex flex-col gap-0.5 justify-center">

--- a/app/views/talks/_video_player.html.erb
+++ b/app/views/talks/_video_player.html.erb
@@ -22,7 +22,7 @@
   <div class="relative overflow-hidden bg-gray-300 aspect-video banner-img card-horizontal-img rounded-xl outline outline-1 outline-gray-300 w-full max-w-full">
     <% if talk.external_player %>
       <%= link_to talk.external_player_url, target: "_blank", class: "relative w-full h-full block" do %>
-        <%= image_tag talk.thumbnail_xl, class: "w-full h-full object-cover rounded-xl", style: "view-transition-name: #{dom_id(talk, :image)}" %>
+        <%= image_tag talk.thumbnail_xl, alt: "#{talk.title} thumbnail", class: "w-full h-full object-cover rounded-xl", style: "view-transition-name: #{dom_id(talk, :image)}" %>
 
         <div class="absolute inset-0 flex flex-col items-center justify-center gap-6 p-6 text-xl font-bold text-center text-white bg-black/80 rounded-xl">
           This talk is available to watch on <%= URI.parse(talk.external_player_url).host %>
@@ -50,7 +50,7 @@
 
       <% if current_user_watched_talk&.in_progress? && !is_watched && talk.video_available? %>
         <div class="absolute inset-0 cursor-pointer group/resume" data-video-player-target="resumeOverlay" data-action="click->video-player#resumePlayback">
-          <%= image_tag talk.thumbnail_xl, class: "absolute inset-0 w-full h-full object-cover rounded-xl", style: "view-transition-name: #{dom_id(talk, :image)}" %>
+          <%= image_tag talk.thumbnail_xl, alt: "#{talk.title} thumbnail", class: "absolute inset-0 w-full h-full object-cover rounded-xl", style: "view-transition-name: #{dom_id(talk, :image)}" %>
           <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-black/20 rounded-xl"></div>
           <div class="absolute inset-0 bg-gradient-to-t from-black/60 via-black/20 to-transparent rounded-xl opacity-0 group-hover/resume:opacity-100 transition-opacity duration-300"></div>
           <div class="absolute inset-0 flex flex-col items-center justify-center gap-3 p-6 text-center text-white">
@@ -66,7 +66,7 @@
         </div>
       <% elsif video_provider.in?(["mp4", "youtube", "vimeo"]) && !is_watched && talk.video_available? %>
         <div class="absolute inset-0 cursor-pointer group/play" data-video-player-target="playOverlay" data-action="click->video-player#startPlayback">
-          <%= image_tag talk.thumbnail_xl, class: "absolute inset-0 w-full h-full object-cover rounded-xl", style: "view-transition-name: #{dom_id(talk, :image)}" %>
+          <%= image_tag talk.thumbnail_xl, alt: "#{talk.title} thumbnail", class: "absolute inset-0 w-full h-full object-cover rounded-xl", style: "view-transition-name: #{dom_id(talk, :image)}" %>
           <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-black/20 rounded-xl"></div>
           <div class="absolute inset-0 bg-gradient-to-t from-black/60 via-black/20 to-transparent rounded-xl opacity-0 group-hover/play:opacity-100 transition-opacity duration-300"></div>
           <div class="absolute inset-0 flex flex-col items-center justify-center gap-3 p-6 text-center text-white">

--- a/app/views/talks/video_providers/_children.html.erb
+++ b/app/views/talks/video_providers/_children.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (talk:, video_provider:, video_id:, is_watched: false) %>
 
 <div class="relative w-full h-full block max-w-full">
-  <%= image_tag talk.thumbnail_xl, class: "w-full h-full rounded-xl #{talk.thumbnail_classes.presence || "object-cover"}" %>
+  <%= image_tag talk.thumbnail_xl, alt: "#{talk.title} thumbnail", class: "w-full h-full rounded-xl #{talk.thumbnail_classes.presence || "object-cover"}" %>
 
   <div class="absolute inset-0 text-white bg-black/70 flex flex-col gap-3 justify-center items-center text-xl rounded-xl p-6 overflow-y-scroll">
     <span class="text-center text-2xl p-4 rounded-full mb-2 font-bold">

--- a/app/views/talks/video_providers/_not_published.html.erb
+++ b/app/views/talks/video_providers/_not_published.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (talk:, video_provider:, video_id:, is_watched: false) %>
 
 <div class="relative w-full h-full block max-w-full">
-  <%= image_tag talk.thumbnail_xl, class: "w-full h-full rounded-xl #{talk.thumbnail_classes.presence || "object-cover"}" %>
+  <%= image_tag talk.thumbnail_xl, alt: "#{talk.title} thumbnail", class: "w-full h-full rounded-xl #{talk.thumbnail_classes.presence || "object-cover"}" %>
 
   <div class="absolute inset-0 flex flex-col items-center justify-center gap-3 p-6 text-center text-white bg-gradient-to-t from-black/80 via-black/50 to-black/30 rounded-xl">
     <div class="p-4 bg-white/20 backdrop-blur-sm rounded-full">

--- a/app/views/talks/video_providers/_not_recorded.html.erb
+++ b/app/views/talks/video_providers/_not_recorded.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (talk:, video_provider:, video_id:, is_watched: false) %>
 
 <div class="relative w-full h-full block max-w-full">
-  <%= image_tag talk.thumbnail_xl, class: "w-full h-full rounded-xl #{talk.thumbnail_classes.presence || "object-cover"}" %>
+  <%= image_tag talk.thumbnail_xl, alt: "#{talk.title} thumbnail", class: "w-full h-full rounded-xl #{talk.thumbnail_classes.presence || "object-cover"}" %>
 
   <div class="absolute inset-0 flex flex-col items-center justify-center gap-3 p-6 text-center text-white bg-gradient-to-t from-black/80 via-black/50 to-black/30 rounded-xl">
     <div class="p-4 bg-white/20 backdrop-blur-sm rounded-full">

--- a/app/views/talks/video_providers/_scheduled.html.erb
+++ b/app/views/talks/video_providers/_scheduled.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (talk:, video_provider:, video_id:, is_watched: false) %>
 
 <div class="relative w-full h-full block max-w-full">
-  <%= image_tag talk.thumbnail_xl, class: "w-full h-full rounded-xl #{talk.thumbnail_classes.presence || "object-cover"}" %>
+  <%= image_tag talk.thumbnail_xl, alt: "#{talk.title} thumbnail", class: "w-full h-full rounded-xl #{talk.thumbnail_classes.presence || "object-cover"}" %>
 
   <div class="absolute inset-0 flex flex-col items-center justify-center gap-3 p-6 text-center text-white bg-gradient-to-t from-black/80 via-black/50 to-black/30 rounded-xl">
     <div class="p-4 bg-white/20 backdrop-blur-sm rounded-full">

--- a/app/views/talks/video_providers/_video_unavailable.html.erb
+++ b/app/views/talks/video_providers/_video_unavailable.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (talk:, video_provider:, video_id:, is_watched: false) %>
 
 <div class="relative w-full h-full block max-w-full">
-  <%= image_tag talk.thumbnail_xl, class: "w-full h-full object-cover rounded-xl" %>
+  <%= image_tag talk.thumbnail_xl, alt: "#{talk.title} thumbnail", class: "w-full h-full object-cover rounded-xl" %>
 
   <div class="absolute inset-0 flex flex-col items-center justify-center gap-3 p-6 text-center text-white bg-gradient-to-t from-black/80 via-black/50 to-black/30 rounded-xl">
     <div class="p-4 bg-white/20 backdrop-blur-sm rounded-full">

--- a/app/views/talks/watched_talks/_watched_overlay.html.erb
+++ b/app/views/talks/watched_talks/_watched_overlay.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (talk:) %>
 
 <div class="absolute inset-0 cursor-pointer group/watched" data-video-player-target="watchedOverlay" data-action="click->video-player#dismissWatchedOverlay">
-  <%= image_tag talk.thumbnail_xl, class: "absolute inset-0 w-full h-full object-cover rounded-xl opacity-60", style: "view-transition-name: #{dom_id(talk, :image)}" %>
+  <%= image_tag talk.thumbnail_xl, alt: "#{talk.title} thumbnail", class: "absolute inset-0 w-full h-full object-cover rounded-xl opacity-60", style: "view-transition-name: #{dom_id(talk, :image)}" %>
   <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-black/20 rounded-xl"></div>
   <div class="absolute inset-0 bg-gradient-to-t from-black/60 via-black/20 to-transparent rounded-xl opacity-0 group-hover/watched:opacity-100 transition-opacity duration-300"></div>
   <div class="absolute inset-0 flex flex-col items-center justify-center gap-3 p-6 text-center text-white">

--- a/app/views/transcript_searches/index.html.erb
+++ b/app/views/transcript_searches/index.html.erb
@@ -25,7 +25,7 @@
           <div class="flex gap-4 p-4 rounded-xl bg-base-200/40">
             <% if group[:thumbnail].present? %>
               <%= link_to talk_path(group[:talk_slug]), class: "shrink-0", data: {turbo_frame: "_top"} do %>
-                <%= image_tag group[:thumbnail], loading: "lazy", class: "w-32 sm:w-44 aspect-video object-cover rounded-lg" %>
+                <%= image_tag group[:thumbnail], alt: "#{group[:talk_title]} thumbnail", loading: "lazy", class: "w-32 sm:w-44 aspect-video object-cover rounded-lg" %>
               <% end %>
             <% end %>
 


### PR DESCRIPTION
## Description
On hack day at RubyConf, I ran a Lighthouse a11y report and noticed that most of what it flagged were missing `alt`s on the images, so I went ahead and added any missing ones that I could find. Finally making the PR now.

## Screenshots

Screenshot showing the `alt` text audit passing for my local copy's home page
<img width="1728" height="997" alt="Screenshot 2026-07-21 at 12 27 02 AM" src="https://github.com/user-attachments/assets/51137bbd-5864-4a1e-b2db-096acf1a9577" />

Screenshot showing the `alt` text audit failing for prod's home page
<img width="1728" height="995" alt="Screenshot 2026-07-21 at 12 27 33 AM" src="https://github.com/user-attachments/assets/9cdbedda-05c5-417d-af5e-fdf2ebfe27d4" />

## Testing Steps

- [x] Lighthouse score increased from 88 to 96 for the home page (similar increases on the other pages I spot-checked, though a few pages have lower scores than the 96)
- [x] After clicking around through as much of the app as I could think of, no new errors surfaced in the server logs or console (I also had Claude do a sanity check for me in case there were any pages I missed)

## References
N/A
