### PR TITLE
Migrate `rails verify_thumbnails` to static validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,9 +165,6 @@ jobs:
       - name: Run Seed Smoke Test
         run: bin/rails test test/tasks/seed_test.rb
 
-      - name: Verify all thumbnails for child talks are present
-        run: bin/rails verify_thumbnails
-
   build:
     name: Build Docker Image
     needs: changes

--- a/app/models/static/validators/missing_thumbnails.rb
+++ b/app/models/static/validators/missing_thumbnails.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Static
+  module Validators
+    class MissingThumbnails
+      PATTERNS = ["**/videos.yml"].freeze
+      THUMBNAIL_ROOT = "app/assets/images/thumbnails"
+
+      def initialize(file_path:, document: nil)
+        @file_path = file_path
+        @document = document
+      end
+
+      def applicable?
+        return false unless File.exist?(@file_path)
+
+        PATTERNS.any? { |pattern| File.fnmatch?(pattern, @file_path, File::FNM_PATHNAME) }
+      end
+
+      def errors
+        @errors ||= validate
+      end
+
+      def validate
+        return [] unless applicable?
+        return [] unless document.root
+
+        document.root.each.flat_map do |video|
+          parent_id = video.value_at("id")
+
+          Array(video["talks"]&.each&.to_a).filter_map do |child|
+            next unless speaker?(child)
+            next unless usable_start_cue?(child)
+
+            video_id = child.value_at("video_id")
+            next if parent_id.blank? || video_id.blank?
+
+            path = thumbnail_path(parent_id, video_id)
+            next if File.exist?(path)
+
+            node = child["video_id"] || child["start_cue"]
+
+            Static::Validators::Error.new(
+              %(missing thumbnail for talk "#{video_id}" at #{relative_path(path)}. Run `bin/rails extract_thumbnails` to generate it.),
+              file_path: @file_path,
+              line: node&.location&.start_line || 1,
+              end_line: node&.location&.end_line
+            )
+          end
+        end
+      end
+
+      def document
+        @document ||= Yerba.parse_file(@file_path)
+      end
+
+      private
+
+      def speaker?(child)
+        Array(child.value_at("speakers")).any? { |name| name.to_s.strip.present? }
+      end
+
+      def usable_start_cue?(child)
+        cue = child.value_at("start_cue")
+        cue.present? && cue != "TODO"
+      end
+
+      def thumbnail_path(parent_id, video_id)
+        Rails.root.join(THUMBNAIL_ROOT, event_slug, parent_id, "#{video_id}.webp")
+      end
+
+      def event_slug
+        @event_slug ||= File.basename(File.dirname(File.expand_path(@file_path)))
+      end
+
+      def relative_path(path)
+        path.to_s.sub("#{Rails.root}/", "")
+      end
+    end
+  end
+end

--- a/app/models/static/validators/validator.rb
+++ b/app/models/static/validators/validator.rb
@@ -72,7 +72,8 @@ class Static::Validators::Validator
       Static::Validators::TalkPublishedAt,
       Static::Validators::TalkRenames,
       Static::Validators::TalkShortKind,
-      Static::Validators::UniqueTalkIds
+      Static::Validators::UniqueTalkIds,
+      Static::Validators::MissingThumbnails
     ]
   end
 end

--- a/lib/tasks/thumbnails.rake
+++ b/lib/tasks/thumbnails.rake
@@ -38,31 +38,3 @@ task reorg_thumbnails: :environment do
     unknown.each { |path| puts "  #{path}" }
   end
 end
-
-desc "Verify all talks with start_cue have thumbnails"
-task verify_thumbnails: :environment do |t, args|
-  thumbnails_count = 0
-  child_talks_with_missing_thumbnails = []
-
-  Talk.where(meta_talk: true).flat_map(&:child_talks).each do |child_talk|
-    if child_talk.static_metadata
-      if child_talk.static_metadata.start_cue.present? && child_talk.static_metadata.start_cue != "TODO"
-        if child_talk.thumbnails.path.exist?
-          thumbnails_count += 1
-        else
-          puts "missing thumbnail for child_talk: #{child_talk.video_id} at: #{child_talk.thumbnails.path}"
-          child_talks_with_missing_thumbnails << child_talk
-        end
-      end
-    else
-      puts "missing static_metadata for child_talk: #{child_talk.video_id}"
-      child_talks_with_missing_thumbnails << child_talk
-    end
-  end
-
-  if child_talks_with_missing_thumbnails.any?
-    raise "missing #{child_talks_with_missing_thumbnails.count} thumbnails"
-  else
-    puts "All #{thumbnails_count} thumbnails present!"
-  end
-end

--- a/test/models/static/validators/missing_thumbnails_test.rb
+++ b/test/models/static/validators/missing_thumbnails_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "fileutils"
+require "tmpdir"
+
+class Static::Validators::MissingThumbnailsTest < ActiveSupport::TestCase
+  def write_videos(dir, contents)
+    FileUtils.mkdir_p(dir)
+    path = File.join(dir, "videos.yml")
+    File.write(path, contents)
+    path
+  end
+
+  def child(video_id:, start_cue: "01:00", speakers: ["Jane Doe"])
+    speaker_lines = speakers.map { |name| "        - #{name.inspect}" }.join("\n")
+    <<~YAML
+      - id: "parent-test-event"
+        title: "Meta"
+        video_id: "PARENT123"
+        talks:
+          - id: "#{video_id}"
+            title: "Talk"
+            video_id: "#{video_id}"
+            start_cue: #{start_cue.inspect}
+            speakers:
+      #{speaker_lines}
+    YAML
+  end
+
+  test "applicable? only for videos.yml files" do
+    Dir.mktmpdir do |root|
+      path = write_videos(File.join(root, "series", "test-event"), "[]\n")
+      assert Static::Validators::MissingThumbnails.new(file_path: path).applicable?
+    end
+
+    assert_not Static::Validators::MissingThumbnails.new(file_path: Rails.root.join("data/blue-ridge-ruby/series.yml").to_s).applicable?
+  end
+
+  test "flags a child talk with a speaker and start_cue but no thumbnail" do
+    Dir.mktmpdir do |root|
+      path = write_videos(File.join(root, "series", "test-event"), child(video_id: "jane-doe-test-event"))
+
+      errors = Static::Validators::MissingThumbnails.new(file_path: path).errors
+
+      assert_equal 1, errors.size
+      assert_match "jane-doe-test-event", errors.first.message
+    end
+  end
+
+  test "no error when the thumbnail exists" do
+    slug = "missing-thumbnails-test-event"
+    thumbnail = Rails.root.join("app/assets/images/thumbnails", slug, "parent-test-event", "jane-doe-test-event.webp")
+    FileUtils.mkdir_p(File.dirname(thumbnail))
+    FileUtils.touch(thumbnail)
+
+    Dir.mktmpdir do |root|
+      path = write_videos(File.join(root, "series", slug), child(video_id: "jane-doe-test-event"))
+
+      assert_empty Static::Validators::MissingThumbnails.new(file_path: path).errors
+    end
+  ensure
+    FileUtils.rm_rf(Rails.root.join("app/assets/images/thumbnails", slug))
+  end
+
+  test "ignores speaker-less segments such as open mics" do
+    Dir.mktmpdir do |root|
+      path = write_videos(File.join(root, "series", "test-event"), child(video_id: "open-mic-test-event", speakers: []))
+
+      assert_empty Static::Validators::MissingThumbnails.new(file_path: path).errors
+    end
+  end
+
+  test "ignores talks without a usable start_cue" do
+    Dir.mktmpdir do |root|
+      path = write_videos(File.join(root, "series", "test-event"), child(video_id: "jane-doe-test-event", start_cue: "TODO"))
+
+      assert_empty Static::Validators::MissingThumbnails.new(file_path: path).errors
+    end
+  end
+end


### PR DESCRIPTION
## Description

This pull request replaces the database-backed `verify_thumbnails` rake task with a static validator that reads `videos.yml` directly, so the check no longer needs a fully seeded database to run.

## Screenshots

\-

## Testing Steps

\-

## References
\-
