### PR TITLE
Fix meetup filter

### DIFF
--- a/app/controllers/locations/meetups_controller.rb
+++ b/app/controllers/locations/meetups_controller.rb
@@ -4,7 +4,7 @@ class Locations::MeetupsController < Locations::BaseController
   def index
     @meetups = @location.events
       .joins(:series)
-      .where(event_series: {kind: :meetup})
+      .where(events: {kind: :meetup})
       .includes(:series)
       .order("event_series.name", start_date: :desc)
 

--- a/lib/tasks/seed.rake
+++ b/lib/tasks/seed.rake
@@ -39,6 +39,13 @@ namespace :db do
       end
     end
 
+    desc "Seed all meetups"
+    task meetups: :environment do
+      Search::Backend.without_indexing do
+        Static::Event.import_meetups!
+      end
+    end
+
     desc "Seed all speakers"
     task speakers: :environment do
       Search::Backend.without_indexing do


### PR DESCRIPTION
## Description
<!-- Please describe your changes. -->

We weren't seeing meetups the didn't have a kind of meetup on the event_series.

## Screenshots
<!-- Add screenshots or GIFs if applicable. -->
<img width="1466" height="754" alt="Screenshot 2026-07-27 at 12 44 12 PM" src="https://github.com/user-attachments/assets/d253cc93-56ee-4ec6-a6f1-925d624cdf7d" />

## Testing Steps
<!-- List steps to test your changes. -->
<!-- If this is a content PR, link to the affected pages -->
- /countries/australia/meetups

## References
<!-- Link to related issues, discussions, other PRs, or references you used to write the PR. -->
- closes #1978
