### PR TITLE
Fix Generators - MCP Tools and Talk template ordering

### DIFF
--- a/lib/generators/event_base.rb
+++ b/lib/generators/event_base.rb
@@ -12,7 +12,7 @@ module Generators
     def event_series_slug
       @series_slug ||= options[:event_series]
         || static_event&.series_slug
-        || say_error("Could not determine event series.", :red) && exit(1)
+        || say_error("Could not determine event series.", :red)
     end
 
     def static_event

--- a/lib/generators/talk/templates/talk.yml.tt
+++ b/lib/generators/talk/templates/talk.yml.tt
@@ -4,23 +4,23 @@
 <%- if @talk.original_title.present? -%>
   original_title: "<%= @talk.original_title %>"
 <%- end -%>
+<%- if @talk.write_kind? -%>
+  kind: "<%= @talk.kind %>"
+<%- end -%>
+  date: "<%= @talk.date %>"
+  language: "<%= @talk.language %>"
+<%- if options[:announced_at] -%>
+  announced_at: "<%= @talk.announced_at %>"
+<%- end -%>
+  video_provider: "scheduled"
+  video_id: "<%= @talk.id %>"
 <%- if @talk.description.blank? -%>
   description: "" # TODO
 <%- else -%>
   description: |-
 <%= optimize_indentation(@talk.description, 4) %>
 <%- end -%>
-<%- if @talk.write_kind? -%>
-  kind: "<%= @talk.kind %>"
-<%- end -%>
-  language: "<%= @talk.language %>"
-  date: "<%= @talk.date %>"
-<%- if options[:announced_at] -%>
-  announced_at: "<%= @talk.announced_at %>"
-<%- end -%>
   speakers:
   <%- @talk.speakers.each do |speaker| -%>
     - <%= speaker %>
   <%- end -%>
-  video_provider: "scheduled"
-  video_id: "<%= @talk.id %>"


### PR DESCRIPTION
## Description
<!-- Please describe your changes. -->
Yerba specifies the order of the attributes in a template and they did not match the generator.
Exit 1 shuts down the mcp server from within a generator and the template calls all fail if there's no event series slug anyway.

## Screenshots
<!-- Add screenshots or GIFs if applicable. -->

## Testing Steps
<!-- List steps to test your changes. -->
<!-- If this is a content PR, link to the affected pages -->

Run bin/rails g talk and confirm yerba check reveals no errors.

<img width="770" height="162" alt="Screenshot 2026-07-27 at 10 11 07 PM" src="https://github.com/user-attachments/assets/f07fbb44-9163-4b89-bf06-005f028979c4" />

## References
<!-- Link to related issues, discussions, other PRs, or references you used to write the PR. -->
- closes #<!-- issue number -->
