### PR TITLE
Fix non-existing brand colors and streamline alphabet filters

### DIFF
--- a/app/views/events/archive/index.html.erb
+++ b/app/views/events/archive/index.html.erb
@@ -30,7 +30,7 @@
     </div>
   </div>
 
-  <%= render "shared/alphabet_filter", extra_params: {kind: params[:kind]}, anchor_ids: true %>
+  <%= render "shared/alphabet_filter", extra_params: {kind: params[:kind]} %>
 
   <% if params[:letter].present? %>
     <div class="mb-12 font-medium">

--- a/app/views/events/archive/index.html.erb
+++ b/app/views/events/archive/index.html.erb
@@ -30,17 +30,7 @@
     </div>
   </div>
 
-  <div class="flex w-full flex-wrap justify-between gap-1 py-8 hotwire-native:hidden">
-    <%= link_to archive_events_path(kind: params[:kind]), class: class_names("flex items-center justify-center w-10 text-gray-500 rounded hover:bg-brand-lighter border", "bg-brand-lighter": params[:letter].blank?) do %>
-      all
-    <% end %>
-
-    <% ("a".."z").each do |letter| %>
-      <%= link_to archive_events_path(letter: letter, kind: params[:kind]), id: letter, class: class_names("flex items-center justify-center w-10 text-gray-500 rounded hover:bg-brand-lighter border", "bg-brand-lighter": letter == params[:letter]) do %>
-        <%= letter.upcase %>
-      <% end %>
-    <% end %>
-  </div>
+  <%= render "shared/alphabet_filter", extra_params: {kind: params[:kind]}, anchor_ids: true %>
 
   <% if params[:letter].present? %>
     <div class="mb-12 font-medium">

--- a/app/views/gems/index.html.erb
+++ b/app/views/gems/index.html.erb
@@ -10,17 +10,7 @@
     Browse Ruby gems featured in <%= pluralize(TopicGem.joins(:topic).sum("topics.talks_count"), "conference talk") %>.
   </p>
 
-  <div class="flex w-full flex-wrap justify-between gap-1 py-4 hotwire-native:hidden">
-    <% ("a".."z").each do |letter| %>
-      <%= link_to gems_path(letter: letter), class: class_names("flex items-center justify-center w-10 text-gray-500 rounded hover:bg-brand-lighter border", "bg-brand-lighter": letter == params[:letter]) do %>
-        <%= letter.upcase %>
-      <% end %>
-    <% end %>
-
-    <%= link_to gems_path, class: class_names("flex items-center justify-center w-10 text-gray-500 rounded hover:bg-brand-lighter border", "bg-brand-lighter": params[:letter].blank?) do %>
-      all
-    <% end %>
-  </div>
+  <%= render "shared/alphabet_filter" %>
 
   <div id="gems" class="grid min-w-full gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
     <% @gems.each do |topic_gem| %>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -46,13 +46,7 @@
     <% end %>
   <% end %>
 
-  <div class="flex w-full flex-wrap justify-between gap-1 py-8 hotwire-native:hidden">
-    <% ("a".."z").each do |letter| %>
-      <%= link_to organizations_path(letter: letter), class: class_names("flex items-center justify-center w-10 text-gray-500 rounded hover:bg-brand-lighter border", "bg-brand-lighter": letter == params[:letter]) do %>
-        <%= letter.upcase %>
-      <% end %>
-    <% end %>
-  </div>
+  <%= render "shared/alphabet_filter" %>
 
   <div
     id="organizations"

--- a/app/views/shared/_alphabet_filter.html.erb
+++ b/app/views/shared/_alphabet_filter.html.erb
@@ -1,0 +1,18 @@
+<%# locals: (extra_params: {}, anchor_ids: false) %>
+
+<% current_letter = params[:letter].to_s.downcase.presence %>
+
+<div class="flex w-full flex-wrap justify-between gap-1 py-8 hotwire-native:hidden">
+  <% [nil, *("a".."z")].each do |letter| %>
+    <% active = letter == current_letter %>
+
+    <%= link_to letter&.upcase || "All",
+          url_for(extra_params.merge(letter: letter).compact),
+          id: (letter if anchor_ids),
+          class: class_names(
+            "flex w-10 items-center justify-center rounded border transition-colors",
+            "bg-primary/10 text-primary border-primary/20 font-semibold": active,
+            "text-gray-500 hover:bg-base-200": !active
+          ) %>
+  <% end %>
+</div>

--- a/app/views/shared/_alphabet_filter.html.erb
+++ b/app/views/shared/_alphabet_filter.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (extra_params: {}, anchor_ids: false) %>
+<%# locals: (extra_params: {}) %>
 
 <% current_letter = params[:letter].to_s.downcase.presence %>
 
@@ -8,7 +8,6 @@
 
     <%= link_to letter&.upcase || "All",
           url_for(extra_params.merge(letter: letter).compact),
-          id: (letter if anchor_ids),
           class: class_names(
             "flex w-10 items-center justify-center rounded border transition-colors",
             "bg-primary/10 text-primary border-primary/20 font-semibold": active,

--- a/app/views/shared/_toast.html.erb
+++ b/app/views/shared/_toast.html.erb
@@ -8,8 +8,8 @@
         data-transition-enter-to-value="translate-y-0 opacity-100 sm:translate-x-0"
         data-transition-leave-after-value="2000"
         class="
-          ring-brand-lighter pointer-events-auto hidden max-w-sm overflow-hidden rounded-lg bg-white text-neutral
-          shadow-lg ring-1
+          pointer-events-auto hidden max-w-sm overflow-hidden rounded-lg bg-white text-neutral shadow-lg ring-1
+          ring-black/5
         "
       >
         <div class="p-2 sm:p-4">

--- a/app/views/speakers/index.html.erb
+++ b/app/views/speakers/index.html.erb
@@ -7,17 +7,7 @@
     <% end %>
   </h1>
 
-  <div class="flex w-full flex-wrap justify-between gap-1 py-8 hotwire-native:hidden">
-    <% ("a".."z").each do |letter| %>
-      <%= link_to speakers_path(letter: letter), class: class_names("flex items-center justify-center w-10 text-gray-500 rounded hover:bg-brand-lighter border", "bg-brand-lighter": letter == params[:letter]) do %>
-        <%= letter.upcase %>
-      <% end %>
-    <% end %>
-
-    <%= link_to speakers_path, class: class_names("flex items-center justify-center w-10 text-gray-500 rounded hover:bg-brand-lighter border", "bg-brand-lighter": params[:letter].blank?) do %>
-      all
-    <% end %>
-  </div>
+  <%= render "shared/alphabet_filter" %>
 
   <div
     id="speakers"

--- a/app/views/sponsors/missing/index.html.erb
+++ b/app/views/sponsors/missing/index.html.erb
@@ -53,10 +53,10 @@
 
           <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
             <% events.each do |event| %>
-              <%= link_to event_path(event), class: "block bg-white border border-gray-200 rounded-lg p-4 hover:shadow-md transition-shadow hover:border-gray-300" do %>
+              <%= link_to event_path(event), class: "group block bg-white border border-gray-200 rounded-lg p-4 hover:shadow-md transition-shadow hover:border-gray-300" do %>
                 <div class="flex items-start justify-between">
                   <div class="flex-1">
-                    <h3 class="hover:text-brand-600 mb-1 font-semibold text-gray-900">
+                    <h3 class="mb-1 font-semibold text-gray-900 transition-colors group-hover:text-primary">
                       <%= event.name %>
                     </h3>
 

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -9,17 +9,7 @@
     <% end %>
   </div>
 
-  <div class="flex w-full flex-wrap justify-between gap-1 py-8 hotwire-native:hidden">
-    <% ("a".."z").each do |letter| %>
-      <%= link_to topics_path(letter: letter), class: class_names("flex items-center justify-center w-10 text-gray-500 rounded hover:bg-brand-lighter border", "bg-brand-lighter": letter == params[:letter]) do %>
-        <%= letter.upcase %>
-      <% end %>
-    <% end %>
-
-    <%= link_to topics_path, class: class_names("flex items-center justify-center w-10 text-gray-500 rounded hover:bg-brand-lighter border", "bg-brand-lighter": params[:letter].blank?) do %>
-      all
-    <% end %>
-  </div>
+  <%= render "shared/alphabet_filter" %>
 
   <div id="topics" class="grid min-w-full gap-x-8 gap-y-2 sm:grid-cols-2 lg:grid-cols-3 lg:gap-x-12 xl:grid-cols-4">
     <%= render partial: "topic", collection: @topics, as: :topic %>

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -15,7 +15,7 @@ class EventsTest < ApplicationSystemTestCase
     click_on "Archive"
     assert_selector "h1", text: "Events Archive"
 
-    find("a#t", text: "T").click
+    click_on "T", exact_text: true
     assert_selector "span", text: "Tropical Ruby"
   end
 

--- a/test/system/sponsors_test.rb
+++ b/test/system/sponsors_test.rb
@@ -84,24 +84,24 @@ class SponsorsTest < ApplicationSystemTestCase
       assert_link @organization_three.name
     end
 
-    assert_link "A"
-    click_on "A"
+    assert_link "A", exact_text: true
+    click_on "A", exact_text: true
     within "#organizations" do
       assert_link @organization_one.name
       assert_no_link @organization_two.name
       assert_no_link @organization_three.name
     end
 
-    assert_link "B"
-    click_on "B"
+    assert_link "B", exact_text: true
+    click_on "B", exact_text: true
     within "#organizations" do
       assert_no_link @organization_one.name
       assert_link @organization_two.name
       assert_no_link @organization_three.name
     end
 
-    assert_link "C"
-    click_on "C"
+    assert_link "C", exact_text: true
+    click_on "C", exact_text: true
     within "#organizations" do
       assert_no_link @organization_one.name
       assert_no_link @organization_two.name


### PR DESCRIPTION
While building something else I found that the alphabet filters use the non-existing `bg-brand-lighter` color, these have been dropped in 80de288 which dropped the legacy `extend.colors` block from tailwind.config.js without updating any of the view, so none of these pages had a visible selected state.

Also noticed that the alphabet filter is implemented a bit different in multiple places, this streamlines it into one partial that is re-used.

Leading to:

- Selected state works again.
- "All" is always shown and as the first option, consistent in all places.

I fixed the usage of the brand color in two other places as well. The blocks for missing sponsors has become a bit nicer with a transition and hover color for the whole block instead of just the title.

## Screenshots
Before:
<img width="3270" height="838" alt="CleanShot 2026-08-06 at 13 18 10@2x" src="https://github.com/user-attachments/assets/914d885b-836a-42f8-9c0f-f4d52a2e7aa2" />

After:
<img width="3230" height="902" alt="CleanShot 2026-08-06 at 13 17 49@2x" src="https://github.com/user-attachments/assets/99d1e24f-8061-4c4b-b684-00645b849df3" />

<img width="1504" height="752" alt="CleanShot 2026-08-06 at 13 16 14@2x" src="https://github.com/user-attachments/assets/a3fbc99b-605f-4fbb-a403-5658455fb40f" />
