### PR TITLE
Add WNB.rb meetup CFP

### DIFF
--- a/data/wnb-rb/wnb-rb-meetup/cfp.yml
+++ b/data/wnb-rb/wnb-rb-meetup/cfp.yml
@@ -1,0 +1,4 @@
+---
+- name: "WNB.rb Meetup Talk Proposal"
+  link: "https://docs.google.com/forms/d/e/1FAIpQLSdmOJxLdSdy74mXYxsr6ZRRhTN95Yxnq2B6n5mhUoGkVmDUGA/viewform"
+  open_date: "2026-08-17"


### PR DESCRIPTION
## Description

Adds a cfp.yml for the WNB.rb online meetup series.

## Screenshots
<img width="2039" height="1084" alt="Screenshot 2026-08-17 at 12 45 35 PM" src="https://github.com/user-attachments/assets/f5af12ad-8574-45e9-bf6c-f87c811da3cd" />


## Testing Steps
`bin/lint` succeeds

## References

See https://www.wnb-rb.dev/ and https://www.wnb-rb.dev/meetups