### PR TITLE
Speed up data-only image builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile
 
 # Copy application code
-COPY . .
+COPY --exclude=data . .
 
 # Precompile bootsnap code for faster boot times
 RUN bundle exec bootsnap precompile app/ lib/
@@ -77,6 +77,8 @@ RUN groupadd --system --gid 1000 rails && \
     useradd rails --uid 1000 --gid 1000 --create-home --shell /bin/bash && \
     chown -R rails:rails db log storage tmp
 USER 1000:1000
+
+COPY data /rails/data
 
 # Entrypoint prepares the database.
 ENTRYPOINT ["/rails/bin/docker-entrypoint"]


### PR DESCRIPTION
### Description

This pull request makes a Docker image rebuild nearly free when a change only touches the `data/` folder. Previously `data/` was copied in as part of `COPY . .`, which sits before `bootsnap precompile` and `assets:precompile` in the build stage, so any change under `data/` invalidated that layer and forced both precompile steps to re-run, turning a one-line data edit into a full, multi-minute image build.

The fix is to move `data/` out of the code-copy layer and into the very last layer of the final image. The build stage now uses `COPY --exclude=data . .` so the precompile steps no longer depend on `data/`, and the final stage adds `COPY data /rails/data` as its last instruction. A data-only change therefore reuses every cached layer and only re-runs the small `COPY data` layer. Combined with the BuildKit registry cache the CI build already uses, that should take a data-only rebuild from minutes down to seconds.