### PR TITLE
Add hotels to Rocky Mountain Ruby 2024-2026.

### DIFF
--- a/data/rocky-mountain-ruby/rocky-mountain-ruby-2024/venue.yml
+++ b/data/rocky-mountain-ruby/rocky-mountain-ruby-2024/venue.yml
@@ -18,3 +18,80 @@ maps:
   google: "https://maps.google.com/?q=eTown+Hall,40.0201669,-105.275401"
   apple: "https://maps.apple.com/?q=eTown+Hall&ll=40.0201669,-105.275401"
   openstreetmap: "https://www.openstreetmap.org/?mlat=40.0201669&mlon=-105.275401"
+
+hotels:
+  - name: "Bradley Boulder Inn"
+    url: "https://www.thebradleyboulder.com"
+    address:
+      street: "2040 16th St"
+      city: "Boulder"
+      region: "Colorado"
+      postal_code: "80302"
+      country: "United States"
+      country_code: "US"
+      display: "2040 16th St, Boulder, CO 80302"
+    distance: "2 minute walk"
+    coordinates:
+      latitude: 40.01994639898552
+      longitude: -105.27465506004552
+    maps:
+      google: "https://maps.app.goo.gl/N7zWnBrhYcY89TWq6"
+      apple: ""
+      openstreetmap: ""
+
+  - name: "Hotel Boulderado"
+    url: "https://www.boulderado.com"
+    address:
+      street: "2115 13th St"
+      city: "Boulder"
+      region: "Colorado"
+      postal_code: "80302"
+      country: "United States"
+      country_code: "US"
+      display: "2115 13th St, Boulder, CO 80302"
+    distance: "5 minute walk"
+    coordinates:
+      latitude: 40.0196474228801
+      longitude: -105.27919321217307
+    maps:
+      google: "https://maps.app.goo.gl/6Z7g1k8X3v9J2Q4y5"
+      apple: ""
+      openstreetmap: ""
+
+  - name: "Hilton Garden Inn Boulder"
+    url: "https://www.hilton.com/en/hotels/wbubogi-hilton-garden-inn-boulder/"
+    address:
+      street: "2701 Canyon Boulevard"
+      city: "Boulder"
+      region: "Colorado"
+      postal_code: "80302"
+      country: "United States"
+      country_code: "US"
+      display: "2701 Canyon Boulevard, Boulder, Colorado, 80302, USA"
+    distance: "23 minute walk; 5 minute drive"
+    coordinates:
+      latitude: 40.01814579031145
+      longitude: -105.25930050979834
+    maps:
+      google: "https://maps.app.goo.gl/C9JHjPY68BLxYaTd9"
+      apple: ""
+      openstreetmap: ""
+
+  - name: "Marriott Boulder"
+    url: "https://www.marriott.com/en-us/hotels/denbo-boulder-marriott/overview/"
+    address:
+      street: "2660 Canyon Blvd"
+      city: "Boulder"
+      region: "Colorado"
+      postal_code: "80302"
+      country: "United States"
+      country_code: "US"
+      display: "2660 Canyon Blvd, Boulder, CO 80302"
+    distance: "24 minute walk; 5 minute drive"
+    coordinates:
+      latitude: 40.01638945310912
+      longitude: -105.26010548428526
+    maps:
+      google: "https://maps.app.goo.gl/8n6C5zWGDAaoh44F7"
+      apple: ""
+      openstreetmap: ""

--- a/data/rocky-mountain-ruby/rocky-mountain-ruby-2025/venue.yml
+++ b/data/rocky-mountain-ruby/rocky-mountain-ruby-2025/venue.yml
@@ -18,3 +18,80 @@ maps:
   google: "https://maps.google.com/?q=eTown+Hall,40.0201669,-105.275401"
   apple: "https://maps.apple.com/?q=eTown+Hall&ll=40.0201669,-105.275401"
   openstreetmap: "https://www.openstreetmap.org/?mlat=40.0201669&mlon=-105.275401"
+
+hotels:
+  - name: "Bradley Boulder Inn"
+    url: "https://www.thebradleyboulder.com"
+    address:
+      street: "2040 16th St"
+      city: "Boulder"
+      region: "Colorado"
+      postal_code: "80302"
+      country: "United States"
+      country_code: "US"
+      display: "2040 16th St, Boulder, CO 80302"
+    distance: "2 minute walk"
+    coordinates:
+      latitude: 40.01994639898552
+      longitude: -105.27465506004552
+    maps:
+      google: "https://maps.app.goo.gl/N7zWnBrhYcY89TWq6"
+      apple: ""
+      openstreetmap: ""
+
+  - name: "Hotel Boulderado"
+    url: "https://www.boulderado.com"
+    address:
+      street: "2115 13th St"
+      city: "Boulder"
+      region: "Colorado"
+      postal_code: "80302"
+      country: "United States"
+      country_code: "US"
+      display: "2115 13th St, Boulder, CO 80302"
+    distance: "5 minute walk"
+    coordinates:
+      latitude: 40.0196474228801
+      longitude: -105.27919321217307
+    maps:
+      google: "https://maps.app.goo.gl/6Z7g1k8X3v9J2Q4y5"
+      apple: ""
+      openstreetmap: ""
+
+  - name: "Hilton Garden Inn Boulder"
+    url: "https://www.hilton.com/en/hotels/wbubogi-hilton-garden-inn-boulder/"
+    address:
+      street: "2701 Canyon Boulevard"
+      city: "Boulder"
+      region: "Colorado"
+      postal_code: "80302"
+      country: "United States"
+      country_code: "US"
+      display: "2701 Canyon Boulevard, Boulder, Colorado, 80302, USA"
+    distance: "23 minute walk; 5 minute drive"
+    coordinates:
+      latitude: 40.01814579031145
+      longitude: -105.25930050979834
+    maps:
+      google: "https://maps.app.goo.gl/C9JHjPY68BLxYaTd9"
+      apple: ""
+      openstreetmap: ""
+
+  - name: "Marriott Boulder"
+    url: "https://www.marriott.com/en-us/hotels/denbo-boulder-marriott/overview/"
+    address:
+      street: "2660 Canyon Blvd"
+      city: "Boulder"
+      region: "Colorado"
+      postal_code: "80302"
+      country: "United States"
+      country_code: "US"
+      display: "2660 Canyon Blvd, Boulder, CO 80302"
+    distance: "24 minute walk; 5 minute drive"
+    coordinates:
+      latitude: 40.01638945310912
+      longitude: -105.26010548428526
+    maps:
+      google: "https://maps.app.goo.gl/8n6C5zWGDAaoh44F7"
+      apple: ""
+      openstreetmap: ""

--- a/data/rocky-mountain-ruby/rocky-mountain-ruby-2026/venue.yml
+++ b/data/rocky-mountain-ruby/rocky-mountain-ruby-2026/venue.yml
@@ -18,3 +18,80 @@ maps:
   google: "https://maps.google.com/?q=eTown+Hall,40.0201669,-105.275401"
   apple: "https://maps.apple.com/?q=eTown+Hall&ll=40.0201669,-105.275401"
   openstreetmap: "https://www.openstreetmap.org/?mlat=40.0201669&mlon=-105.275401"
+
+hotels:
+  - name: "Bradley Boulder Inn"
+    url: "https://www.thebradleyboulder.com"
+    address:
+      street: "2040 16th St"
+      city: "Boulder"
+      region: "Colorado"
+      postal_code: "80302"
+      country: "United States"
+      country_code: "US"
+      display: "2040 16th St, Boulder, CO 80302"
+    distance: "2 minute walk"
+    coordinates:
+      latitude: 40.01994639898552
+      longitude: -105.27465506004552
+    maps:
+      google: "https://maps.app.goo.gl/N7zWnBrhYcY89TWq6"
+      apple: ""
+      openstreetmap: ""
+
+  - name: "Hotel Boulderado"
+    url: "https://www.boulderado.com"
+    address:
+      street: "2115 13th St"
+      city: "Boulder"
+      region: "Colorado"
+      postal_code: "80302"
+      country: "United States"
+      country_code: "US"
+      display: "2115 13th St, Boulder, CO 80302"
+    distance: "5 minute walk"
+    coordinates:
+      latitude: 40.0196474228801
+      longitude: -105.27919321217307
+    maps:
+      google: "https://maps.app.goo.gl/6Z7g1k8X3v9J2Q4y5"
+      apple: ""
+      openstreetmap: ""
+
+  - name: "Hilton Garden Inn Boulder"
+    url: "https://www.hilton.com/en/hotels/wbubogi-hilton-garden-inn-boulder/"
+    address:
+      street: "2701 Canyon Boulevard"
+      city: "Boulder"
+      region: "Colorado"
+      postal_code: "80302"
+      country: "United States"
+      country_code: "US"
+      display: "2701 Canyon Boulevard, Boulder, Colorado, 80302, USA"
+    distance: "23 minute walk; 5 minute drive"
+    coordinates:
+      latitude: 40.01814579031145
+      longitude: -105.25930050979834
+    maps:
+      google: "https://maps.app.goo.gl/C9JHjPY68BLxYaTd9"
+      apple: ""
+      openstreetmap: ""
+
+  - name: "Marriott Boulder"
+    url: "https://www.marriott.com/en-us/hotels/denbo-boulder-marriott/overview/"
+    address:
+      street: "2660 Canyon Blvd"
+      city: "Boulder"
+      region: "Colorado"
+      postal_code: "80302"
+      country: "United States"
+      country_code: "US"
+      display: "2660 Canyon Blvd, Boulder, CO 80302"
+    distance: "24 minute walk; 5 minute drive"
+    coordinates:
+      latitude: 40.01638945310912
+      longitude: -105.26010548428526
+    maps:
+      google: "https://maps.app.goo.gl/8n6C5zWGDAaoh44F7"
+      apple: ""
+      openstreetmap: ""


### PR DESCRIPTION
## Description
<!-- Please describe your changes. -->

Added hotels to Rocky Mountain Ruby. This conference is in the same location every year, so updated 2025 and 2024 too.

## Screenshots
<!-- Add screenshots or GIFs if applicable. -->
<img width="2560" height="2648" alt="localhost_3000_events_rocky-mountain-ruby-2026_venue (2)" src="https://github.com/user-attachments/assets/d0ffb22c-7a27-4555-9c04-d3a95bd70c06" />


## Testing Steps
<!-- List steps to test your changes. -->
<!-- If this is a content PR, link to the affected pages -->
- /events/rocky-mountain-ruby-2026/venue
- /events/rocky-mountain-ruby-2025/venue
- /events/rocky-mountain-ruby-2024/venue

## References
<!-- Link to related issues, discussions, other PRs, or references you used to write the PR. -->
- https://rockymtnruby.dev/boulder-guide/
