### PR TITLE
Add LSP server support to opencode

### DIFF
--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -8,5 +8,16 @@
       ],
       "enabled": true
     }
+  },
+  "lsp": {
+    "herb": {
+      "command": [
+        "herb-language-server",
+        "--stdio"
+      ],
+      "extensions": [
+        ".erb"
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Description
Adds LSP (Language Server Protocol) server support to opencode for richer in-editor tooling:

- **Herb** (`herb-language-server`) — a custom LSP for ERB templates. Registered under `.erb` because opencode matches servers by a file's last extension, so the previous `.html.erb` mapping never matched.
- The built-in **ruby-lsp** (Ruby/Rails) and **yaml-ls** (YAML) servers are also active for this repo.

## Screenshots
N/A

## Testing Steps
1. Restart opencode so the config is reloaded.
2. Run `opencode debug lsp status` — confirm `herb`, `ruby-lsp`, and `yaml-ls` are listed.
3. Run `opencode debug lsp diagnostics <file>.erb` on an ERB template and confirm the herb language server reports syntax diagnostics.

## References
- Split out of #2053 so the permission changes there can merge independently.