### PR TITLE
Add more columns to the compact contributors view

### DIFF
--- a/app/views/page/contributors.html.erb
+++ b/app/views/page/contributors.html.erb
@@ -73,7 +73,7 @@
           <%= @contributors.count %> Contributors
         </h2>
 
-        <div class="md:grid-cols-16 lg:grid-cols-20 mb-6 grid grid-cols-10 gap-3 sm:grid-cols-12">
+        <div class="grid grid-cols-10 sm:grid-cols-12 md:grid-cols-16 lg:grid-cols-25 gap-3 mb-6">
           <% @contributors.each do |contributor| %>
             <%= link_to contributor.user ? profile_path(contributor.user) : contributor.html_url,
                   target: contributor.user ? nil : "_blank",

--- a/app/views/page/contributors.html.erb
+++ b/app/views/page/contributors.html.erb
@@ -73,7 +73,7 @@
           <%= @contributors.count %> Contributors
         </h2>
 
-        <div class="grid grid-cols-10 sm:grid-cols-12 md:grid-cols-16 lg:grid-cols-25 gap-3 mb-6">
+        <div class="mb-6 grid grid-cols-10 gap-3 sm:grid-cols-12 md:grid-cols-16 lg:grid-cols-25">
           <% @contributors.each do |contributor| %>
             <%= link_to contributor.user ? profile_path(contributor.user) : contributor.html_url,
                   target: contributor.user ? nil : "_blank",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -53,6 +53,10 @@ module.exports = {
           '0%': { opacity: '1' },
           '100%': { opacity: '0' }
         }
+      },
+      gridTemplateColumns: {
+        16: 'repeat(16, minmax(0, 1fr))',
+        25: 'repeat(25, minmax(0, 1fr))'
       }
     }
   },


### PR DESCRIPTION
## Description

Adds more columns to the compact view of the `/contributors` page, up to 25 columns on large screens (the compact view is used for social media screenshots).

The compact grid declared `md:grid-cols-16 lg:grid-cols-20`, but those utilities never generated CSS — Tailwind's default grid scale stops at 12 and nothing registered them in the theme. The grid silently capped at 10 columns on md+ screens. Now `grid-cols-16` and `grid-cols-25` are registered in `tailwind.config.js` and the grid uses `grid grid-cols-10 sm:grid-cols-12 md:grid-cols-16 lg:grid-cols-25`.

## Screenshots

![contributors-compact.png](https://github.com/user-attachments/assets/833b3dd3-0492-4adf-a8ee-ab1d2500c832)

## Testing Steps

1. Visit the `/contributors` page.
2. Toggle the **Compact** view.
3. On a wide (lg+) viewport the grid should render 25 columns instead of 10.

## References