### PR TITLE
Fix typos in involvement role names

### DIFF
--- a/data/balticruby/balticruby-2026/involvements.yml
+++ b/data/balticruby/balticruby-2026/involvements.yml
@@ -6,7 +6,7 @@
   organisations:
     - Rubyness
 
-- name: "Programm Comittee Member"
+- name: "Program Committee Member"
   users:
     - Mina Slater
     - Youssef Boulkaid

--- a/data/euruko/noruko-2020/involvements.yml
+++ b/data/euruko/noruko-2020/involvements.yml
@@ -1,4 +1,4 @@
 ---
-- name: "Orgnizer"
+- name: "Organizer"
   organisations:
     - Stichting Ruby NL # https://rubynl.org/

--- a/data/rubyconf-austria/rubyconf-austria-2026/involvements.yml
+++ b/data/rubyconf-austria/rubyconf-austria-2026/involvements.yml
@@ -3,7 +3,7 @@
   users:
     - Muhamed Isabegović
 
-- name: "Programm Comittee Member"
+- name: "Program Committee Member"
   users:
     - Hans Schnedlitz
     - Christoph Lipautz


### PR DESCRIPTION
## Description

Correct a couple of typos:
- "Orgnizer" -> "Organizer" (NoRuKo 2020)
- "Programm Comittee Member" -> "Program Committee Member" (Baltic Ruby 2026 and RubyConf Austria 2026)

I double-checked with @marcoroth, and he said they're likely typos!

## Screenshots

N/A. Let me know if you'd like screenshots

## Testing Steps

- Ensure typos are fixed on the following pages:
	- `/events/noruko-2020/involvements`
	- `/events/balticruby-2026/involvements`
	- `/events/rubyconf-austria-2026/involvements`

## References

N/A
