### PR TITLE
Update data for Fable Tales

### DIFF
--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -5191,7 +5191,9 @@
   bluesky: "sang.io"
   slug: "fabio-sangiovanni"
 - name: "Fable Tales"
+  bluesky: "fable-computers.bsky.social"
   github: "fables-tales"
+  mastodon: "https://hachyderm.io/@fables_tales"
   website: "https://penelope.zone"
   slug: "fable-tales"
   aliases:


### PR DESCRIPTION
## Description

While updating my own data (#2017), I noticed that Fable Tales's socials weren't linked. So I've done that.