### PR TITLE
Correct date for XO Ruby Seattle

### DIFF
--- a/data/xoruby/xoruby-seattle-2026/event.yml
+++ b/data/xoruby/xoruby-seattle-2026/event.yml
@@ -6,8 +6,8 @@ timezone: "America/Los_Angeles"
 kind: "conference"
 description: |-
   XO Ruby Seattle is a single-day, single-track conference designed to draw folks in from the city and the region. An approachable $100 ticket price coupled with no need for a hotel or airfare means you can connect with your community without breaking the bank.
-start_date: "2026-08-07"
-end_date: "2026-08-07"
+start_date: "2026-08-08"
+end_date: "2026-08-08"
 year: 2026
 website: "https://www.xoruby.com/event/seattle/"
 tickets_url: "https://buy.stripe.com/9B6bJ24HJe9q3Q9g2A43S0m"


### PR DESCRIPTION
## Description

Correct the date for XO Ruby Seattle from August 7th to August 8th, 2026.

## Screenshots

<img width="1456" height="929" alt="image" src="https://github.com/user-attachments/assets/790259f7-209d-4463-82c5-f455ab5269ba" />


## Testing Steps

- [ ] Check to make sure `/events/xoruby-seattle-2026` renders August 8th.

## References

- https://www.xoruby.com/event/seattle/
   <img width="1078" height="622" alt="image" src="https://github.com/user-attachments/assets/4fe96c0e-3170-45fd-8395-ad197b323d3e" />
