### PR TITLE
Require permission for GitHub-changing git and gh commands

### DIFF
--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -8,5 +8,20 @@
       ],
       "enabled": true
     }
+  },
+  "permission": {
+    "bash": {
+      "gh *": "ask",
+      "git *": "ask",
+      "git add*": "allow",
+      "git diff*": "allow",
+      "git log*": "allow",
+      "git show*": "allow",
+      "git status*": "allow",
+      "gh pr diff*": "allow",
+      "gh pr view*": "allow",
+      "gh issue view*": "allow",
+      "gh repo view*": "allow"
+    }
   }
 }


### PR DESCRIPTION
## Description
Require permission for any git or gh command that changes state. Read-only operations (`git status`, `git diff`, `git log`, `git show`, `git add`, and `gh * view`/`gh * diff`) run without prompting; everything else — commits, pushes, merges, PR/issue creation, comments, releases, workflow runs, etc. — now prompts for approval.

## Screenshots
N/A

## Testing Steps
- Restart opencode for the config change to take effect
- Run `git status` — should run without permission prompt
- Run `git add <file>` — should run without permission prompt
- Run `gh pr view 2053` — should run without permission prompt
- Run `git push`, `git commit`, or `gh pr merge` — should prompt for permission

## References
- N/A