### PR TITLE
Add continent filter pills to event collections

### DIFF
--- a/app/controllers/concerns/continent_filterable.rb
+++ b/app/controllers/concerns/continent_filterable.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module ContinentFilterable
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :selected_continent
+  end
+
+  private
+
+  def selected_continent
+    return @selected_continent if defined?(@selected_continent)
+
+    @selected_continent = Continent.find(params[:continent])
+  end
+
+  def filter_by_continent(scope)
+    return scope if selected_continent.nil?
+
+    scope.where(country_code: selected_continent.country_codes)
+  end
+end

--- a/app/controllers/events/past_controller.rb
+++ b/app/controllers/events/past_controller.rb
@@ -1,10 +1,11 @@
 class Events::PastController < ApplicationController
+  include ContinentFilterable
+
   skip_before_action :authenticate_user!, only: %i[index]
 
   def index
-    @events = Event.includes(:series, :keynote_speakers)
-      .where(end_date: ...Date.today)
-      .order(start_date: :desc)
-      .limit(50)
+    @events = filter_by_continent(
+      Event.includes(:series, :keynote_speakers).where(end_date: ...Date.today)
+    ).order(start_date: :desc).limit(50)
   end
 end

--- a/app/controllers/events/years_controller.rb
+++ b/app/controllers/events/years_controller.rb
@@ -1,5 +1,7 @@
 module Events
   class YearsController < ApplicationController
+    include ContinentFilterable
+
     skip_before_action :authenticate_user!, only: %i[index]
 
     def index
@@ -13,11 +15,12 @@ module Events
         redirect_to events_path, alert: "Invalid year" and return
       end
 
-      @events = Event.includes(:series, :keynote_speakers)
-        .not_meetup
-        .canonical
-        .where(start_date: Date.new(@year).all_year)
-        .order(start_date: :asc)
+      @events = filter_by_continent(
+        Event.includes(:series, :keynote_speakers)
+          .not_meetup
+          .canonical
+          .where(start_date: Date.new(@year).all_year)
+      ).order(start_date: :asc)
 
       @monthly_events = @events.reject { |e| e.date_precision == "year" }
       @yearly_events = @events.select { |e| e.date_precision == "year" }

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,5 +1,6 @@
 class EventsController < ApplicationController
   include WatchedTalks
+  include ContinentFilterable
   include Pagy::Backend
 
   skip_before_action :authenticate_user!, only: %i[index show]
@@ -9,9 +10,9 @@ class EventsController < ApplicationController
 
   # GET /events
   def index
-    @events = Event.includes(:series, :keynote_speakers)
-      .where(end_date: Date.today..)
-      .order(start_date: :asc)
+    @events = filter_by_continent(
+      Event.includes(:series, :keynote_speakers).where(end_date: Date.today..)
+    ).order(start_date: :asc)
 
     respond_to do |format|
       format.html

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -49,6 +49,10 @@ module EventsHelper
       end
   end
 
+  def continent_filter_path(continent)
+    url_for(continent: continent&.slug)
+  end
+
   def featured_cta_path(event)
     if event.featured_reason == :cfp_closing
       event_cfp_index_path(event)

--- a/app/javascript/controllers/event_list_controller.js
+++ b/app/javascript/controllers/event_list_controller.js
@@ -11,7 +11,10 @@ export default class extends Controller {
 
     const firstEvent = this.itemTargets[0]
 
-    this.posterTargetFor(firstEvent.dataset.eventId)?.classList.remove('hidden')
+    if (firstEvent) {
+      this.posterTargetFor(firstEvent.dataset.eventId)?.classList.remove('hidden')
+    }
+
     this.updateGradients()
   }
 

--- a/app/models/continent.rb
+++ b/app/models/continent.rb
@@ -13,6 +13,8 @@ class Continent
     "south-america" => {name: "South America", alpha2: "SA", emoji: "🌎"}
   }.freeze
 
+  UNPOPULATED = %w[antarctica].freeze # Very unlikely to have an event here ;)
+
   BOUNDS = {
     "africa" => {southwest: [-25.0, -35.0], northeast: [60.0, 40.0]},
     "antarctica" => {southwest: [-180.0, -90.0], northeast: [180.0, -60.0]},
@@ -129,7 +131,11 @@ class Continent
 
   class << self
     def all
-      @all ||= CONTINENT_DATA.keys.map { |slug| new(slug) }
+      @all ||= slugs.map { |slug| new(slug) }
+    end
+
+    def populated
+      @populated ||= (slugs - UNPOPULATED).map { |slug| new(slug) }
     end
 
     def find(term)

--- a/app/views/events/_collections_navigation.html.erb
+++ b/app/views/events/_collections_navigation.html.erb
@@ -1,5 +1,6 @@
 <%# locals: (active:) %>
 <% continent = params[:continent] %>
+
 <% collections = [
      ["Upcoming", events_path(continent:), :upcoming],
      ["Past", past_events_path(continent:), :past],

--- a/app/views/events/_collections_navigation.html.erb
+++ b/app/views/events/_collections_navigation.html.erb
@@ -1,8 +1,9 @@
 <%# locals: (active:) %>
+<% continent = params[:continent] %>
 <% collections = [
-     ["Upcoming", events_path, :upcoming],
-     ["Past", past_events_path, :past],
-     ["Calendar", year_events_path(year: Date.current.year), :calendar],
+     ["Upcoming", events_path(continent:), :upcoming],
+     ["Past", past_events_path(continent:), :past],
+     ["Calendar", year_events_path(year: Date.current.year, continent:), :calendar],
      ["Archive", archive_events_path, :archive],
      ["Meetups", meetups_events_path, :meetups]
    ] %>

--- a/app/views/events/_continent_filter.html.erb
+++ b/app/views/events/_continent_filter.html.erb
@@ -2,8 +2,7 @@
 <%= link_to label,
       path,
       class: class_names(
-        "flex items-center justify-center whitespace-nowrap rounded border px-4 py-2 text-sm",
-        "border-primary/30 bg-primary/10 font-semibold text-primary" => active,
-        "text-gray-500 hover:bg-base-200" => !active
+        "tab whitespace-nowrap max-md:h-auto max-md:min-h-6 max-md:rounded-lg max-md:px-2.5 max-md:py-1 max-md:text-xs max-md:leading-tight",
+        "tab-active" => active
       ),
       aria: {current: active ? "page" : nil} %>

--- a/app/views/events/_continent_filter.html.erb
+++ b/app/views/events/_continent_filter.html.erb
@@ -1,0 +1,9 @@
+<%# locals: (label:, path:, active: false) %>
+<%= link_to label,
+      path,
+      class: class_names(
+        "flex items-center justify-center whitespace-nowrap rounded border px-4 py-2 text-sm",
+        "border-primary/30 bg-primary/10 font-semibold text-primary" => active,
+        "text-gray-500 hover:bg-base-200" => !active
+      ),
+      aria: {current: active ? "page" : nil} %>

--- a/app/views/events/_continent_filters.html.erb
+++ b/app/views/events/_continent_filters.html.erb
@@ -1,14 +1,16 @@
 <%# locals: (selected: nil) %>
-<nav
-  aria-label="Filter events by continent"
-  class="flex w-full flex-wrap gap-1 py-8 hotwire-native:hidden"
->
-  <%= render "events/continent_filter", label: "All", path: continent_filter_path(nil), active: selected.nil? %>
+<div class="py-6 hotwire-native:hidden">
+  <nav
+    aria-label="Filter events by continent"
+    class="tabs-boxed tabs inline-flex flex-wrap gap-1 max-md:rounded-xl max-md:p-1.5"
+  >
+    <%= render "events/continent_filter", label: "All", path: continent_filter_path(nil), active: selected.nil? %>
 
-  <% Continent.populated.each do |continent| %>
-    <%= render "events/continent_filter",
-          label: continent.name,
-          path: continent_filter_path(continent),
-          active: selected == continent %>
-  <% end %>
-</nav>
+    <% Continent.populated.each do |continent| %>
+      <%= render "events/continent_filter",
+            label: continent.name,
+            path: continent_filter_path(continent),
+            active: selected == continent %>
+    <% end %>
+  </nav>
+</div>

--- a/app/views/events/_continent_filters.html.erb
+++ b/app/views/events/_continent_filters.html.erb
@@ -1,0 +1,14 @@
+<%# locals: (selected: nil) %>
+<nav
+  aria-label="Filter events by continent"
+  class="flex w-full flex-wrap gap-1 py-8 hotwire-native:hidden"
+>
+  <%= render "events/continent_filter", label: "All", path: continent_filter_path(nil), active: selected.nil? %>
+
+  <% Continent.populated.each do |continent| %>
+    <%= render "events/continent_filter",
+          label: continent.name,
+          path: continent_filter_path(continent),
+          active: selected == continent %>
+  <% end %>
+</nav>

--- a/app/views/events/_no_events.html.erb
+++ b/app/views/events/_no_events.html.erb
@@ -1,0 +1,15 @@
+<% without_filter_path = continent_filter_path(nil) %>
+
+<div class="py-12 text-center">
+  <div class="mx-auto max-w-md">
+    <h2 class="mb-4 text-2xl font-bold text-gray-900">No events found</h2>
+
+    <p class="mb-6 text-gray-600">
+      There are no events matching the current selection.
+    </p>
+
+    <% unless current_page?(without_filter_path, check_parameters: true) %>
+      <%= link_to "Show all events", without_filter_path, class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -12,37 +12,45 @@
     >
       <%= render "events/collections_navigation", active: :upcoming %>
 
-      <div class="flex shrink-0 items-center overflow-x-auto pb-2 md:pb-1">
-        <div class="tabs-boxed tabs">
-          <button
-            type="button"
-            class="tab tab-active"
-            data-events-view-switcher-target="button"
-            data-events-view-switcher-view-param="preview"
-            data-action="click->events-view-switcher#show"
-          >
-            Preview
-          </button>
+      <% if @events.any? %>
+        <div class="flex shrink-0 items-center overflow-x-auto pb-2 md:pb-1">
+          <div class="tabs-boxed tabs">
+            <button
+              type="button"
+              class="tab tab-active"
+              data-events-view-switcher-target="button"
+              data-events-view-switcher-view-param="preview"
+              data-action="click->events-view-switcher#show"
+            >
+              Preview
+            </button>
 
-          <button
-            type="button"
-            class="tab"
-            data-events-view-switcher-target="button"
-            data-events-view-switcher-view-param="list"
-            data-action="click->events-view-switcher#show"
-          >
-            List
-          </button>
+            <button
+              type="button"
+              class="tab"
+              data-events-view-switcher-target="button"
+              data-events-view-switcher-view-param="list"
+              data-action="click->events-view-switcher#show"
+            >
+              List
+            </button>
+          </div>
         </div>
-      </div>
+      <% end %>
     </div>
   </div>
 
-  <div data-events-view-switcher-target="view" data-events-view-switcher-view-param="preview">
-    <%= render partial: "events/featured_card_list", locals: {events: @events} %>
-  </div>
+  <%= render "events/continent_filters", selected: selected_continent %>
 
-  <div class="mt-6 hidden" data-events-view-switcher-target="view" data-events-view-switcher-view-param="list">
-    <%= render partial: "events/plain_list", locals: {events: @events} %>
-  </div>
+  <% if @events.any? %>
+    <div data-events-view-switcher-target="view" data-events-view-switcher-view-param="preview">
+      <%= render partial: "events/featured_card_list", locals: {events: @events} %>
+    </div>
+
+    <div class="mt-6 hidden" data-events-view-switcher-target="view" data-events-view-switcher-view-param="list">
+      <%= render partial: "events/plain_list", locals: {events: @events} %>
+    </div>
+  <% else %>
+    <%= render "events/no_events" %>
+  <% end %>
 </div>

--- a/app/views/events/past/index.html.erb
+++ b/app/views/events/past/index.html.erb
@@ -16,37 +16,45 @@
     >
       <%= render "events/collections_navigation", active: :past %>
 
-      <div class="flex shrink-0 items-center overflow-x-auto pb-2 md:pb-1">
-        <div class="tabs-boxed tabs">
-          <button
-            type="button"
-            class="tab tab-active"
-            data-events-view-switcher-target="button"
-            data-events-view-switcher-view-param="preview"
-            data-action="click->events-view-switcher#show"
-          >
-            Preview
-          </button>
+      <% if @events.any? %>
+        <div class="flex shrink-0 items-center overflow-x-auto pb-2 md:pb-1">
+          <div class="tabs-boxed tabs">
+            <button
+              type="button"
+              class="tab tab-active"
+              data-events-view-switcher-target="button"
+              data-events-view-switcher-view-param="preview"
+              data-action="click->events-view-switcher#show"
+            >
+              Preview
+            </button>
 
-          <button
-            type="button"
-            class="tab"
-            data-events-view-switcher-target="button"
-            data-events-view-switcher-view-param="list"
-            data-action="click->events-view-switcher#show"
-          >
-            List
-          </button>
+            <button
+              type="button"
+              class="tab"
+              data-events-view-switcher-target="button"
+              data-events-view-switcher-view-param="list"
+              data-action="click->events-view-switcher#show"
+            >
+              List
+            </button>
+          </div>
         </div>
-      </div>
+      <% end %>
     </div>
   </div>
 
-  <div data-events-view-switcher-target="view" data-events-view-switcher-view-param="preview">
-    <%= render partial: "events/featured_card_list", locals: {events: @events} %>
-  </div>
+  <%= render "events/continent_filters", selected: selected_continent %>
 
-  <div class="mt-6 hidden" data-events-view-switcher-target="view" data-events-view-switcher-view-param="list">
-    <%= render partial: "events/plain_list", locals: {events: @events} %>
-  </div>
+  <% if @events.any? %>
+    <div data-events-view-switcher-target="view" data-events-view-switcher-view-param="preview">
+      <%= render partial: "events/featured_card_list", locals: {events: @events} %>
+    </div>
+
+    <div class="mt-6 hidden" data-events-view-switcher-target="view" data-events-view-switcher-view-param="list">
+      <%= render partial: "events/plain_list", locals: {events: @events} %>
+    </div>
+  <% else %>
+    <%= render "events/no_events" %>
+  <% end %>
 </div>

--- a/app/views/events/years/_header.html.erb
+++ b/app/views/events/years/_header.html.erb
@@ -13,22 +13,24 @@
 
     <nav aria-label="Calendar years" class="flex shrink-0 items-center gap-2 overflow-x-auto pb-2 md:pb-1">
       <% if year != Date.current.year %>
-        <%= link_to "Today", year_events_path(year: Date.current.year), class: "inline-flex h-10 items-center rounded-full bg-red-500 px-3 text-sm font-medium text-white transition-all hover:bg-red-600 md:px-4" %>
+        <%= link_to "Today", year_events_path(year: Date.current.year, continent: params[:continent]), class: "inline-flex h-10 items-center rounded-full bg-red-500 px-3 text-sm font-medium text-white transition-all hover:bg-red-600 md:px-4" %>
       <% end %>
 
       <% if has_previous_year %>
-        <%= link_to year_events_path(year: year - 1), class: "flex h-10 items-center gap-2 rounded-full border border-gray-200 px-3 text-sm text-gray-500 transition-all hover:border-gray-900 hover:text-gray-900 md:px-4 md:text-base" do %>
+        <%= link_to year_events_path(year: year - 1, continent: params[:continent]), class: "flex h-10 items-center gap-2 rounded-full border border-gray-200 px-3 text-sm text-gray-500 transition-all hover:border-gray-900 hover:text-gray-900 md:px-4 md:text-base" do %>
           <%= fa "arrow-left", class: "text-xs md:text-sm" %>
           <span class="font-medium"><%= year - 1 %></span>
         <% end %>
       <% end %>
 
       <% if has_next_year %>
-        <%= link_to year_events_path(year: year + 1), class: "flex h-10 items-center gap-2 rounded-full border border-gray-200 px-3 text-sm text-gray-500 transition-all hover:border-gray-900 hover:text-gray-900 md:px-4 md:text-base" do %>
+        <%= link_to year_events_path(year: year + 1, continent: params[:continent]), class: "flex h-10 items-center gap-2 rounded-full border border-gray-200 px-3 text-sm text-gray-500 transition-all hover:border-gray-900 hover:text-gray-900 md:px-4 md:text-base" do %>
           <span class="font-medium"><%= year + 1 %></span>
           <%= fa "arrow-right", class: "text-xs md:text-sm" %>
         <% end %>
       <% end %>
     </nav>
   </div>
+
+  <%= render "events/continent_filters", selected: selected_continent %>
 </header>

--- a/app/views/events/years/index.html.erb
+++ b/app/views/events/years/index.html.erb
@@ -22,6 +22,6 @@
     </p>
 
     <span aria-hidden="true" class="text-gray-300">·</span>
-    <%= render "shared/subscribe_to_calendar", url: events_url(format: :ics), modal_id: "modal-middle" %>
+    <%= render "shared/subscribe_to_calendar", url: events_url(format: :ics, continent: params[:continent]), modal_id: "modal-middle" %>
   </div>
 </div>

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -21,6 +21,56 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     assert_includes response.body, "UID:RUBYEVENTS-#{@event.id}"
   end
 
+  test "should render a pill for every continent except Antarctica" do
+    get events_url
+
+    assert_response :success
+    assert_select "nav[aria-label=?] a", "Filter events by continent", count: Continent.populated.size + 1
+    assert_select "nav[aria-label=?] a", "Filter events by continent", text: "Antarctica", count: 0
+    assert_select "nav[aria-label=?] a[aria-current=page]", "Filter events by continent", text: "All"
+  end
+
+  test "should filter upcoming events by continent" do
+    europe, north_america = upcoming_events_on_two_continents
+
+    get events_url
+    assert_response :success
+    assert_select "[data-event-id=#{europe.slug}]"
+    assert_select "[data-event-id=#{north_america.slug}]"
+
+    get events_url(continent: "europe")
+    assert_response :success
+    assert_select "[data-event-id=#{europe.slug}]"
+    assert_select "[data-event-id=#{north_america.slug}]", false
+    assert_select "nav[aria-label=?] a[aria-current=page]", "Filter events by continent", text: "Europe"
+  end
+
+  test "should ignore an unknown continent" do
+    get events_url(continent: "not-a-continent")
+
+    assert_response :success
+    assert_select "[data-event-id=#{@event.slug}]", 2
+    assert_select "nav[aria-label=?] a[aria-current=page]", "Filter events by continent", text: "All"
+  end
+
+  test "should show the empty state for a continent without events" do
+    get events_url(continent: "africa")
+
+    assert_response :success
+    assert_select "h2", text: "No events found"
+    assert_select "[data-event-id=#{@event.slug}]", false
+  end
+
+  test "should filter the ics feed by continent" do
+    europe, north_america = upcoming_events_on_two_continents
+
+    get events_url(format: :ics, continent: "europe")
+
+    assert_response :success
+    assert_includes response.body, "UID:RUBYEVENTS-#{europe.id}"
+    assert_not_includes response.body, "UID:RUBYEVENTS-#{north_america.id}"
+  end
+
   test "should show event" do
     get event_url(@event)
     assert_response :success
@@ -67,5 +117,18 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
     assert_select "p", text: "No events found"
+  end
+
+  private
+
+  # Moves two fixtures into the upcoming window on different continents.
+  def upcoming_events_on_two_continents
+    europe = events(:rails_world_2023) # NL
+    north_america = events(:railsconf_2025) # US
+
+    europe.update!(start_date: 1.week.from_now, end_date: 1.week.from_now, date: 1.week.from_now)
+    north_america.update!(start_date: 2.weeks.from_now, end_date: 2.weeks.from_now, date: 2.weeks.from_now)
+
+    [europe, north_america]
   end
 end

--- a/test/system/events_test.rb
+++ b/test/system/events_test.rb
@@ -19,6 +19,36 @@ class EventsTest < ApplicationSystemTestCase
     assert_selector "span", text: "Tropical Ruby"
   end
 
+  test "filtering upcoming events by continent" do
+    europe = events(:rails_world_2023)
+    north_america = events(:railsconf_2025)
+    europe.update!(start_date: 1.week.from_now, end_date: 1.week.from_now, date: 1.week.from_now)
+    north_america.update!(start_date: 2.weeks.from_now, end_date: 2.weeks.from_now, date: 2.weeks.from_now)
+
+    visit events_url
+
+    assert_selector "#event-list", text: europe.name
+    assert_selector "#event-list", text: north_america.name
+
+    within "nav[aria-label='Filter events by continent']" do
+      click_on "Europe"
+    end
+
+    assert_selector "#event-list", text: europe.name
+    assert_no_selector "#event-list", text: north_america.name
+
+    within "nav[aria-label='Filter events by continent']" do
+      click_on "Africa"
+    end
+
+    assert_selector "h2", text: "No events found"
+
+    click_on "Show all events"
+
+    assert_selector "#event-list", text: europe.name
+    assert_selector "#event-list", text: north_america.name
+  end
+
   test "visiting the show" do
     visit event_url(@event)
     assert_selector "h1", text: @event.name


### PR DESCRIPTION
I think most people prefer to go to conferences near them (on the same continent) more often. 
This adds continent filters on top of the event pages (upcoming, past, calendar), making it easier to find 'closer' conferences. 

The filter 'pills' are designed similarly to the alphabet filters found on other pages. It persists the filter state across the pages.

## Screenshots

https://github.com/user-attachments/assets/00341f74-635e-4987-87c4-075b859c272a
