### PR TITLE
Install yarn during bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -37,6 +37,7 @@ FileUtils.chdir APP_ROOT do
   end
 
   puts "\n== Installing node dependencies =="
+  system! "corepack enable"
   system! "yarn install"
 
   puts "\n== Preparing database =="


### PR DESCRIPTION
## Description

If you're installing Node for the first time, you might not have yarn installed. Enabling corepack tells Node to install the package manager as specified by package.json. This makes local setup a little nicer.

See https://yarnpkg.com/corepack
