### PR TITLE
Fix tab overflow in tabs on /cfp

### DIFF
--- a/app/views/cfp/index.html.erb
+++ b/app/views/cfp/index.html.erb
@@ -5,7 +5,7 @@
     </h1>
 
     <div class="mt-4 flex items-center gap-4 md:mt-0">
-      <div class="tab tabs-boxed">
+      <div class="tabs-boxed tabs">
         <%= link_to "All", cfp_index_path(kind: "all"), class: "tab #{"tab-active" if params[:kind].blank? || params[:kind] == "all"}" %>
         <%= link_to "Conferences", cfp_index_path(kind: "conference"), class: "tab #{"tab-active" if params[:kind] == "conference"}" %>
         <%= link_to "Meetups", cfp_index_path(kind: "meetup"), class: "tab #{"tab-active" if params[:kind] == "meetup"}" %>


### PR DESCRIPTION
## Description
The selected tab overflows on /cfp. This is a regression introduced by commit 0f3ae467e (“Adopt Herb Formatter and Tailwind Class Sorter”, #2013), which rewrote the line from `class="tabs tabs-boxed"` to `class="tab tabs-boxed"` (singular `tab` vs `tabs`).

## Screenshots
<img width="1102" height="398" alt="CleanShot 2026-08-06 at 11 24 21@2x" src="https://github.com/user-attachments/assets/8033b3d2-f343-4c91-bcab-11c6ea00e495" />

