### PR TITLE
Fix mobile profile talk links

### DIFF
--- a/app/views/profiles/_talks.html.erb
+++ b/app/views/profiles/_talks.html.erb
@@ -7,7 +7,8 @@
             user_watched_talks: user_watched_talks,
             show_event_name: true,
             variant: :profile,
-            tooltip: false
+            tooltip: false,
+            turbo_frame: "_top"
           } %>
   </div>
 

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -15,6 +15,9 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
     get profile_url(@user_with_talk)
     assert_response :success
     assert_equal @user_with_talk.talks_count, assigns(:talks).length
+
+    talk = assigns(:talks).first
+    assert_select "a##{dom_id(talk, :card_horizontal)}[data-turbo-frame='_top']"
   end
 
   test "should redirect to canonical user" do


### PR DESCRIPTION
## Description

This makes mobile profile talk cards navigate outside the profile Turbo Frame. Desktop partials specify turbo frame `_top`, mobile partials did not - and now they do. 

https://github.com/user-attachments/assets/e241b34b-0a0c-412c-8766-cabdb233ae60

## Testing Steps




`bin/rails test test/controllers/profiles_controller_test.rb`

## References

- closes #2059