### PR TITLE
Fix /jobs dashboard in development without authentication

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -45,5 +45,7 @@ module RubyEvents
 
     # disable Mission Control auth as we use the route Authenticator
     config.mission_control.jobs.http_basic_auth_enabled = false
+    # do not inherit from ApplicationController (the default), because that calls `authenticate_user!`
+    config.mission_control.jobs.base_controller_class = "ActionController::Base"
   end
 end


### PR DESCRIPTION
I noticed the /jobs dashboard can't be reached in development if you're not authenticated.

## Description
It inherits from ApplicationController by default, which requires authentication via `authenticate_user!.

The dashboard itself is protected via routes and can be accessed without being authenticated in development, so the controller doesn't need to do that.

## Screenshots
<img width="2580" height="1418" alt="CleanShot 2026-08-11 at 09 07 47@2x" src="https://github.com/user-attachments/assets/b8b61600-2aa3-4752-abd7-fca938145fbb" />

I think the "no route matches" error will go away as well, it probably tries to calculate the route in the scope of the jobs dashboard routes instead of the main app. Since it won't inherit that controller anymore anyway this will go away.

