### PR TITLE
Add organizers, sponsors and new speakers for Deccan Queen on Rails 2026

### DIFF
--- a/data/deccan-queen-on-rails/deccan-queen-on-rails-2026/involvements.yml
+++ b/data/deccan-queen-on-rails/deccan-queen-on-rails-2026/involvements.yml
@@ -1,0 +1,6 @@
+---
+- name: "Organizer"
+  users:
+    - Vipul A M
+  organisations:
+    - Saeloun

--- a/data/deccan-queen-on-rails/deccan-queen-on-rails-2026/sponsors.yml
+++ b/data/deccan-queen-on-rails/deccan-queen-on-rails-2026/sponsors.yml
@@ -1,0 +1,18 @@
+---
+- tiers:
+  - name: "Platinum"
+    level: 0
+    sponsors:
+      - name: "Saeloun"
+        website: "https://saeloun.com"
+        slug: "saeloun"
+        logo_url: "https://deccanqueonrails.com/dqor/saeloun-logo.png"
+
+  - name: "Wifi"
+    level: 1
+    sponsors:
+      - name: "Typesense"
+        website: "https://typesense.org"
+        slug: "typesense"
+        logo_url: "https://deccanqueenonrails.com/dqor/typesense-logo.png"
+        badge: "Wifi Sponsor"

--- a/data/deccan-queen-on-rails/deccan-queen-on-rails-2026/venue.yml
+++ b/data/deccan-queen-on-rails/deccan-queen-on-rails-2026/venue.yml
@@ -1,5 +1,6 @@
 ---
 name: "Hyatt Regency Pune & Residences"
+instructions: "If you want to come by the Deccan Queen, land in Mumbai, hop on the iconic Deccan Queen express from Mumbai CST. Departs 17:10, arrives पुणे 20:30 — scenic, comfortable, and the most fitting way to arrive at a conference named after it. You can also fly into Mumbai (BOM) or direct to Pune (PNQ)."
 url: "https://www.hyatt.com/hyatt-regency/en-US/punhr-hyatt-regency-pune"
 
 address:

--- a/data/deccan-queen-on-rails/deccan-queen-on-rails-2026/videos.yml
+++ b/data/deccan-queen-on-rails/deccan-queen-on-rails-2026/videos.yml
@@ -58,3 +58,23 @@
   description: "" # TODO
   speakers:
     - Carmine Paolino
+
+- id: "keshav-biswa-deccan-queen-on-rails-2026"
+  title: "Talk by Keshav Biswa"
+  date: "2026-10-08"
+  language: "English"
+  video_provider: "scheduled"
+  video_id: "keshav-biswa-deccan-queen-on-rails-2026"
+  description: "" # TODO
+  speakers:
+    - Keshav Biswa
+
+- id: "pawel-strzalkowski-deccan-queen-on-rails-2026"
+  title: "Talk by Paweł Strzałkowski"
+  date: "2026-10-08"
+  language: "English"
+  video_provider: "scheduled"
+  video_id: "pawel-strzalkowski-deccan-queen-on-rails-2026"
+  description: "" # TODO
+  speakers:
+    - Paweł Strzałkowski


### PR DESCRIPTION
## Description
Update Deccan Queen on Rails 2026 with data from deccanqueonrails.com:
- Add talks for newly announced speakers Keshav Biswa and Paweł Strzałkowski
- Add involvements (Organizer: Vipul A M / Saeloun)
- Add sponsors (Saeloun Platinum, Typesense Wifi)

## Screenshots
<!-- Add screenshots or GIFs if applicable. -->

## Testing Steps
- Event talks page: http://localhost:3000/events/deccan-queen-on-rails-2026/talks
- Event sponsors page: http://localhost:3000/events/deccan-queen-on-rails-2026/sponsors
- Event page: http://localhost:3000/events/deccan-queen-on-rails-2026

## References
- closes #

## Screenshots

![Event page](https://github.com/user-attachments/assets/6b5cf7fd-cd78-49e0-94d3-eeaafd039a9c)

![Talks page](https://github.com/user-attachments/assets/927bcebf-94ed-4565-949a-a8d1712608f4)

![Sponsors page](https://github.com/user-attachments/assets/f7d291e2-8cd3-40cc-ab87-752d2c4bddb2)
