### PR TITLE
Validate speaker slugs use GitHub if they cannot be parameterized AND Sync Speakers in the TalkGenerator

### DIFF
--- a/.agents/skills/event-data/SKILL.md
+++ b/.agents/skills/event-data/SKILL.md
@@ -110,21 +110,24 @@ When updating speakers.yml, the structure is:
 ```yaml
 - name: "Speaker Name"
   github: "github_handle"
-  slug: "speaker-slug"
+  slug: "speaker-name"
 ```
 
 Other fields are permitted, but these are the fields I want you to focus on.
 The GitHub handle is how we deduplicate speakers, and populate their profile, so the key should always be present.
 These speakers are used for talks and involvements, so if a speaker is missing, you need to create a new record for them here.
 
-**Slug convention:** Prefer the speaker's GitHub handle as the slug (e.g., `slug: "tenderlove"` for `github: "tenderlove"`). Only transliterate or generate a slug from the name when the speaker has no GitHub handle.
+**Slug convention:**
+1. Prefer the speaker's parameterized name as the slug (e.g., `slug: "chris-hasinski"` for `name: "Chris Hasiński"`).
+2. If the name cannot be parameterized cleanly, use the speaker's GitHub handle as the slug (most common with Japanese names, eg. "河野十行", slug: "jugyo").
+3. Only transliterate when the speaker has no GitHub handle.
 
 If the GitHub is unknown:
 
 ```yaml
 - name: "Speaker Name"
   github: ""
-  slug: "speaker-slug"
+  slug: "speaker-name"
 ```
 
 If the speaker has multiple aliases, they'll be included as aliases.
@@ -132,14 +135,14 @@ If the speaker has multiple aliases, they'll be included as aliases.
 ```yaml
 - name: "Speaker Name"
   github: "github_handle"
-  slug: "speaker-slug"
+  slug: "speaker-name"
   aliases:
     - name: "Other Name"
-      slug: "other-slug"
+      slug: "other-name"
 ```
 
 To update a speaker programmatically, use `Static::SpeakersFile` with a rails runner:
 
 ```bash
-bin/rails runner 'file = Static::SpeakersFile.new; speaker = file.find_by(github: "handle"); speaker["slug"] = "new-slug"; file.save!'
+bin/rails runner 'file = Static::SpeakersFile.new; speaker = file.find_by(name: "Speaker Name"); speaker["github"] = "github-handle"; file.save!'
 ```

--- a/app/models/static/speakers_file.rb
+++ b/app/models/static/speakers_file.rb
@@ -22,6 +22,8 @@ module Static
     ].freeze
 
     class StaleFileError < StandardError; end
+    class InvalidSpeakerError < StandardError; end
+    class DuplicateSpeakerError < StandardError; end
 
     def initialize(path = Rails.root.join(SPEAKERS_PATH).to_s, document: nil)
       @path = path
@@ -84,17 +86,48 @@ module Static
       document.where(**criteria)
     end
 
+    def upsert(name:, github: "", **attributes)
+      raise InvalidSpeakerError, "Speaker name cannot be blank" if name.blank?
+
+      index = index_for(name: name, github: github)
+
+      if index
+        update_entry(document[index], github: github, attributes: attributes)
+      else
+        add(name: name, github: github, **attributes)
+      end
+    end
+
     def add(name:, github: "", slug: nil, **attributes)
+      name = name.strip
+      github = github.strip
+      slug = slug&.strip
+
+      raise InvalidSpeakerError, "Speaker name cannot be blank" if name.blank?
+      raise DuplicateSpeakerError, "Speaker '#{name}' already exists" if known_names.include?(name)
+      raise DuplicateSpeakerError, "A speaker with GitHub handle '#{github}' already exists" if github.present? && index_by(:github)[github]
+
       slug ||= name.parameterize
 
-      entry = {name: name, github: github, slug: slug}
-      entry.merge!(attributes.reject { |_, value| value.nil? || value.to_s.empty? })
+      entry = {name: name, github: github, slug: slug}.merge!(clean_attributes(attributes))
 
       document << entry
 
       reset_cache
 
       entry
+    end
+
+    def update_entry(entry, github:, attributes:)
+      updates = clean_attributes({"github" => github}.merge!(attributes))
+
+      updates.each do |key, value|
+        entry[key] = value
+      end
+
+      reset_cache
+
+      entry.to_h
     end
 
     def all_speaker_references
@@ -136,7 +169,7 @@ module Static
       missing = missing_speakers
 
       entries = missing.map do |name|
-        {name: name, github: "", slug: name.parameterize}
+        {name:, github: "", slug: name.parameterize}
       end
 
       document.concat(entries) if entries.any?
@@ -223,15 +256,43 @@ module Static
     private
 
     def index_for(name: nil, slug: nil, github: nil)
-      (slug && index_by(:slug)[slug]) ||
-        (github && index_by(:github)[github]) ||
-        (name && index_by(:name)[name])
+      name = name&.strip
+      slug = slug&.strip
+      github = github&.strip
+
+      (slug.present? && index_by(:slug)[slug]) ||
+        (github.present? && index_by(:github)[github]) ||
+        (name.present? && index_by(:name)[name]) ||
+        (name.present? && index_aliases[name])
+    end
+
+    def index_aliases
+      @index_aliases ||= begin
+        result = {}
+
+        entries.each_with_index do |entry, index|
+          next unless entry.is_a?(Hash)
+
+          Array(entry["aliases"]).each do |alias_entry|
+            result[alias_entry["name"]] = index if alias_entry.is_a?(Hash) && alias_entry["name"]
+          end
+        end
+
+        result
+      end
+    end
+
+    def clean_attributes(attributes)
+      attributes
+        .reject { |_, value| value.nil? || value.to_s.empty? }
+        .transform_values { |value| value.is_a?(String) ? value.strip : value }
     end
 
     def reset_cache
       @known_names = nil
       @entries = nil
       @indexes = nil
+      @index_aliases = nil
       @all_speaker_references = nil
       @all_referenced_names = nil
       @near_duplicate_names = nil

--- a/app/models/static/speakers_file.rb
+++ b/app/models/static/speakers_file.rb
@@ -99,8 +99,8 @@ module Static
     end
 
     def add(name:, github: "", slug: nil, **attributes)
-      name = name.strip
-      github = github.strip
+      name = name.to_s.strip
+      github = github.to_s.strip
       slug = slug&.strip
 
       raise InvalidSpeakerError, "Speaker name cannot be blank" if name.blank?
@@ -284,7 +284,7 @@ module Static
 
     def clean_attributes(attributes)
       attributes
-        .reject { |_, value| value.nil? || value.to_s.empty? }
+        .reject { |_, value| value.blank? }
         .transform_values { |value| value.is_a?(String) ? value.strip : value }
     end
 

--- a/app/models/static/validators/speaker_slug_matches_name.rb
+++ b/app/models/static/validators/speaker_slug_matches_name.rb
@@ -2,7 +2,7 @@
 
 module Static
   module Validators
-    class SlugMatchesName
+    class SpeakerSlugMatchesName
       def initialize(file_path:, document: nil)
         @file_path = file_path
         @document = document

--- a/app/models/static/validators/speaker_slug_matches_name.rb
+++ b/app/models/static/validators/speaker_slug_matches_name.rb
@@ -30,7 +30,7 @@ module Static
         errors = []
 
         @document ||= Yerba.parse_file(@file_path)
-        name_slug_pairs = @document.pluck(:name).zip(@document.pluck(:slug))
+        name_slug_pairs = @document.pluck(:name).zip(@document.pluck(:slug), @document.pluck(:github))
         errors.concat(find_errors_for_name_slug_pairs(name_slug_pairs) do |name|
           @document.find_by(name: name)&.[]("slug")
         end)
@@ -47,17 +47,30 @@ module Static
       private
 
       def find_errors_for_name_slug_pairs(name_slug_pairs, &block)
-        name_slug_pairs.filter_map do |name, slug|
+        name_slug_pairs.filter_map do |name, slug, github|
           expected_slug = name.parameterize
           next if slug == expected_slug
-          next if expected_slug.empty?
-          location = block.call(name)&.location
-          Static::Validators::Error.new(
-            "Slug must be the name parameterized, expected: #{name.to_s.parameterize}",
-            file_path: @file_path,
-            line: location&.start_line || 1,
-            end_line: location&.end_line
-          )
+
+          entry = block.call(name)
+
+          if expected_slug.empty?
+            next if github.blank?
+            expected_slug = github.to_s.parameterize
+            next if slug == expected_slug
+            Static::Validators::Error.new(
+              "Name cannot be parameterized. Slug must be the GitHub handle, expected: #{expected_slug}.",
+              file_path: @file_path,
+              line: entry&.location&.start_line || 1,
+              end_line: entry&.location&.end_line
+            )
+          else
+            Static::Validators::Error.new(
+              "Slug must be the name parameterized, expected: #{expected_slug}",
+              file_path: @file_path,
+              line: entry&.location&.start_line || 1,
+              end_line: entry&.location&.end_line
+            )
+          end
         end
       end
     end

--- a/app/models/static/validators/validator.rb
+++ b/app/models/static/validators/validator.rb
@@ -43,7 +43,7 @@ class Static::Validators::Validator
     @speaker_validators ||= [
       Static::Validators::Schema,
       Static::Validators::SimilarSpeakerNames,
-      Static::Validators::SlugMatchesName,
+      Static::Validators::SpeakerSlugMatchesName,
       Static::Validators::UniqueSpeakerFields,
       Static::Validators::UniqueSpeakers
     ]

--- a/data/rbqconf/rbqconf-2026/videos.yml
+++ b/data/rbqconf/rbqconf-2026/videos.yml
@@ -131,8 +131,6 @@
   speakers:
     - Yaroslav Konovets
 
-
-
 - id: "bart-de-water-rbqconf-2026"
   title: "How to quit your job (and come back later)"
   raw_title: "RBQ 2026 - How to quit your job (and come back later)"

--- a/data/speakers.yml
+++ b/data/speakers.yml
@@ -2171,6 +2171,7 @@
 - name: "beta_chelsea"
   github: "betachelsea"
   twitter: "beta_chelsea"
+  speakerdeck: "betachelsea"
   slug: "beta_chelsea"
   aliases:
     - name: "betachelsea"
@@ -2575,6 +2576,7 @@
 - name: "Bruno Aguirre"
   github: "elcuervo"
   website: "https://elcuervo.dev"
+  speakerdeck: "elcuervo"
   slug: "bruno-aguirre"
   aliases:
     - name: "elcuervo"
@@ -3007,6 +3009,7 @@
   slug: "chanelle-henry"
 - name: "Chang Sau Sheong"
   github: "sausheong"
+  speakerdeck: "sausheong"
   slug: "chang-sau-sheong"
   aliases:
     - name: "Sau Sheong Chang"
@@ -4776,6 +4779,7 @@
   github: "eileencodes"
   twitter: "eileencodes"
   website: "https://eileencodes.com"
+  speakerdeck: "eileencodes"
   slug: "eileen-alayce"
   aliases:
     - name: "Eileen M. Uchitelle"
@@ -9700,6 +9704,7 @@
   github: "udzura"
   twitter: "udzura"
   website: "https://github.com/udzura/slides"
+  speakerdeck: "udzura"
   slug: "kondo-uchio"
   aliases:
     - name: "Uchio KONDO"
@@ -11839,6 +11844,7 @@
 - name: "Michał Taszycki"
   github: "mehowte"
   twitter: "mehowte"
+  speakerdeck: "mehowte"
   slug: "michal-taszycki"
   aliases:
     - name: "Michal Taszycki"
@@ -15805,6 +15811,7 @@
 - name: "Soichiro Isshiki"
   github: "sisshiki1969"
   twitter: "s_isshiki1969"
+  speakerdeck: "sisshiki1969"
   slug: "soichiro-isshiki"
   aliases:
     - name: "monochrome"
@@ -15845,6 +15852,7 @@
   twitter: "sora_h"
   mastodon: "https://hachyderm.io/@sorah"
   website: "https://sorah.jp/"
+  speakerdeck: "sorah"
   slug: "sorah-fukumori"
   aliases:
     - name: "Shota Fukumori"

--- a/lib/generators/talk/talk_generator.rb
+++ b/lib/generators/talk/talk_generator.rb
@@ -131,6 +131,10 @@ class TalkGenerator < Generators::EventBase
 
     speakers_file.save!
     say("Added or updated #{speakers.to_sentence} in #{speakers_file_path}.", :green)
+  rescue Static::SpeakersFile::InvalidSpeakerError,
+    Static::SpeakersFile::DuplicateSpeakerError,
+    Static::SpeakersFile::StaleFileError => e
+    say_error("Could not sync speakers to #{speakers_file_path}: #{e.message}", :red)
   end
 
   private

--- a/lib/generators/talk/talk_generator.rb
+++ b/lib/generators/talk/talk_generator.rb
@@ -97,6 +97,10 @@ class TalkGenerator < Generators::EventBase
     @videos_file_path ||= File.join(event_directory, "videos.yml")
   end
 
+  def speakers_file_path
+    @speakers_file_path ||= File.join(destination_root, "data", "speakers.yml")
+  end
+
   def ensure_file_exists
     template "videos.yml.tt", videos_file_path unless File.exist?(videos_file_path)
   end
@@ -114,6 +118,19 @@ class TalkGenerator < Generators::EventBase
       say("Appending new talk with id:'#{@talk.id}'...", :green)
       append_to_file videos_file_path, template_content(talk_template)
     end
+  end
+
+  def maybe_add_speaker_to_file
+    speakers = @talk.speakers
+    return if speakers.empty?
+
+    speakers_file = Static::SpeakersFile.new(speakers_file_path)
+    speakers.each { |name| speakers_file.upsert(name: name) }
+
+    return unless speakers_file.changed?
+
+    speakers_file.save!
+    say("Added or updated #{speakers.to_sentence} in #{speakers_file_path}.", :green)
   end
 
   private

--- a/test/lib/generators/talk_generator_test.rb
+++ b/test/lib/generators/talk_generator_test.rb
@@ -328,6 +328,23 @@ class TalkGeneratorTest < Rails::Generators::TestCase
     ], read_speakers_file
   end
 
+  test "reports a red message and continues when speaker sync fails" do
+    seed_speakers_file
+
+    videos_file_path = File.join(destination_root, "data/rubyconf/2045/videos.yml")
+    stderr = capture(:stderr) do
+      run_generator ["--event-series", "rubyconf", "--event", "2045", "--title", "Broken Speaker", "--speakers", ""]
+    end
+
+    assert_includes stderr, "Could not sync speakers"
+    assert_includes stderr, "Speaker name cannot be blank"
+
+    assert_file videos_file_path do |content|
+      assert_match(/id: "/, content)
+    end
+    assert_empty read_speakers_file
+  end
+
   def seed_speakers_file(content = "--- []\n")
     FileUtils.mkdir_p(File.dirname(speakers_file_path))
     File.write(speakers_file_path, content)

--- a/test/lib/generators/talk_generator_test.rb
+++ b/test/lib/generators/talk_generator_test.rb
@@ -10,6 +10,7 @@ class TalkGeneratorTest < Rails::Generators::TestCase
   teardown { FileUtils.remove_entry(destination_root) }
 
   test "creates minimum videos.yml with valid yaml" do
+    seed_speakers_file
     videos_file_path = File.join(destination_root, "data/rubyconf/2024/videos.yml")
     run_generator [
       "--event-series", "rubyconf",
@@ -26,6 +27,8 @@ class TalkGeneratorTest < Rails::Generators::TestCase
   end
 
   test "creates maximum videos.yml with valid yaml" do
+    seed_speakers_file
+
     videos_file_path = File.join(destination_root, "data/rubyconf/2025/videos.yml")
     run_generator [
       "--event-series", "rubyconf",
@@ -49,6 +52,8 @@ class TalkGeneratorTest < Rails::Generators::TestCase
   end
 
   test "infers a non-default kind from the title when --kind is omitted" do
+    seed_speakers_file
+
     videos_file_path = File.join(destination_root, "data/rubyconf/2030/videos.yml")
     run_generator [
       "--event-series", "rubyconf",
@@ -63,6 +68,8 @@ class TalkGeneratorTest < Rails::Generators::TestCase
   end
 
   test "does not write a kind when the title classifies as the default talk" do
+    seed_speakers_file
+
     videos_file_path = File.join(destination_root, "data/rubyconf/2031/videos.yml")
     run_generator [
       "--event-series", "rubyconf",
@@ -78,6 +85,8 @@ class TalkGeneratorTest < Rails::Generators::TestCase
   end
 
   test "an explicit --kind wins over the title inference" do
+    seed_speakers_file
+
     videos_file_path = File.join(destination_root, "data/rubyconf/2032/videos.yml")
 
     run_generator [
@@ -94,6 +103,8 @@ class TalkGeneratorTest < Rails::Generators::TestCase
   end
 
   test "writes an explicit --kind talk that overrides a non-default classification" do
+    seed_speakers_file
+
     videos_file_path = File.join(destination_root, "data/rubyconf/2033/videos.yml")
     run_generator [
       "--event-series", "rubyconf",
@@ -110,6 +121,8 @@ class TalkGeneratorTest < Rails::Generators::TestCase
   end
 
   test "update videos.yml if called twice" do
+    seed_speakers_file
+
     videos_file_path = File.join(destination_root, "data/rubyconf/2026/videos.yml")
     run_generator [
       "--event-series", "rubyconf",
@@ -133,6 +146,8 @@ class TalkGeneratorTest < Rails::Generators::TestCase
   end
 
   test "append to videos.yml if called with a different details" do
+    seed_speakers_file
+
     videos_file_path = File.join(destination_root, "data/rubyconf/2027/videos.yml")
     run_generator ["--event-series", "rubyconf", "--event", "2027", "--title", "Keynote: Jane Doe", "--speakers", "Jane Doe", "--kind", "keynote"]
     run_generator ["--event-series", "rubyconf", "--event", "2027", "--title", "RubyEvents is great", "--speakers", "Rachael Wright-Munn", "Marco Roth"]
@@ -152,6 +167,8 @@ class TalkGeneratorTest < Rails::Generators::TestCase
   end
 
   test "fails when --id does not match an existing talk and lists the available ids" do
+    seed_speakers_file
+
     File.join(destination_root, "data/rubyconf/2035/videos.yml")
     run_generator ["--event-series", "rubyconf", "--event", "2035", "--title", "Keynote: Jane Doe", "--speakers", "Jane Doe"]
 
@@ -164,6 +181,8 @@ class TalkGeneratorTest < Rails::Generators::TestCase
   end
 
   test "updating with --id does not append a new entry" do
+    seed_speakers_file
+
     videos_file_path = File.join(destination_root, "data/rubyconf/2036/videos.yml")
     run_generator ["--event-series", "rubyconf", "--event", "2036", "--title", "Building Better APIs", "--speakers", "Jane Doe"]
     run_generator ["--event-series", "rubyconf", "--event", "2036", "--id", "jane-doe-2036", "--description", "Updated description."]
@@ -176,6 +195,8 @@ class TalkGeneratorTest < Rails::Generators::TestCase
   end
 
   test "fails when --id is an old_id" do
+    seed_speakers_file
+
     videos_file_path = File.join(destination_root, "data/rubyconf/2037/videos.yml")
     run_generator ["--event-series", "rubyconf", "--event", "2037", "--title", "Building Better APIs", "--speakers", "Jane Doe"]
 
@@ -192,6 +213,8 @@ class TalkGeneratorTest < Rails::Generators::TestCase
   end
 
   test "adds the kind to the id when the speaker already has a talk in the file" do
+    seed_speakers_file
+
     videos_file_path = File.join(destination_root, "data/rubyconf/2034/videos.yml")
     run_generator ["--event-series", "rubyconf", "--event", "2034", "--title", "Building Better APIs", "--speakers", "Jane Doe"]
     run_generator ["--event-series", "rubyconf", "--event", "2034", "--title", "Keynote: Jane Doe", "--kind", "keynote", "--speakers", "Jane Doe"]
@@ -203,6 +226,8 @@ class TalkGeneratorTest < Rails::Generators::TestCase
   end
 
   test "finds event series from static event if not provided" do
+    seed_speakers_file
+
     videos_file_path = File.join(destination_root, "data/tropicalrb/tropical-on-rails-2026/videos.yml")
     run_generator ["--event", "tropical-on-rails-2026", "--title", "Keynote: Marco Roth", "--speakers", "Marco Roth"]
 
@@ -212,6 +237,8 @@ class TalkGeneratorTest < Rails::Generators::TestCase
   end
 
   test "creates minimum lightning talk entry when lightning_talks option is true" do
+    seed_speakers_file
+
     videos_file_path = File.join(destination_root, "data/rubyconf/2028/videos.yml")
     run_generator ["--event-series", "rubyconf",
       "--event", "2028",
@@ -227,6 +254,8 @@ class TalkGeneratorTest < Rails::Generators::TestCase
   end
 
   test "creates maximum lightning talk entry when lightning_talks option is true" do
+    seed_speakers_file
+
     videos_file_path = File.join(destination_root, "data/rubyconf/2029/videos.yml")
     run_generator ["--event-series", "rubyconf",
       "--event", "2029",
@@ -243,6 +272,73 @@ class TalkGeneratorTest < Rails::Generators::TestCase
       assert_match(/language: "English"/, content)
       assert_match(/talks: \[\]/, content)
     end
+  end
+
+  test "adds unknown speakers to data/speakers.yml with generated slugs" do
+    seed_speakers_file
+
+    run_generator ["--event-series", "rubyconf", "--event", "2040", "--title", "Keynote: Jane Doe", "--speakers", "Jane Doe", "John Smith"]
+
+    speakers = read_speakers_file
+    assert_equal [
+      {"name" => "Jane Doe", "github" => "", "slug" => "jane-doe"},
+      {"name" => "John Smith", "github" => "", "slug" => "john-smith"}
+    ], speakers
+  end
+
+  test "only adds speakers that don't exist in data/speakers.yml" do
+    seed_speakers_file(<<~YAML)
+      ---
+      - name: Jane Doe
+        slug: jane-doe
+    YAML
+
+    run_generator ["--event-series", "rubyconf", "--event", "2041", "--title", "Keynote: Jane Doe", "--speakers", "Jane Doe", "New Person"]
+
+    speakers = read_speakers_file
+    assert_equal 2, speakers.size
+    assert_equal "Jane Doe", speakers.first["name"]
+    assert_equal({"name" => "New Person", "github" => "", "slug" => "new-person"}, speakers.last)
+  end
+
+  test "does not add speakers that are known from their alias" do
+    seed_speakers_file(<<~YAML)
+      ---
+      - name: Jane Doe
+        slug: jane-doe
+        aliases:
+          - name: JD
+            slug: jane-doe
+    YAML
+
+    run_generator ["--event-series", "rubyconf", "--event", "2042", "--title", "Keynote by JD", "--speakers", "JD"]
+
+    speakers = read_speakers_file
+    assert_equal 1, speakers.size
+    assert_equal "Jane Doe", speakers.first["name"]
+  end
+
+  test "adds a speaker listed twice only once" do
+    seed_speakers_file
+
+    run_generator ["--event-series", "rubyconf", "--event", "2044", "--title", "Double Trouble", "--speakers", "Jane Doe", "Jane Doe"]
+
+    assert_equal [
+      {"name" => "Jane Doe", "github" => "", "slug" => "jane-doe"}
+    ], read_speakers_file
+  end
+
+  def seed_speakers_file(content = "--- []\n")
+    FileUtils.mkdir_p(File.dirname(speakers_file_path))
+    File.write(speakers_file_path, content)
+  end
+
+  def read_speakers_file
+    Yerba.parse_file(speakers_file_path).to_a
+  end
+
+  def speakers_file_path
+    File.join(destination_root, "data", "speakers.yml")
   end
 
   def assert_valid_file(file_path, msg = nil, &block)

--- a/test/models/static/speakers_file_test.rb
+++ b/test/models/static/speakers_file_test.rb
@@ -208,6 +208,15 @@ class Static::SpeakersFileTest < ActiveSupport::TestCase
     assert_equal 1, speakers_file.count
   end
 
+  test "upsert does not overwrite attributes with whitespace-only values" do
+    speakers_file = Static::SpeakersFile.new(@tmp_file.path)
+
+    entry = speakers_file.upsert(name: "Matz", github: "   ", twitter: "   ")
+
+    assert_equal "matz", entry["github"]
+    assert_nil entry["twitter"]
+  end
+
   test "upsert raises InvalidSpeakerError when the name is blank" do
     speakers_file = Static::SpeakersFile.new(@tmp_file.path)
 

--- a/test/models/static/speakers_file_test.rb
+++ b/test/models/static/speakers_file_test.rb
@@ -112,6 +112,112 @@ class Static::SpeakersFileTest < ActiveSupport::TestCase
     assert_empty file.near_duplicate_names(threshold: 0.99)
   end
 
+  test "add raises InvalidSpeakerError when the name is blank" do
+    speakers_file = Static::SpeakersFile.new(@tmp_file.path)
+
+    [nil, "", "   "].each do |blank_name|
+      error = assert_raises(Static::SpeakersFile::InvalidSpeakerError) do
+        speakers_file.add(name: blank_name)
+      end
+
+      assert_equal "Speaker name cannot be blank", error.message
+    end
+
+    assert_equal 1, speakers_file.count
+  end
+
+  test "add raises DuplicateSpeakerError when the name already exists" do
+    speakers_file = Static::SpeakersFile.new(@tmp_file.path)
+
+    error = assert_raises(Static::SpeakersFile::DuplicateSpeakerError) do
+      speakers_file.add(name: "Matz")
+    end
+
+    assert_equal "Speaker 'Matz' already exists", error.message
+    assert_equal 1, speakers_file.count
+  end
+
+  test "add strips whitespace" do
+    speakers_file = Static::SpeakersFile.new(@tmp_file.path)
+
+    entry = speakers_file.add(name: "  Aaron Patterson  ", github: "  tenderlove  ")
+
+    assert_equal "Aaron Patterson", entry[:name]
+    assert_equal "tenderlove", entry[:github]
+    assert_equal "aaron-patterson", entry[:slug]
+  end
+
+  test "upsert adds a new speaker with a generated slug" do
+    speakers_file = Static::SpeakersFile.new(@tmp_file.path)
+
+    entry = speakers_file.upsert(name: "Jane Doe")
+
+    assert_equal({name: "Jane Doe", github: "", slug: "jane-doe"}, entry.to_h)
+    assert_equal 2, speakers_file.count
+  end
+
+  test "upsert updates attributes of an existing speaker found by name" do
+    speakers_file = Static::SpeakersFile.new(@tmp_file.path)
+
+    entry = speakers_file.upsert(name: "Matz", github: "", twitter: " yukihiro_matz ")
+
+    assert_equal "matz", entry["github"]
+    assert_equal "yukihiro_matz", entry["twitter"]
+  end
+
+  test "upsert finds an existing speaker by github handle and keeps their name" do
+    file = speakers_file_with(<<~YAML)
+      ---
+      - name: Yukihiro Matsumoto
+        github: matz
+        slug: yukihiro-matsumoto
+    YAML
+
+    entry = file.upsert(name: "Matz", github: "matz", website: "https://matz.rubyist.net")
+
+    assert_equal "Yukihiro Matsumoto", entry["name"]
+    assert_equal "https://matz.rubyist.net", entry["website"]
+    assert_equal 1, file.count
+  end
+
+  test "upsert matches an alias without renaming the canonical speaker" do
+    file = speakers_file_with(<<~YAML)
+      ---
+      - name: Jane Doe
+        slug: jane-doe
+        aliases:
+          - name: JD
+            slug: jane-doe
+    YAML
+
+    entry = file.upsert(name: "JD", github: "janedoe")
+
+    assert_equal "Jane Doe", entry["name"]
+    assert_equal "janedoe", entry["github"]
+    assert_equal 1, file.count
+  end
+
+  test "add raises DuplicateSpeakerError when the github handle already exists" do
+    speakers_file = Static::SpeakersFile.new(@tmp_file.path)
+
+    error = assert_raises(Static::SpeakersFile::DuplicateSpeakerError) do
+      speakers_file.add(name: "Yukihiro Matsumoto", github: "matz")
+    end
+
+    assert_equal "A speaker with GitHub handle 'matz' already exists", error.message
+    assert_equal 1, speakers_file.count
+  end
+
+  test "upsert raises InvalidSpeakerError when the name is blank" do
+    speakers_file = Static::SpeakersFile.new(@tmp_file.path)
+
+    assert_raises(Static::SpeakersFile::InvalidSpeakerError) do
+      speakers_file.upsert(name: "")
+    end
+
+    assert_equal 1, speakers_file.count
+  end
+
   private
 
   def speakers_file_with(yaml)

--- a/test/models/static/validators/speaker_slug_matches_name_test.rb
+++ b/test/models/static/validators/speaker_slug_matches_name_test.rb
@@ -2,28 +2,28 @@
 
 require "test_helper"
 
-class Static::Validators::SlugMatchesNameTest < ActiveSupport::TestCase
+class Static::Validators::SpeakerSlugMatchesNameTest < ActiveSupport::TestCase
   self.fixture_table_names = []
   SPEAKERS_FILE = Rails.root.join("data/speakers.yml").to_s
 
   test "applicable? returns true for speakers.yml" do
-    validator = Static::Validators::SlugMatchesName.new(file_path: SPEAKERS_FILE)
+    validator = Static::Validators::SpeakerSlugMatchesName.new(file_path: SPEAKERS_FILE)
     assert validator.applicable?
   end
 
   test "applicable? returns false for a non-speakers file" do
     file = Dir.glob(Rails.root.join("data/**/event.yml")).first
-    validator = Static::Validators::SlugMatchesName.new(file_path: file)
+    validator = Static::Validators::SpeakerSlugMatchesName.new(file_path: file)
     assert_not validator.applicable?
   end
 
   test "applicable? returns false for a non-existent file" do
-    validator = Static::Validators::SlugMatchesName.new(file_path: "/nonexistent/speakers.yml")
+    validator = Static::Validators::SpeakerSlugMatchesName.new(file_path: "/nonexistent/speakers.yml")
     assert_not validator.applicable?
   end
 
   test "returns empty errors for the real speakers.yml" do
-    validator = Static::Validators::SlugMatchesName.new(file_path: SPEAKERS_FILE)
+    validator = Static::Validators::SpeakerSlugMatchesName.new(file_path: SPEAKERS_FILE)
     assert_empty validator.errors
   end
 
@@ -35,7 +35,7 @@ class Static::Validators::SlugMatchesNameTest < ActiveSupport::TestCase
         slug: chaelcodes
     YAML
     with_temp_speakers_yaml(yaml) do |path|
-      validator = Static::Validators::SlugMatchesName.new(file_path: path)
+      validator = Static::Validators::SpeakerSlugMatchesName.new(file_path: path)
       errors = validator.errors
       error = errors.first.to_h
       assert_equal "Slug must be the name parameterized, expected: rachael-wright-munn", error["message"]
@@ -51,7 +51,7 @@ class Static::Validators::SlugMatchesNameTest < ActiveSupport::TestCase
         slug: RachaelWrightMunn
     YAML
     with_temp_speakers_yaml(yaml) do |path|
-      validator = Static::Validators::SlugMatchesName.new(file_path: path)
+      validator = Static::Validators::SpeakerSlugMatchesName.new(file_path: path)
       errors = validator.errors
       error = errors.first.to_h
       assert_equal "Slug must be the name parameterized, expected: rachael-wright-munn", error["message"]
@@ -68,7 +68,7 @@ class Static::Validators::SlugMatchesNameTest < ActiveSupport::TestCase
         slug: rachael-wright-munn
     YAML
     with_temp_speakers_yaml(yaml) do |path|
-      validator = Static::Validators::SlugMatchesName.new(file_path: path)
+      validator = Static::Validators::SpeakerSlugMatchesName.new(file_path: path)
       assert_empty validator.errors
     end
   end
@@ -98,7 +98,7 @@ class Static::Validators::SlugMatchesNameTest < ActiveSupport::TestCase
             slug: yukihiro-matsumoto
     YAML
     with_temp_speakers_yaml(yaml) do |path|
-      validator = Static::Validators::SlugMatchesName.new(file_path: path)
+      validator = Static::Validators::SpeakerSlugMatchesName.new(file_path: path)
       assert_empty validator.errors
     end
   end
@@ -118,7 +118,7 @@ class Static::Validators::SlugMatchesNameTest < ActiveSupport::TestCase
             slug: Matz
     YAML
     with_temp_speakers_yaml(yaml) do |path|
-      validator = Static::Validators::SlugMatchesName.new(file_path: path)
+      validator = Static::Validators::SpeakerSlugMatchesName.new(file_path: path)
       errors = validator.errors
       error = errors.first.to_h
       assert_equal "Slug must be the name parameterized, expected: matz", error["message"]
@@ -134,7 +134,7 @@ class Static::Validators::SlugMatchesNameTest < ActiveSupport::TestCase
         slug: RachaelWrightMunn
     YAML
     with_temp_speakers_yaml(yaml) do |path|
-      validator = Static::Validators::SlugMatchesName.new(file_path: path)
+      validator = Static::Validators::SpeakerSlugMatchesName.new(file_path: path)
       assert validator.errors.all? { |e| e.is_a?(Static::Validators::Error) }
     end
   end

--- a/test/models/static/validators/speaker_slug_matches_name_test.rb
+++ b/test/models/static/validators/speaker_slug_matches_name_test.rb
@@ -73,6 +73,64 @@ class Static::Validators::SpeakerSlugMatchesNameTest < ActiveSupport::TestCase
     end
   end
 
+  test "no errors when name cannot be parameterized and slug matches github handle" do
+    yaml = <<~YAML
+      ---
+      - name: まつもとゆきひろ
+        github: matz
+        slug: matz
+    YAML
+    with_temp_speakers_yaml(yaml) do |path|
+      validator = Static::Validators::SpeakerSlugMatchesName.new(file_path: path)
+      assert_empty validator.errors
+    end
+  end
+
+  test "errors for github handle slug when name cannot be parameterized" do
+    yaml = <<~YAML
+      ---
+      - name: まつもとゆきひろ
+        github: matz
+        slug: ruby
+    YAML
+    with_temp_speakers_yaml(yaml) do |path|
+      validator = Static::Validators::SpeakerSlugMatchesName.new(file_path: path)
+      errors = validator.errors
+      error = errors.first.to_h
+      assert_equal "Name cannot be parameterized. Slug must be the GitHub handle, expected: matz.", error["message"]
+      assert_equal 4, error["line"], "Line number #{error["line"]} does not match line number 4."
+      assert_equal 4, error["end_line"], "End line number #{error["end_line"]} does not match line number 4."
+    end
+  end
+
+  test "no errors for any slug when name cannot be parameterized and no github handle" do
+    yaml = <<~YAML
+      ---
+      - name: まつもとゆきひろ
+        slug: yukihiro-matsumoto
+    YAML
+    with_temp_speakers_yaml(yaml) do |path|
+      validator = Static::Validators::SpeakerSlugMatchesName.new(file_path: path)
+      assert_empty validator.errors
+    end
+  end
+
+  test "no errors for alias with unparameterizable name not matching speaker github handle" do
+    yaml = <<~YAML
+      ---
+      - name: NARUSE Yui
+        github: nurse
+        slug: naruse-yui
+        aliases:
+          - name: 成瀬ゆい
+            slug: naruse-yui
+    YAML
+    with_temp_speakers_yaml(yaml) do |path|
+      validator = Static::Validators::SpeakerSlugMatchesName.new(file_path: path)
+      assert_empty validator.errors
+    end
+  end
+
   test "no errors for alias slugs that are parameterized names" do
     yaml = <<~YAML
       ---


### PR DESCRIPTION
## Description
### Speaker sync in the talk generator

TalkGenerator updates speakers.yml. For each talk, it adds the speaker with an empty GitHub handle if they are not already present.

### Slug validation for non-parameterizable names

The `Static::Validators::SpeakerSlugMatchesName` validator previously skipped validation entirely when a speaker's name parameterized to an empty string (e.g. names written in non-Latin scripts like `まつもとゆきひろ`).

This PR tightens that rule:

- If the parameterized name is empty and the speaker has a `github` handle, the slug must match the GitHub handle (otherwise an error is reported: "Name cannot be parameterized. Slug must be the GitHub handle, expected: <slug>.")
- If there's no GitHub handle, validation is still skipped (any slug allowed)
- Aliases remain exempt — they don't carry their own GitHub handle and may be used for redirecting from the prior name

Also renames the validator file/class from `SlugMatchesName` to `SpeakerSlugMatchesName` because there is 0 chance it will be reused now.

### Fixes event-data

Event-data used to encourage the AI to use github handles instead of parameterizing the name. We're only supposed to do that instead of transliterating the name.

## Screenshots

<!-- Not applicable — no UI changes. -->

## Testing Steps

- `bin/rails g talk --event "rails-camp-west-2026" --speakers "Caleb Owens"`

## References
- closes #2060
- references #2070
