### PR TITLE
Backfill the sponsor logos for Balkan Ruby 2026

### DIFF
--- a/data/balkanruby/balkanruby-2026/sponsors.yml
+++ b/data/balkanruby/balkanruby-2026/sponsors.yml
@@ -6,46 +6,57 @@
         - name: "Dext"
           website: "https://dext.com"
           slug: "dext"
+          logo_url: "https://balkanruby.com/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6Mzg0LCJwdXIiOiJibG9iX2lkIn19--d7e8e39c4f40527e69248327028520ab5a00e9a8/dext.svg"
 
         - name: "SwissCRM"
           website: "https://swisscrm.com"
           slug: "swisscrm"
+          logo_url: "https://balkanruby.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MzgzLCJwdXIiOiJibG9iX2lkIn19--acf008810561c34b6b8f37cef914700f0e64f54c/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJwbmciLCJyZXNpemVfdG9fbGltaXQiOls1MDAsNTAwXX0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--1af0099157b76e9cbcc497a0d35cdb95437cfe52/SWISS-LOGO.png"
 
         - name: "Typesense"
           website: "https://typesense.org"
           slug: "typesense"
+          logo_url: "https://balkanruby.com/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MzM4LCJwdXIiOiJibG9iX2lkIn19--fe75fe5714e7828e23f11e235cd9d42ce4e8cece/typesense-logo.svg"
 
         - name: "Studio Raketa"
           website: "https://raketadesign.com"
           slug: "studio-raketa"
+          logo_url: "https://balkanruby.com/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MzY1LCJwdXIiOiJibG9iX2lkIn19--3588a75b74cddcb23228f9da4374e34db8f86bc8/Raketa%20CombinationMark.svg"
 
         - name: "AppSignal"
           website: "https://www.appsignal.com"
           slug: "appsignal"
+          logo_url: "https://balkanruby.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsiZGF0YSI6NDAsInB1ciI6ImJsb2JfaWQifX0=--6594f09203f380442d3fc6da9f13987d6f559b84/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJwbmciLCJyZXNpemVfdG9fbGltaXQiOls1MDAsNTAwXX0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--1af0099157b76e9cbcc497a0d35cdb95437cfe52/appsignal.png"
 
         - name: "tutuf"
           website: "https://tutuf.com"
           slug: "tutuf"
+          logo_url: "https://balkanruby.com/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6NDM0LCJwdXIiOiJibG9iX2lkIn19--68cfa1736445352a12dcf1fcf9df837c655c737e/tutuf_name_and_logo_en.svg"
 
         - name: "B2B Media Group"
-          website: "https://b2bmediagroup.com"
+          website: "https://www.b2bmg.com"
           slug: "b2b-media-group"
+          logo_url: "https://balkanruby.com/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6NDE5LCJwdXIiOiJibG9iX2lkIn19--21d816432de56169d68732b449a8e47a116c2d6e/B2BMG-Logo-1.svg"
 
         - name: "Intercom"
           website: "https://www.intercom.com"
           slug: "intercom"
+          logo_url: "https://balkanruby.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MzU3LCJwdXIiOiJibG9iX2lkIn19--748206d1d8ad41003f976f38930e2599f8ef11a6/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJwbmciLCJyZXNpemVfdG9fbGltaXQiOls1MDAsNTAwXX0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--1af0099157b76e9cbcc497a0d35cdb95437cfe52/intercom.png"
 
         - name: "JetBrains"
           website: "https://www.jetbrains.com"
           slug: "jetbrains"
+          logo_url: "https://balkanruby.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MzYyLCJwdXIiOiJibG9iX2lkIn19--b43dd05757426b1e7edf50f2d19c7d1ec76268d7/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJwbmciLCJyZXNpemVfdG9fbGltaXQiOls1MDAsNTAwXX0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--1af0099157b76e9cbcc497a0d35cdb95437cfe52/jetbrains.png"
 
         - name: "Packt"
           website: "https://www.packtpub.com"
           slug: "packt"
+          logo_url: "https://balkanruby.com/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6Mzk5LCJwdXIiOiJibG9iX2lkIn19--144865933613183139a1be17877e33292a137608/packt-Dz-8EKdV.svg"
 
         - name: "Avo"
           website: "https://avohq.io"
           slug: "avo"
+          logo_url: "https://balkanruby.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsiZGF0YSI6NDEsInB1ciI6ImJsb2JfaWQifX0=--cbce6aee6ac3d7174a63c79803abc5d83d624bce/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJwbmciLCJyZXNpemVfdG9fbGltaXQiOls1MDAsNTAwXX0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--1af0099157b76e9cbcc497a0d35cdb95437cfe52/avo.png"
 
     - name: "Community Partners"
       level: 2
@@ -53,15 +64,29 @@
         - name: "Digger Video"
           website: "https://diggervideo.com"
           slug: "digger-video"
+          logo_url: "https://balkanruby.com/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6NDYxLCJwdXIiOiJibG9iX2lkIn19--f74a164d79db1d594c48e202ca81be33002be6f7/10.DiggerVideo-Full_Black.svg"
 
         - name: "Ruby Community Conference"
-          website: "https://rubycommconf.com"
+          website: "https://www.rubycommunityconference.com"
           slug: "ruby-community-conference"
+          logo_url: "https://balkanruby.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MzUwLCJwdXIiOiJibG9iX2lkIn19--88ebb88e17c5657c79ed47f0f60e432c0c298523/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJwbmciLCJyZXNpemVfdG9fbGltaXQiOls1MDAsNTAwXX0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--1af0099157b76e9cbcc497a0d35cdb95437cfe52/Balkan%20Ruby%202025%20Sofia.png"
 
         - name: "Puzl"
-          website: "https://puzl.com"
+          website: "https://www.puzl.com"
           slug: "puzl"
+          logo_url: "https://balkanruby.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MzUzLCJwdXIiOiJibG9iX2lkIn19--61ab8f70770f8e2b924a5cf0ec3fb5b022e53737/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJwbmciLCJyZXNpemVfdG9fbGltaXQiOls1MDAsNTAwXX0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--1af0099157b76e9cbcc497a0d35cdb95437cfe52/Balkan%20Ruby%202025%20Puzzle.png"
 
         - name: "Flat Manager"
-          website: "https://flatmanager.com"
+          website: "https://book.flatmanager.bg"
           slug: "flat-manager"
+          logo_url: "https://balkanruby.com/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsiZGF0YSI6MzgwLCJwdXIiOiJibG9iX2lkIn19--37d6f4af5044a72d9c0863588849002ed21fc6d9/flat-manager.svg"
+
+        - name: "Geneva.rb"
+          website: "https://www.meetup.com/geneva-rb"
+          slug: "geneva-rb"
+          logo_url: "https://balkanruby.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsiZGF0YSI6NDU2LCJwdXIiOiJibG9iX2lkIn19--2b7fd81d5782fa70cbf7f493c7b0fc2eeafee9d3/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJwbmciLCJyZXNpemVfdG9fbGltaXQiOls1MDAsNTAwXX0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--1af0099157b76e9cbcc497a0d35cdb95437cfe52/geneva-rb.avif"
+
+        - name: "Fury Escape Works"
+          website: "https://www.furyescapeworks.com"
+          slug: "fury-escape-works"
+          logo_url: "https://balkanruby.com/rails/active_storage/representations/redirect/eyJfcmFpbHMiOnsiZGF0YSI6NDU3LCJwdXIiOiJibG9iX2lkIn19--89155ca0bb474ba4d6090c1cb38a94d2ceb31a35/eyJfcmFpbHMiOnsiZGF0YSI6eyJmb3JtYXQiOiJwbmciLCJyZXNpemVfdG9fbGltaXQiOls1MDAsNTAwXX0sInB1ciI6InZhcmlhdGlvbiJ9fQ==--1af0099157b76e9cbcc497a0d35cdb95437cfe52/fury-escape-works.png"


### PR DESCRIPTION
## Description

Asked the robots to crawl https://balkanruby.com and get the sponsors' logo assets. The built-in skill worked wonderfully!

## Screenshots

<img width="1840" height="1197" alt="Screenshot 2026-08-07 at 13 53 04" src="https://github.com/user-attachments/assets/cd342aba-52d1-4e95-bb91-a8918bfc0ac3" />


## Testing Steps

Seeded the local database and run the change locally.

## References

- https://balkanruby.com