### PR TITLE
Update dependencies august 2026

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "rails", github: "rails/rails"
 gem "propshaft"
 
 # Use sqlite3 as the database for Active Record
-gem "sqlite3", ">= 2.1.0"
+gem "sqlite3", ">= 2.9.5"
 
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma"

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem "rails", github: "rails/rails"
 gem "propshaft"
 
 # Use sqlite3 as the database for Active Record
-gem "sqlite3", ">= 2.9.5"
+gem "sqlite3", ">= 2.1.0"
 
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -636,8 +636,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.7.0)
-      loofah (~> 2.25)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rails-i18n (8.1.0)
       i18n (>= 0.7, < 2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -740,14 +740,14 @@ GEM
       activejob (>= 7.2)
       activerecord (>= 7.2)
       railties (>= 7.2)
-    sqlite3 (2.9.3-aarch64-linux-gnu)
-    sqlite3 (2.9.3-aarch64-linux-musl)
-    sqlite3 (2.9.3-arm-linux-gnu)
-    sqlite3 (2.9.3-arm-linux-musl)
-    sqlite3 (2.9.3-arm64-darwin)
-    sqlite3 (2.9.3-x86_64-darwin)
-    sqlite3 (2.9.3-x86_64-linux-gnu)
-    sqlite3 (2.9.3-x86_64-linux-musl)
+    sqlite3 (2.9.5-aarch64-linux-gnu)
+    sqlite3 (2.9.5-aarch64-linux-musl)
+    sqlite3 (2.9.5-arm-linux-gnu)
+    sqlite3 (2.9.5-arm-linux-musl)
+    sqlite3 (2.9.5-arm64-darwin)
+    sqlite3 (2.9.5-x86_64-darwin)
+    sqlite3 (2.9.5-x86_64-linux-gnu)
+    sqlite3 (2.9.5-x86_64-linux-musl)
     sshkit (1.25.0)
       base64
       logger
@@ -934,7 +934,7 @@ DEPENDENCIES
   sitemap_generator (~> 6.3)
   solid_cache
   solid_queue!
-  sqlite3 (>= 2.1.0)
+  sqlite3 (= 2.9.5)
   stackprof
   standardrb (~> 1.0)
   thruster

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -828,7 +828,7 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.9.2)
     websocket (1.2.11)
-    websocket-driver (0.8.1)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -471,7 +471,7 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     lumberjack (1.4.2)
@@ -955,4 +955,4 @@ RUBY VERSION
   ruby 4.0.6
 
 BUNDLED WITH
-  4.0.3
+  4.0.16


### PR DESCRIPTION
## Description
Update of dependencies when Bundle audit raise a CVE.
**WARNING => I left the updates for Avo and Puma** as those are not minors

## Testing Steps
Test passes except for remaining updates
Launch app locally it works

## References
```
Name: avo
Version: 3.30.4
CVE: CVE-2026-42205
GHSA: GHSA-qc5p-3mg5-9fh8
Criticality: High
URL: https://github.com/avo-hq/avo/security/advisories/GHSA-qc5p-3mg5-9fh8
Title: Broken Access Control Through Unauthorized Execution of Arbitrary Action Classes Across Resources
Solution: update to '>= 3.31.1'

Name: avo
Version: 3.30.4
CVE: CVE-2026-53769
GHSA: GHSA-pqpw-cvm4-8mv9
Criticality: Medium
URL: https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-53769
Title: Direct attachment upload endpoint lacks upload authorization and bypasses field-level upload policy
Solution: update to '~> 3.32.0', '>= 4.0.0.beta.41'

Name: avo
Version: 3.30.4
CVE: CVE-2026-55518
GHSA: GHSA-8fq9-273g-6mrg
Criticality: Critical
URL: https://www.cve.org/CVERecord?id=CVE-2026-55518
Title: Avo - Missing Authorization in Avo Association Attach Endpoint Allows Unauthorized Relationship Manipulation and Privilege Escalation
Solution: update to '~> 3.32.1', '>= 4.0.0.beta.51'

Name: puma
Version: 7.2.0
CVE: CVE-2026-47736
GHSA: GHSA-qpgp-93vx-g8v8
Criticality: High
URL: https://www.cve.org/CVERecord?id=CVE-2026-47736
Title: Puma PROXY Protocol v1 Parser Allows Remote Memory Exhaustion
Solution: update to '~> 7.2.1', '>= 8.0.2'

Name: puma
Version: 7.2.0
CVE: CVE-2026-47737
GHSA: GHSA-2vqw-3mp8-cgmx
Criticality: High
URL: https://www.cve.org/CVERecord/SearchResults?query=CVE-2026-47737
Title: Puma PROXY Protocol v1 Accepts Repeated Protocol Headers on Persistent Connections
Solution: update to '~> 7.2.1', '>= 8.0.2'

Vulnerabilities found!
```
