### PR TITLE
Add sponsors for Kansai RubyKaigi 09

### DIFF
--- a/data/kansai-rubykaigi/kansai-rubykaigi-09/sponsors.yml
+++ b/data/kansai-rubykaigi/kansai-rubykaigi-09/sponsors.yml
@@ -1,0 +1,84 @@
+---
+- tiers:
+  - name: "Biwa Sponsor"
+    level: 1
+    sponsors:
+    - name: "TORANOANA Inc."
+      website: "https://toranoana-lab.co.jp/"
+      slug: "TORANOANAInc"
+      logo_url: "https://regional.rubykaigi.org/kansai09/sponsors/toranoanalab.jpg"
+
+  - name: "Gold Sponsor"
+    level: 3
+    sponsors:
+    - name: "A's Child Inc."
+      website: "https://www.as-child.com/"
+      slug: "AsChildInc"
+      logo_url: "https://regional.rubykaigi.org/kansai09/sponsors/aschild.png"
+
+    - name: "PONOS Corp."
+      website: "https://www.ponos.jp/"
+      slug: "ponos"
+      logo_url: "https://regional.rubykaigi.org/kansai09/sponsors/ponos.png"
+
+    - name: "Gaji-Labo"
+      website: "https://www.gaji.jp/"
+      slug: "gajilabo"
+      logo_url: "https://regional.rubykaigi.org/kansai09/sponsors/gajilabo.png"
+
+    - name: "IVRy Inc."
+      website: "https://ivry.jp/"
+      slug: "IVRyInc"
+      logo_url: "https://regional.rubykaigi.org/kansai09/sponsors/ivry.png"
+
+    - name: "Leaner Technologies Inc."
+      website: "https://leaner.co.jp/"
+      slug: "LeanerTechnologiesInc"
+      logo_url: "https://regional.rubykaigi.org/kansai09/sponsors/leaner.png"
+
+    - name: "Ruby Development Inc."
+      website: "https://www.ruby-dev.jp/"
+      slug: "RubyDevelopmentInc"
+      logo_url: "https://regional.rubykaigi.org/kansai09/sponsors/rubydevelopment.jpg"
+
+    - name: "Agileware"
+      website: "https://agileware.jp/"
+      slug: "agileware"
+      logo_url: "https://regional.rubykaigi.org/kansai09/sponsors/agileware.png"
+
+    - name: "INGAGE Inc."
+      website: "https://ingage.co.jp/"
+      slug: "ingage"
+      logo_url: "https://regional.rubykaigi.org/kansai09/sponsors/ingage.png"
+
+    - name: "Net Protections, Inc."
+      website: "https://corp.netprotections.com/"
+      slug: "net-protections-inc"
+      logo_url: "https://regional.rubykaigi.org/kansai09/sponsors/netprotections.png"
+
+    - name: "Eiwa System Management, Inc."
+      website: "https://esm.co.jp/"
+      slug: "EiwaSystemManagementInc"
+      logo_url: "https://regional.rubykaigi.org/kansai09/sponsors/esm.png"
+
+  - name: "Silver Sponsor"
+    level: 4
+    sponsors:
+    - name: "SmartHR, Inc."
+      website: "https://smarthr.co.jp/"
+      slug: "smarthr"
+      logo_url: "https://regional.rubykaigi.org/kansai09/sponsors/smarthr.png"
+
+    - name: "Network Applied Communication Laboratory Ltd."
+      website: "https://www.netlab.jp/"
+      slug: "NetworkAppliedCommunicationLaboratoryLtd"
+      logo_url: "https://regional.rubykaigi.org/kansai09/sponsors/nacl.png"
+
+  - name: "Tool Sponsor"
+    level: 5
+    sponsors:
+    - name: "esa LLC"
+      badge: "Tools Sponsor"
+      website: "https://esa.io/"
+      slug: "goudoushikaishiesa"
+      logo_url: "https://regional.rubykaigi.org/kansai09/sponsors/esa.png"


### PR DESCRIPTION
## Description
Add sponsors for Kansai RubyKaigi 09

## Screenshots
<img width="1424" height="782" alt="2026-07-27_kansai-rubykaigi-09-sponsor-1" src="https://github.com/user-attachments/assets/470db498-d156-4bc6-b20c-2f766ce19510" />
<img width="1379" height="784" alt="2026-07-27_kansai-rubykaigi-09-sponsor-2" src="https://github.com/user-attachments/assets/30847589-ae00-4575-918f-1b35eb42cb72" />
<img width="1386" height="785" alt="2026-07-27_kansai-rubykaigi-09-sponsor-3" src="https://github.com/user-attachments/assets/e42f9be0-ee55-423a-8f0d-3c54d79a264e" />


## Testing Steps
1. On Rubyevents, search for Kansai RubyKaigi 09
2. Select Sponsors

## References
<!-- Link to related issues, discussions, other PRs, or references you used to write the PR. -->
- closes #<!-- issue number -->
