### PR TITLE
Start date and end date is optional for event generation

### DIFF
--- a/lib/generators/event/event_generator.rb
+++ b/lib/generators/event/event_generator.rb
@@ -11,8 +11,8 @@ class EventGenerator < Generators::EventBase
   class_option :kind, type: :string, enum: Event.kinds.keys, desc: "Event kind (e.g. conference, meetup, workshop)", default: "conference", group: "Fields"
 
   # Dates
-  class_option :start_date, type: :string, desc: "Start date (YYYY-MM-DD)", required: true, group: "Fields"
-  class_option :end_date, type: :string, desc: "End date (YYYY-MM-DD)", required: true, group: "Fields"
+  class_option :start_date, type: :string, desc: "Start date (YYYY-MM-DD)", group: "Fields"
+  class_option :end_date, type: :string, desc: "End date (YYYY-MM-DD)", group: "Fields"
   class_option :announced_on, type: :string, desc: "Date when the event was announced (YYYY-MM-DD)", group: "Fields"
   class_option :recordings_published_date, type: :string, desc: "Date when the event's recordings were published (YYYY-MM-DD)", group: "Fields"
   class_option :date_precision, type: :string, enum: ["year", "month", "day"], desc: "Precision of the date (when exact dates are unknown)", group: "Fields"
@@ -40,8 +40,15 @@ class EventGenerator < Generators::EventBase
     @event_file_path ||= File.join(event_directory, "event.yml")
   end
 
+  def validate_options
+    return if meetup?
+
+    raise Thor::RequiredArgumentMissingError, "No value provided for required options '--start-date'" if options[:start_date].blank?
+    raise Thor::RequiredArgumentMissingError, "No value provided for required options '--end-date'" if options[:end_date].blank?
+  end
+
   def initialize_values
-    @year = Date.parse(options[:start_date]).year
+    @year = options[:start_date].present? ? Date.parse(options[:start_date]).year : nil
     @geocoded_address = nil
     @location = if options[:online]
       "online"
@@ -58,6 +65,10 @@ class EventGenerator < Generators::EventBase
 
   def copy_event_file
     template "event.yml.tt", event_file_path
+  end
+
+  def meetup?
+    options[:kind] == "meetup"
   end
 
   def generate_venue_file

--- a/lib/generators/event/templates/event.yml.tt
+++ b/lib/generators/event/templates/event.yml.tt
@@ -18,9 +18,15 @@ recordings_published_date: "<%= options[:recordings_published_date] %>"
 <%- if options[:announced_on] -%>
 announced_on: "<%= options[:announced_on] %>"
 <%- end -%>
+<%- if options[:start_date] -%>
 start_date: "<%= options[:start_date] %>"
+<%- end -%>
+<%- if options[:end_date] -%>
 end_date: "<%= options[:end_date] %>"
+<%- end -%>
+<%- if @year -%>
 year: <%= @year %>
+<%- end -%>
 <%- if options[:date_precision] -%>
 date_precision: "<%= options[:date_precision] %>"
 <%- end -%>
@@ -28,7 +34,9 @@ website: "<%= options[:website] %>"<%= " # TODO" if options[:website].blank? %>
 <%- if options[:original_website] -%>
 original_website: "<%= options[:original_website] %>"
 <%- end -%>
-tickets_url: "<%= options[:tickets_url] %>"<%= " # TODO" if options[:tickets_url].blank? %>
+<%- if options[:tickets_url].present? -%>
+tickets_url: "<%= options[:tickets_url] %>"
+<%- end -%>
 <%- if options[:last_edition] -%>
 last_edition: true
 <%- end -%>

--- a/test/lib/generators/event_generator_test.rb
+++ b/test/lib/generators/event_generator_test.rb
@@ -140,6 +140,41 @@ class EventGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  test "meetup event without dates passes schema validation" do
+    event_file_path = File.join(destination_root, "data/tokyo-rb/tokyo-rb-meetup/event.yml")
+    run_generator ["--force",
+      "--event-series", "tokyo-rb",
+      "--event", "tokyo-rb-meetup",
+      "--title", "Tokyo.rb Meetup",
+      "--kind", "meetup",
+      "--location", "Tokyo, Japan",
+      "--online"]
+
+    assert_valid_file event_file_path do |content|
+      assert_match(/title: "Tokyo.rb Meetup"/, content)
+      assert_match(/kind: "meetup"/, content)
+      assert_no_match(/start_date/, content)
+      assert_no_match(/end_date/, content)
+      assert_no_match(/year:/, content)
+      assert_no_match(/tickets_url/, content)
+    end
+  end
+
+  test "non-meetup event without dates does not generate a file" do
+    event_file_path = File.join(destination_root, "data/rubyconf/2030/event.yml")
+
+    stderr = capture(:stderr) do
+      run_generator ["--force",
+        "--event-series", "rubyconf",
+        "--event", "2030",
+        "--title", "RubyConf 2030",
+        "--online"]
+    end
+
+    assert_match(/start-date/, stderr)
+    assert_not File.exist?(event_file_path)
+  end
+
   def assert_valid_file(file_path, msg = nil, &block)
     errors = Static::Validators::Validator.event_validator_classes.flat_map do |validator|
       validator.new(file_path:).errors


### PR DESCRIPTION
## Description
Start date and end date should be optional for event generation

## Screenshots
<img width="1319" height="83" alt="image" src="https://github.com/user-attachments/assets/8e1c8879-0fcb-4d7e-bbaa-36518b2d02bb" />

## Testing Steps
bin/rails g event --kind meetup --event-series tokyo-rb --event tokyo-rb-meetup --title "Tokyo.rb" --online
## References
(https://github.com/rubyevents/rubyevents/issues/2071)
