### PR TITLE
Add XO Ruby Montreal 2026

### DIFF
--- a/data/xoruby/xoruby-montreal-2026/event.yml
+++ b/data/xoruby/xoruby-montreal-2026/event.yml
@@ -1,0 +1,19 @@
+---
+id: "xoruby-montreal-2026"
+title: "XO Ruby Montréal 2026"
+location: "Montréal, QC, Canada"
+timezone: "America/Toronto"
+kind: "conference"
+description: |-
+    XO Ruby is a single-day, single-track conference designed to draw folks in from the city and the region. An approachable $100 ticket price coupled with no need for a hotel or airfare means you can connect with your community without breaking the bank.
+start_date: "2026-10-17"
+end_date: "2026-10-17"
+year: 2026
+website: "https://www.xoruby.com/event/montreal-2/"
+tickets_url: "https://buy.stripe.com/bJe14ogqr3uMeuNbMk43S0p"
+banner_background: "#230902"
+featured_background: "#230902"
+featured_color: "#FE470B"
+coordinates:
+  latitude: 45.5094
+  longitude: -73.5632

--- a/data/xoruby/xoruby-montreal-2026/venue.yml
+++ b/data/xoruby/xoruby-montreal-2026/venue.yml
@@ -1,0 +1,24 @@
+# docs/ADDING_VENUES.md
+---
+name: "MEM - Centre des mémoires montréalaises"
+description: "We'll be meeting at the MEM – Centre des mémoires montréalaises, Montréal's own memorabilia museum, in its spacious Cabaret room. Right in the heart of Montréal's Quartier des spectacles on boulevard Saint-Laurent, the MEM is steps away from good food (try La Belle Province for Poutine), the Montréal night life, the Complexe Desjardins and Old Montréal is within walking distance too."
+instructions: "MEM is a corner-of-Sainte-Catherine-and-Saint-Laurent walk from the Saint-Laurent metro station on the Green Line, putting it within easy reach for anyone coming by transit. Drivers will find paid street parking and garages scattered throughout the surrounding Quartier des spectacles blocks."
+url: ""
+
+address:
+  street: "1210 Boulevard Saint-Laurent"
+  city: "Montreal"
+  region: "Quebec"
+  postal_code: "H2X 2S8"
+  country: "Canada"
+  country_code: "ca"
+  display: "1210 boul. Saint-Laurent, Montréal, Québec H2X 2S5"
+
+coordinates:
+  latitude: 45.5094065
+  longitude: -73.5631662
+
+maps:
+  google: "https://maps.google.com/?q=MEM+-+Centre+des+mémoires+montréalaises,45.5094065,-73.5631662"
+  apple: "https://maps.apple.com/?q=MEM+-+Centre+des+mémoires+montréalaises&ll=45.5094065,-73.5631662"
+  openstreetmap: "https://www.openstreetmap.org/?mlat=45.5094065&mlon=-73.5631662"


### PR DESCRIPTION
## Description
Adds the XO Ruby Montreal 2026 event, a single-day, single-track conference taking place on October 17, 2026 in Montreal, QC. Includes the MEM - Centre des mémoires montréalaises venue. Data sourced from https://www.xoruby.com/event/montreal-2/

- Event: `data/xoruby/xoruby-montreal-2026/event.yml`
- Venue: `data/xoruby/xoruby-montreal-2026/venue.yml`

## Screenshots
<!-- Add screenshots or GIFs if applicable. -->

## Testing Steps
- Run `bin/rails validate:all`
- Run `bundle exec yerba check`
- Affected page: https://rubyevents.org/events/xoruby-montreal-2026

## References
- Event website: https://www.xoruby.com/event/montreal-2/
## Screenshots

![montreal-event.png](https://github.com/user-attachments/assets/2934c0be-2f42-401d-bfa9-5fca649ca4bc)
![montreal-venue.png](https://github.com/user-attachments/assets/3a23ea3c-a3dd-48c3-bf37-77d41a48ec0a)
