### PR TITLE
Events should appear grayed out when cancelled.

### DIFF
--- a/app/controllers/page_controller.rb
+++ b/app/controllers/page_controller.rb
@@ -28,6 +28,7 @@ class PageController < ApplicationController
     featured_ids = Event.where(id: featured_ids)
       .includes(:cfps)
       .sort_by { |event| event.featured_distance(today: today) }
+      .reject { |event| event.static_metadata.cancelled? }
       .first(15)
       .map(&:id)
 
@@ -82,6 +83,9 @@ class PageController < ApplicationController
   end
 
   def featured
+    @events = Event.featurable
+      .order(date: :desc)
+      .reject { |event| event.static_metadata.cancelled? }
   end
 
   def components

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,4 +1,8 @@
 module EventsHelper
+  def event_cancelled?(event)
+    event.static_metadata.cancelled?
+  end
+
   def event_date_display(event, day_name: false)
     return "Date TBD" unless event.start_date.present?
 

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -1,4 +1,4 @@
-<%= link_to event_path(event), id: dom_id(event), class: "event flex justify-between items-center" do %>
+<%= link_to event_path(event), id: dom_id(event), class: "event flex justify-between items-center #{"opacity-50 grayscale" if event_cancelled?(event)}" do %>
   <div class="flex items-center gap-2">
     <%= image_tag image_path(event.avatar_image_path), style: "view-transition-name: #{dom_id(event, :logo)}", class: "size-8 rounded-full", alt: event.name.to_s, loading: "lazy" %>
     <span class="event-name"><%= event.name %></span>

--- a/app/views/events/_event_list.html.erb
+++ b/app/views/events/_event_list.html.erb
@@ -18,7 +18,7 @@
   >
     <% events.each do |event| %>
       <%= link_to event, class: "event-item flex gap-4 group p-2 hover:bg-gray-200 rounded-md relative", data: {action: "mouseover->event-list#reveal", event_list_target: "item", event_id: event.slug} do %>
-        <div class="lg:justify-right flex flex-shrink-0 flex-col items-center gap-8 text-center lg:flex-row lg:text-left">
+        <div class="lg:justify-right flex flex-shrink-0 flex-col items-center gap-8 text-center lg:flex-row lg:text-left <%= "opacity-50 grayscale" if event_cancelled?(event) %>">
           <%= image_tag image_path(event.avatar_image_path),
                 class: "rounded-xl border border-[#D9DFE3] size-16",
                 alt: event.name.to_s,
@@ -27,11 +27,11 @@
         </div>
 
         <div class="relative flex flex-col justify-center overflow-hidden">
-          <div class="text-xl font-bold text-black <% if event.static_metadata.cancelled? %> text-red-500 line-through opacity-50 <% end %>">
+          <div class="text-xl font-bold text-black <%= "text-red-500 line-through opacity-50" if event_cancelled?(event) %>">
             <%= event.name %>
           </div>
 
-          <div class="text-[#636B74] group-hover:text-inherit <% if event.static_metadata.cancelled? %> line-through opacity-50 <% end %>">
+          <div class="text-[#636B74] group-hover:text-inherit <%= "line-through opacity-50" if event_cancelled?(event) %>">
             <%= event.formatted_dates %> • <%= event.to_location.to_html(show_links: false) %>
           </div>
         </div>

--- a/app/views/events/_plain_list.html.erb
+++ b/app/views/events/_plain_list.html.erb
@@ -1,7 +1,7 @@
 <div id="event-plain-list" class="group relative flex flex-col gap-2 rounded-xl">
   <% events.each do |event| %>
     <%= link_to event, class: "event-item flex gap-4 group p-2 hover:bg-gray-200 rounded-md" do %>
-      <div class="lg:justify-right flex flex-shrink-0 flex-col items-center gap-8 text-center lg:flex-row lg:text-left">
+      <div class="lg:justify-right flex flex-shrink-0 flex-col items-center gap-8 text-center lg:flex-row lg:text-left <%= "opacity-50 grayscale" if event_cancelled?(event) %>">
         <%= image_tag image_path(event.avatar_image_path),
               class: "rounded-xl border border-[#D9DFE3] size-16",
               alt: event.name.to_s,
@@ -10,9 +10,11 @@
       </div>
 
       <div class="relative flex flex-col justify-center overflow-hidden">
-        <div class="text-xl font-bold text-black group-hover:text-inherit"><%= event.name %></div>
+        <div class="text-xl font-bold text-black group-hover:text-inherit <%= "text-red-500 line-through opacity-50" if event_cancelled?(event) %>">
+          <%= event.name %>
+        </div>
 
-        <div class="text-[#636B74] group-hover:text-inherit">
+        <div class="text-[#636B74] group-hover:text-inherit <%= "line-through opacity-50" if event_cancelled?(event) %>">
           <%= event.formatted_dates %> • <%= event.to_location.to_html(show_links: false) %>
         </div>
       </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -26,7 +26,7 @@
 
     <div class="mt-8 flex flex-col gap-12">
       <section class="rounded-lg border bg-white p-6 shadow-sm">
-        <div class="grid items-center gap-6 <%= (@event.start_date.present? && @event.start_date > Date.today && @event.date_precision == "day" || (@event.today? && !@event.meetup?)) ? "grid-cols-2 sm:grid-cols-4" : "grid-cols-3" %>">
+        <div class="grid items-center gap-6 <%= (!event_cancelled?(@event) && @event.start_date.present? && @event.start_date > Date.today && @event.date_precision == "day" || (@event.today? && !@event.meetup? && !event_cancelled?(@event))) ? "grid-cols-2 sm:grid-cols-4" : "grid-cols-3" %>">
           <div class="text-center">
             <% if @event.retreat? %>
               <% duration = (@event.end_date - @event.start_date).to_i %>
@@ -59,7 +59,7 @@
             <% end %>
           </div>
 
-          <% if @event.start_date.present? && @event.start_date > Date.today && @event.date_precision == "day" %>
+          <% if !event_cancelled?(@event) && @event.start_date.present? && @event.start_date > Date.today && @event.date_precision == "day" %>
             <% days_until = (@event.start_date - Date.today).to_i %>
             <div class="text-center">
               <div class="mb-2 flex justify-center gap-1">
@@ -86,7 +86,7 @@
 
               <div class="text-sm font-medium text-gray-600">Days Until</div>
             </div>
-          <% elsif @event.today? && !@event.meetup? %>
+          <% elsif !event_cancelled?(@event) && @event.today? && !@event.meetup? %>
             <div class="text-center">
               <div class="mb-1 animate-pulse text-2xl font-bold text-green-600">
                 LIVE

--- a/app/views/events/years/_desktop_calendar.html.erb
+++ b/app/views/events/years/_desktop_calendar.html.erb
@@ -39,12 +39,9 @@
               <div class="group/card relative" data-controller="hover-card" data-action="mouseenter->hover-card#reveal">
                 <%= link_to event_path(event) do %>
                   <div
-                    class="
-                      h-20 w-20 transform overflow-hidden rounded-xl shadow-sm ring-2 ring-gray-100 transition-all
-                      duration-200 group-hover/card:scale-105 group-hover/card:ring-4
-                      group-hover/card:ring-[--brand-color]
-                    "
-                    style="--brand-color: <%= featured_bg %>;"
+                    class="h-20 w-20 transform overflow-hidden rounded-xl shadow-sm ring-2 ring-gray-100 transition-all duration-200 group-hover/card:scale-105 group-hover/card:ring-4 group-hover/card:ring-[--brand-color] <%= "opacity-50 grayscale" if event_cancelled?(event) %>"
+                    style="--brand-color: <%= featured_bg %>; <%= featured_bg %>;"
+                    title="<%= event_cancelled?(event) ? "#{event.name} (Cancelled)" : event.name %>"
                   >
                     <%= image_tag event.avatar_image_path, alt: event.name, class: "w-full h-full object-cover", loading: "lazy" %>
                   </div>

--- a/app/views/events/years/_mobile_calendar.html.erb
+++ b/app/views/events/years/_mobile_calendar.html.erb
@@ -14,7 +14,10 @@
         <% if month_events.any? %>
           <% month_events.each do |event| %>
             <%= link_to event_path(event) do %>
-              <div class="h-10 w-10 overflow-hidden rounded-lg shadow-sm ring-2 ring-gray-100">
+              <div
+                class="h-10 w-10 overflow-hidden rounded-lg shadow-sm ring-2 ring-gray-100 <%= "opacity-50 grayscale" if event_cancelled?(event) %>"
+                title="<%= event_cancelled?(event) ? "#{event.name} (Cancelled)" : event.name %>"
+              >
                 <%= image_tag event.avatar_image_path, alt: event.name, class: "w-full h-full object-cover", loading: "lazy" %>
               </div>
             <% end %>

--- a/app/views/page/featured.html.erb
+++ b/app/views/page/featured.html.erb
@@ -1,8 +1,6 @@
 <main class="container">
-  <% events = Event.featurable.order(date: :desc) %>
-
   <div>
-    <% events.each do |event| %>
+    <% @events.each do |event| %>
       <%= render partial: "events/featured", locals: {event: event} %>
     <% end %>
   </div>

--- a/test/controllers/page_controller_test.rb
+++ b/test/controllers/page_controller_test.rb
@@ -70,4 +70,61 @@ class PageControllerTest < ActionDispatch::IntegrationTest
       assert_select "a[aria-label=?]", "Ruby Camp Test 2026"
     end
   end
+
+  test "home page does not feature events cancelled in event.yml" do
+    cancelled_event, active_event = create_featured_events
+
+    get root_path
+
+    assert_response :success
+    assert_select "section[aria-label=?]", "Featured Events" do
+      assert_select "a[href=?]", event_path(active_event)
+      assert_select "a[href=?]", event_path(cancelled_event), count: 0
+    end
+  end
+
+  test "featured page does not include events cancelled in event.yml" do
+    cancelled_event, active_event = create_featured_events
+
+    get featured_path
+
+    assert_response :success
+    assert_select "a[href=?]", event_path(active_event)
+    assert_select "a[href=?]", event_path(cancelled_event), count: 0
+  end
+
+  private
+
+  def create_featured_events
+    cancelled_slug = "xoruby-salt-lake-city-2026"
+
+    assert_equal "cancelled", Static::Event.find_by_slug(cancelled_slug).status
+
+    attributes = {
+      series: event_series(:rails_world),
+      kind: "conference",
+      start_date: Date.today - 1,
+      end_date: Date.today + 1,
+      home_sort_date: Date.today,
+      geocode_metadata: {}
+    }
+
+    cancelled_event = Event.create!(
+      **attributes,
+      name: "XO Ruby Salt Lake City 2026",
+      slug: cancelled_slug,
+      featured_background: "#230902",
+      featured_color: "#FE470B"
+    )
+
+    active_event = Event.create!(
+      **attributes,
+      name: "Active Featured Event",
+      slug: "active-featured-event",
+      featured_background: "#E7F2E2",
+      featured_color: "#064E3B"
+    )
+
+    [cancelled_event, active_event]
+  end
 end


### PR DESCRIPTION
- Cancelled events appear grayed out in calendar, list, and show views.
- Cancelled events are excluded from the Featured section.

## Description
<!-- Please describe your changes. -->

## Screenshots
<img width="555" height="745" alt="image" src="https://github.com/user-attachments/assets/f5affdc1-69e7-4732-96dc-4f5d83bbf727" />
<img width="498" height="614" alt="image" src="https://github.com/user-attachments/assets/1c2a9fd1-0b79-4ed9-a6c4-16b513f485e9" />
<img width="715" height="330" alt="image" src="https://github.com/user-attachments/assets/36d26e49-b5f0-4cf6-b091-8c9ddfff696f" />
<img width="1258" height="963" alt="image" src="https://github.com/user-attachments/assets/d0d0d738-15b5-4832-9bc6-5f1249d03b57" />

## Testing Steps
/events/xoruby-salt-lake-city-2026(the show view for cancelled events is grayed out)
/events/2026(the calendar view for cancelled events is grayed out)
/events(the list view for cancelled events is grayed out)

## References
closes #1991 
