### PR TITLE
Add `Static::VideosFile#at`, `#since` and `#newly_watchable_talks`

### DIFF
--- a/app/models/static/videos_file.rb
+++ b/app/models/static/videos_file.rb
@@ -69,12 +69,12 @@ module Static
       nil
     end
 
-    def self.added_videos(since)
-      all.flat_map { |file| file.added_videos(since) }
+    def self.added_talks(since)
+      all.flat_map { |file| file.added_talks(since) }
     end
 
-    def self.newly_watchable_videos(since)
-      all.flat_map { |file| file.newly_watchable_videos(since) }
+    def self.newly_watchable_talks(since)
+      all.flat_map { |file| file.newly_watchable_talks(since) }
     end
 
     def self.youtube_videos_missing_published_at
@@ -188,13 +188,13 @@ module Static
       }
     end
 
-    def added_videos(since)
+    def added_talks(since)
       diff = changes(since)
 
       diff ? diff[:added] : ids
     end
 
-    def newly_watchable_videos(since)
+    def newly_watchable_talks(since)
       diff = changes(since)
       return [] unless diff
 

--- a/app/models/static/videos_file.rb
+++ b/app/models/static/videos_file.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "open3"
+
 module Static
   class VideosFile
     VIDEOS_GLOB = "data/**/videos.yml"
@@ -61,6 +63,14 @@ module Static
       end
 
       nil
+    end
+
+    def self.added_videos(since)
+      all.flat_map { |file| file.added_videos(since) }
+    end
+
+    def self.newly_watchable_videos(since)
+      all.flat_map { |file| file.newly_watchable_videos(since) }
     end
 
     def self.youtube_videos_missing_published_at
@@ -142,6 +152,85 @@ module Static
 
     def relative_path
       path.sub("#{Rails.root}/", "")
+    end
+
+    def at(timestamp)
+      return nil if path.blank?
+
+      revision, _, status = git("rev-list", "--max-count=1", "--before", timestamp.to_time.iso8601, "HEAD", "--", File.basename(path.to_s))
+      return nil unless status.success? && revision.strip.present?
+
+      content, _, status = git("show", "#{revision.strip}:./#{File.basename(path.to_s)}")
+      return nil unless status.success?
+
+      self.class.parse(content, path: path)
+    end
+
+    def changes(since)
+      snapshot = at(since)
+      return nil unless snapshot
+
+      current = talks_by_id
+      previous = snapshot.talks_by_id
+
+      modified = (current.keys & previous.keys).filter_map { |id|
+        diff = attribute_changes(previous[id].to_h, current[id].to_h)
+
+        [id, diff] if diff.any?
+      }.to_h
+
+      {
+        added: current.keys - previous.keys,
+        removed: previous.keys - current.keys,
+        modified: modified
+      }
+    end
+
+    def added_videos(since)
+      diff = changes(since)
+
+      diff ? diff[:added] : ids
+    end
+
+    def newly_watchable_videos(since)
+      diff = changes(since)
+      return [] unless diff
+
+      diff[:modified].filter_map { |id, attributes|
+        next unless attributes.key?("video_provider")
+
+        before, after = attributes["video_provider"]
+
+        id if !watchable_provider?(before) && watchable_provider?(after)
+      }
+    end
+
+    protected
+
+    def talks_by_id
+      talks.index_by { |talk| talk.value_at("id") }.except(nil)
+    end
+
+    private
+
+    def watchable_provider?(provider)
+      (provider || "youtube").in?(Talk::WATCHABLE_PROVIDERS)
+    end
+
+    def attribute_changes(before, after)
+      (before.keys | after.keys).filter_map do |key|
+        next if key == "talks"
+
+        [key, [before[key], after[key]]] if before[key] != after[key]
+      end.to_h
+    end
+
+    def git(*args)
+      Open3.capture3("git", "-C", File.dirname(path.to_s), *args)
+    end
+
+    def sequence_items(node)
+      node.is_a?(Yerba::Sequence) ? node.each.to_a : []
     end
   end
 end

--- a/app/models/static/videos_file.rb
+++ b/app/models/static/videos_file.rb
@@ -17,6 +17,10 @@ module Static
       new(path, document: Yerba.parse(content))
     end
 
+    def self.from(path)
+      new(Rails.root.join(path.to_s).to_s)
+    end
+
     def self.all
       @all ||= Dir.glob(Rails.root.join(VIDEOS_GLOB)).filter_map do |path|
         new(path)
@@ -111,9 +115,7 @@ module Static
     end
 
     def top_level_talks
-      return [] unless document.root
-
-      document.root.each.to_a
+      sequence_items(document.root)
     end
 
     def sub_talks

--- a/test/models/static/videos_file_test.rb
+++ b/test/models/static/videos_file_test.rb
@@ -1,0 +1,218 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Static::VideosFileTest < ActiveSupport::TestCase
+  VIDEOS = [
+    {
+      "id" => "lightning-talks-testconf-2024",
+      "title" => "Lightning Talks",
+      "talks" => [
+        {"id" => "one-testconf-2024", "title" => "One", "old_id" => "one-legacy"},
+        {"id" => "two-testconf-2024", "title" => "Two"}
+      ]
+    },
+    {"id" => "jane-doe-testconf-2024", "title" => "Building Things"}
+  ].freeze
+
+  test "video_pairs pairs every video with its nested talks" do
+    with_temp_video(VIDEOS) do |file|
+      pairs = file.video_pairs
+
+      assert_equal 2, pairs.size
+      assert_equal "lightning-talks-testconf-2024", pairs.first.first.value_at("id")
+      assert_equal ["one-testconf-2024", "two-testconf-2024"], pairs.first.last.map { |talk| talk.value_at("id") }
+      assert_equal "jane-doe-testconf-2024", pairs.last.first.value_at("id")
+      assert_empty pairs.last.last
+    end
+  end
+
+  test "top_level_talks and sub_talks split the pairs" do
+    with_temp_video(VIDEOS) do |file|
+      assert_equal ["lightning-talks-testconf-2024", "jane-doe-testconf-2024"], file.top_level_talks.map { |node| node.value_at("id") }
+      assert_equal ["one-testconf-2024", "two-testconf-2024"], file.sub_talks.map { |node| node.value_at("id") }
+    end
+  end
+
+  test "talks lists every top-level video before the nested talks" do
+    with_temp_video(VIDEOS) do |file|
+      assert_equal(
+        ["lightning-talks-testconf-2024", "jane-doe-testconf-2024", "one-testconf-2024", "two-testconf-2024"],
+        file.talks.map { |node| node.value_at("id") }
+      )
+    end
+  end
+
+  test "nodes follows each video with its own nested talks" do
+    with_temp_video(VIDEOS) do |file|
+      assert_equal(
+        ["lightning-talks-testconf-2024", "one-testconf-2024", "two-testconf-2024", "jane-doe-testconf-2024"],
+        file.nodes.map { |node| node.value_at("id") }
+      )
+    end
+  end
+
+  test "ids and old_ids cover nested talks" do
+    with_temp_video(VIDEOS) do |file|
+      assert_equal(
+        ["lightning-talks-testconf-2024", "jane-doe-testconf-2024", "one-testconf-2024", "two-testconf-2024"],
+        file.ids
+      )
+      assert_equal ["one-legacy"], file.old_ids
+    end
+  end
+
+  test "the node tree is walked once and shared between readers" do
+    with_temp_video(VIDEOS) do |file|
+      assert_same file.video_pairs, file.video_pairs
+      assert_same file.top_level_talks.first, file.nodes.first
+      assert_same file.sub_talks.first, file.video_pairs.first.last.first
+    end
+  end
+
+  test "handles a file with an empty sequence" do
+    with_temp_video([]) do |file|
+      assert_empty file.video_pairs
+      assert_empty file.nodes
+      assert_empty file.talks
+      assert_empty file.ids
+    end
+  end
+
+  test "handles a file without a root" do
+    with_temp_file("") do |path|
+      file = Static::VideosFile.new(path)
+
+      assert_empty file.video_pairs
+      assert_empty file.nodes
+      assert_empty file.talks
+    end
+  end
+
+  test "wrap returns an existing VideosFile untouched" do
+    with_temp_video(VIDEOS) do |file|
+      assert_same file, Static::VideosFile.wrap(file.path, file)
+    end
+  end
+
+  test "wrap builds a VideosFile around a given document" do
+    with_temp_file(VIDEOS.to_yaml) do |path|
+      document = Yerba.parse_file(path)
+      file = Static::VideosFile.wrap(path, document)
+
+      assert_instance_of Static::VideosFile, file
+      assert_same document, file.document
+    end
+  end
+
+  test "wrap parses the path when no document is given" do
+    with_temp_file(VIDEOS.to_yaml) do |path|
+      file = Static::VideosFile.wrap(path)
+
+      assert_instance_of Static::VideosFile, file
+      assert_equal 2, file.video_pairs.size
+    end
+  end
+
+  test "at returns the file as it was committed at the given timestamp" do
+    with_temp_video(VIDEOS) do |file|
+      old_videos = [{"id" => "old-testconf-2024", "title" => "Old Title"}]
+
+      with_history(file, "2024-01-15T12:00:00Z" => old_videos, "2024-03-15T12:00:00Z" => VIDEOS)
+
+      assert_equal ["old-testconf-2024"], file.at(Time.utc(2024, 2, 1)).ids
+      assert_equal file.ids, file.at(Time.utc(2024, 4, 1)).ids
+      assert_nil file.at(Time.utc(2023, 1, 1))
+    end
+  end
+
+  test "changes lists talks added, removed and modified since a timestamp" do
+    with_temp_video(VIDEOS) do |file|
+      old_videos = [
+        {"id" => "jane-doe-testconf-2024", "title" => "Old Title"},
+        {"id" => "retracted-testconf-2024", "title" => "Retracted"}
+      ]
+
+      with_history(file, "2024-01-15T12:00:00Z" => old_videos, "2024-03-15T12:00:00Z" => VIDEOS)
+
+      changes = file.changes(Time.utc(2024, 2, 1))
+
+      assert_equal ["lightning-talks-testconf-2024", "one-testconf-2024", "two-testconf-2024"], changes[:added]
+      assert_equal ["retracted-testconf-2024"], changes[:removed]
+      assert_equal({"jane-doe-testconf-2024" => {"title" => ["Old Title", "Building Things"]}}, changes[:modified])
+
+      assert_nil file.changes(Time.utc(2023, 1, 1))
+
+      assert_equal changes[:added], file.added_videos(Time.utc(2024, 2, 1))
+      assert_equal file.ids, file.added_videos(Time.utc(2023, 1, 1))
+    end
+  end
+
+  test "newly_watchable_videos lists talks whose provider became watchable" do
+    current = [
+      {"id" => "a-testconf-2024", "title" => "A", "video_provider" => "youtube"},
+      {"id" => "b-testconf-2024", "title" => "B"},
+      {"id" => "c-testconf-2024", "title" => "C", "video_provider" => "not_recorded"},
+      {"id" => "d-testconf-2024", "title" => "D", "video_provider" => "vimeo"}
+    ]
+
+    old_videos = [
+      {"id" => "a-testconf-2024", "title" => "A", "video_provider" => "scheduled"},
+      {"id" => "b-testconf-2024", "title" => "B", "video_provider" => "scheduled"},
+      {"id" => "c-testconf-2024", "title" => "C", "video_provider" => "scheduled"},
+      {"id" => "d-testconf-2024", "title" => "D", "video_provider" => "vimeo"}
+    ]
+
+    with_temp_video(current) do |file|
+      with_history(file, "2024-01-15T12:00:00Z" => old_videos, "2024-03-15T12:00:00Z" => current)
+
+      assert_equal ["a-testconf-2024", "b-testconf-2024"], file.newly_watchable_videos(Time.utc(2024, 2, 1))
+      assert_empty file.newly_watchable_videos(Time.utc(2023, 1, 1))
+    end
+  end
+
+  test "delegates unknown methods to the underlying document" do
+    with_temp_video(VIDEOS) do |file|
+      assert_equal 2, file.root.length
+      assert_equal "Lightning Talks", file.to_a.first["title"]
+    end
+  end
+
+  private
+
+  def with_temp_video(videos, &block)
+    with_temp_file(videos.to_yaml) { |path| block.call(Static::VideosFile.new(path)) }
+  end
+
+  def with_history(file, versions)
+    repo = file.path.sub(%r{/data/testconf/testconf-2024/videos\.yml\z}, "")
+    git(repo, "init")
+
+    versions.each do |date, videos|
+      File.write(file.path, videos.to_yaml)
+      git(repo, "add", ".")
+      commit(repo, "version at #{date}", date)
+    end
+  end
+
+  def git(repo, *args, env: {})
+    assert system(env, "git", "-C", repo, *args, out: File::NULL, err: File::NULL), "git #{args.join(" ")} failed"
+  end
+
+  def commit(repo, message, date)
+    git(
+      repo, "-c", "user.name=Test", "-c", "user.email=test@example.com", "-c", "commit.gpgsign=false", "commit", "-m", message,
+      env: {"GIT_AUTHOR_DATE" => date, "GIT_COMMITTER_DATE" => date}
+    )
+  end
+
+  def with_temp_file(content)
+    dir = Dir.mktmpdir
+    path = File.join(dir, "data", "testconf", "testconf-2024", "videos.yml")
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, content)
+    yield path
+  ensure
+    FileUtils.rm_rf(dir)
+  end
+end

--- a/test/models/static/videos_file_test.rb
+++ b/test/models/static/videos_file_test.rb
@@ -100,12 +100,12 @@ class Static::VideosFileTest < ActiveSupport::TestCase
 
       assert_nil file.changes(Time.utc(2023, 1, 1))
 
-      assert_equal changes[:added], file.added_videos(Time.utc(2024, 2, 1))
-      assert_equal file.ids, file.added_videos(Time.utc(2023, 1, 1))
+      assert_equal changes[:added], file.added_talks(Time.utc(2024, 2, 1))
+      assert_equal file.ids, file.added_talks(Time.utc(2023, 1, 1))
     end
   end
 
-  test "newly_watchable_videos lists talks whose provider became watchable" do
+  test "newly_watchable_talks lists talks whose provider became watchable" do
     current = [
       {"id" => "a-testconf-2024", "title" => "A", "video_provider" => "youtube"},
       {"id" => "b-testconf-2024", "title" => "B"},
@@ -123,8 +123,8 @@ class Static::VideosFileTest < ActiveSupport::TestCase
     with_temp_video(current) do |file|
       with_history(file, "2024-01-15T12:00:00Z" => old_videos, "2024-03-15T12:00:00Z" => current)
 
-      assert_equal ["a-testconf-2024", "b-testconf-2024"], file.newly_watchable_videos(Time.utc(2024, 2, 1))
-      assert_empty file.newly_watchable_videos(Time.utc(2023, 1, 1))
+      assert_equal ["a-testconf-2024", "b-testconf-2024"], file.newly_watchable_talks(Time.utc(2024, 2, 1))
+      assert_empty file.newly_watchable_talks(Time.utc(2023, 1, 1))
     end
   end
 

--- a/test/models/static/videos_file_test.rb
+++ b/test/models/static/videos_file_test.rb
@@ -15,18 +15,6 @@ class Static::VideosFileTest < ActiveSupport::TestCase
     {"id" => "jane-doe-testconf-2024", "title" => "Building Things"}
   ].freeze
 
-  test "video_pairs pairs every video with its nested talks" do
-    with_temp_video(VIDEOS) do |file|
-      pairs = file.video_pairs
-
-      assert_equal 2, pairs.size
-      assert_equal "lightning-talks-testconf-2024", pairs.first.first.value_at("id")
-      assert_equal ["one-testconf-2024", "two-testconf-2024"], pairs.first.last.map { |talk| talk.value_at("id") }
-      assert_equal "jane-doe-testconf-2024", pairs.last.first.value_at("id")
-      assert_empty pairs.last.last
-    end
-  end
-
   test "top_level_talks and sub_talks split the pairs" do
     with_temp_video(VIDEOS) do |file|
       assert_equal ["lightning-talks-testconf-2024", "jane-doe-testconf-2024"], file.top_level_talks.map { |node| node.value_at("id") }
@@ -43,15 +31,6 @@ class Static::VideosFileTest < ActiveSupport::TestCase
     end
   end
 
-  test "nodes follows each video with its own nested talks" do
-    with_temp_video(VIDEOS) do |file|
-      assert_equal(
-        ["lightning-talks-testconf-2024", "one-testconf-2024", "two-testconf-2024", "jane-doe-testconf-2024"],
-        file.nodes.map { |node| node.value_at("id") }
-      )
-    end
-  end
-
   test "ids and old_ids cover nested talks" do
     with_temp_video(VIDEOS) do |file|
       assert_equal(
@@ -62,18 +41,8 @@ class Static::VideosFileTest < ActiveSupport::TestCase
     end
   end
 
-  test "the node tree is walked once and shared between readers" do
-    with_temp_video(VIDEOS) do |file|
-      assert_same file.video_pairs, file.video_pairs
-      assert_same file.top_level_talks.first, file.nodes.first
-      assert_same file.sub_talks.first, file.video_pairs.first.last.first
-    end
-  end
-
   test "handles a file with an empty sequence" do
     with_temp_video([]) do |file|
-      assert_empty file.video_pairs
-      assert_empty file.nodes
       assert_empty file.talks
       assert_empty file.ids
     end
@@ -83,35 +52,23 @@ class Static::VideosFileTest < ActiveSupport::TestCase
     with_temp_file("") do |path|
       file = Static::VideosFile.new(path)
 
-      assert_empty file.video_pairs
-      assert_empty file.nodes
       assert_empty file.talks
+      assert_empty file.ids
     end
   end
 
-  test "wrap returns an existing VideosFile untouched" do
-    with_temp_video(VIDEOS) do |file|
-      assert_same file, Static::VideosFile.wrap(file.path, file)
-    end
-  end
-
-  test "wrap builds a VideosFile around a given document" do
+  test "from builds a VideosFile from an absolute or Rails-relative path" do
     with_temp_file(VIDEOS.to_yaml) do |path|
-      document = Yerba.parse_file(path)
-      file = Static::VideosFile.wrap(path, document)
+      file = Static::VideosFile.from(path)
 
       assert_instance_of Static::VideosFile, file
-      assert_same document, file.document
+      assert_equal path, file.path
+      assert_equal 2, file.count
     end
-  end
 
-  test "wrap parses the path when no document is given" do
-    with_temp_file(VIDEOS.to_yaml) do |path|
-      file = Static::VideosFile.wrap(path)
+    file = Static::VideosFile.from("data/rails-world/rails-world-2023/videos.yml")
 
-      assert_instance_of Static::VideosFile, file
-      assert_equal 2, file.video_pairs.size
-    end
+    assert_equal Rails.root.join("data/rails-world/rails-world-2023/videos.yml").to_s, file.path
   end
 
   test "at returns the file as it was committed at the given timestamp" do
@@ -168,13 +125,6 @@ class Static::VideosFileTest < ActiveSupport::TestCase
 
       assert_equal ["a-testconf-2024", "b-testconf-2024"], file.newly_watchable_videos(Time.utc(2024, 2, 1))
       assert_empty file.newly_watchable_videos(Time.utc(2023, 1, 1))
-    end
-  end
-
-  test "delegates unknown methods to the underlying document" do
-    with_temp_video(VIDEOS) do |file|
-      assert_equal 2, file.root.length
-      assert_equal "Lightning Talks", file.to_a.first["title"]
     end
   end
 


### PR DESCRIPTION
### Description

Adds git-backed time-travel to `Static::VideosFile`, so we can ask how a `videos.yml` looked at any point in time and what changed since.

  - `at(timestamp)` returns the file as of the last commit before the timestamp (or nil if it didn't exist yet), parsed into a regular `VideosFile` instance
  - `changes(since)` diffs the snapshot against the current file: `{added:, removed:, modified:}`
  - `added_videos(since)` talk ids added since the timestamp (a file with no history before it counts entirely as new)
  - `newly_watchable_videos(since)` talks whose `video_provider` flipped from a placeholder to a watchable provide

Both aggregate methods also exist as class methods that sweep every videos.yml.

```ruby
Static::VideosFile.added_videos(1.month.ago).count
file.changes(1.month.ago)
# => {added: [...], removed: [...], modified: {"dave-thomas-kaigi-on-rails-2026" => {"kind" => [nil, "keynote"]}}}
```

```ruby
file = Static::VideosFile.from("data/madison-ruby/madison-ruby-2013/videos.yml")

file.newly_watchable_videos(1.month.ago)
# => ["bryan-powell-madison-ruby-2013",
#     "aaron-patterson-madison-ruby-2013",
#     "margaret-pagel-madison-ruby-2013",
#     "jason-garber-madison-ruby-2013",
#     "leon-gersing-madison-ruby-2013",
#     "ed-finkler-madison-ruby-2013",
#     "michael-fairley-madison-ruby-2013",
#     "justin-searls-madison-ruby-2013",
#     "fiona-tay-madison-ruby-2013"]

file.changes(1.month.ago)[:modified].first(2)
# => [["desi-mcadam-madison-ruby-2013", {"kind" => [nil, "workshop"]}],
#     ["elisabeth-hendrickson-pat-maddox-madison-ruby-2013", {"kind" => [nil, "workshop"]}]]
```