### PR TITLE
[2040] Rename australia to oceania

### DIFF
--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -12,7 +12,7 @@ class BrowseController < ApplicationController
     inspiring most_liked recommended_community popular_topics talk_kinds topic_rows
     language_rows closing_cfps upcoming_events recent_events featured_organizations
     upcoming_events_europe upcoming_events_north_america upcoming_events_south_america
-    upcoming_events_asia upcoming_events_australia upcoming_events_africa
+    upcoming_events_asia upcoming_events_oceania upcoming_events_africa
     talk_languages always_open_cfps
   ].freeze
 
@@ -504,7 +504,7 @@ class BrowseController < ApplicationController
       .limit(15)
   end
 
-  %w[europe north_america south_america asia australia africa].each do |continent_key|
+  %w[europe north_america south_america asia oceania africa].each do |continent_key|
     define_method("load_upcoming_events_#{continent_key}") do
       slug = continent_key.tr("_", "-")
       @continent = Continent.find(slug)

--- a/app/models/continent.rb
+++ b/app/models/continent.rb
@@ -7,7 +7,8 @@ class Continent
     "africa" => {name: "Africa", alpha2: "AF", emoji: "🌍"},
     "antarctica" => {name: "Antarctica", alpha2: "AN", emoji: "🌎"},
     "asia" => {name: "Asia", alpha2: "AS", emoji: "🌏"},
-    "australia" => {name: "Australia", alpha2: "OC", emoji: "🌏"},
+    # ISO3166 (countries gem) still labels this region "Australia"; keep as alias for lookups.
+    "oceania" => {name: "Oceania", alpha2: "OC", emoji: "🌏", aliases: ["Australia"]},
     "europe" => {name: "Europe", alpha2: "EU", emoji: "🌍"},
     "north-america" => {name: "North America", alpha2: "NA", emoji: "🌎"},
     "south-america" => {name: "South America", alpha2: "SA", emoji: "🌎"}
@@ -17,7 +18,7 @@ class Continent
     "africa" => {southwest: [-25.0, -35.0], northeast: [60.0, 40.0]},
     "antarctica" => {southwest: [-180.0, -90.0], northeast: [180.0, -60.0]},
     "asia" => {southwest: [25.0, -10.0], northeast: [180.0, 80.0]},
-    "australia" => {southwest: [110.0, -50.0], northeast: [180.0, 0.0]},
+    "oceania" => {southwest: [110.0, -50.0], northeast: [180.0, 0.0]},
     "europe" => {southwest: [-25.0, 35.0], northeast: [60.0, 72.0]},
     "north-america" => {southwest: [-170.0, 7.0], northeast: [-50.0, 85.0]},
     "south-america" => {southwest: [-82.0, -56.0], northeast: [-34.0, 13.0]}
@@ -92,7 +93,7 @@ class Continent
   end
 
   def countries
-    @countries ||= Country.all.select { |country| country.continent_name == name }
+    @countries ||= Country.all.select { |country| country.continent == self }
   end
 
   def country_codes
@@ -144,7 +145,7 @@ class Continent
     def find_by_name(name)
       return nil if name.blank?
 
-      slug = CONTINENT_DATA.find { |_, data| data[:name] == name }&.first
+      slug = CONTINENT_DATA.find { |_, data| data[:name] == name || Array(data[:aliases]).include?(name) }&.first
       return nil unless slug
 
       new(slug)
@@ -157,7 +158,7 @@ class Continent
     def africa = new("africa")
     def antarctica = new("antarctica")
     def asia = new("asia")
-    def australia = new("australia")
+    def oceania = new("oceania")
     def europe = new("europe")
     def north_america = new("north-america")
     def south_america = new("south-america")

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -13,11 +13,11 @@ class Country
   delegate :alpha2, :alpha3, :emoji_flag, :subdivisions, :iso_short_name, :common_name, :translations, to: :record
 
   def continent_name
-    record.continent
+    continent&.name || record.continent
   end
 
   def continent
-    @continent ||= Continent.find_by_name(continent_name)
+    @continent ||= Continent.find_by_name(record.continent)
   end
 
   def initialize(record)

--- a/app/views/browse/sections/_upcoming_events_australia.html.erb
+++ b/app/views/browse/sections/_upcoming_events_australia.html.erb
@@ -1,3 +1,0 @@
-<%# locals: (events:, continent:) %>
-
-<%= render "browse/sections/upcoming_events_continent", events: events, continent: continent, frame_id: "browse-upcoming-events-australia" %>

--- a/app/views/browse/sections/_upcoming_events_oceania.html.erb
+++ b/app/views/browse/sections/_upcoming_events_oceania.html.erb
@@ -1,0 +1,3 @@
+<%# locals: (events:, continent:) %>
+
+<%= render "browse/sections/upcoming_events_continent", events: events, continent: continent, frame_id: "browse-upcoming-events-oceania" %>

--- a/app/views/page/attend.html.erb
+++ b/app/views/page/attend.html.erb
@@ -98,7 +98,7 @@
             <%= render "browse/content_row_skeleton" %>
           <% end %>
 
-          <%= turbo_frame_tag "browse-upcoming-events-australia", src: browse_path("upcoming_events_australia"), loading: :lazy do %>
+          <%= turbo_frame_tag "browse-upcoming-events-oceania", src: browse_path("upcoming_events_oceania"), loading: :lazy do %>
             <%= render "browse/content_row_skeleton" %>
           <% end %>
 

--- a/test/models/continent_test.rb
+++ b/test/models/continent_test.rb
@@ -40,6 +40,8 @@ class ContinentTest < ActiveSupport::TestCase
     assert_includes slugs, "europe"
     assert_includes slugs, "north-america"
     assert_includes slugs, "asia"
+    assert_includes slugs, "oceania"
+    assert_not_includes slugs, "australia"
   end
 
   test "name returns continent name" do
@@ -126,6 +128,30 @@ class ContinentTest < ActiveSupport::TestCase
     location = continent.to_location
 
     assert_equal "North America", location.to_text
+  end
+
+  test "oceania is findable by slug and ISO Australia alias" do
+    continent = Continent.find("oceania")
+
+    assert_equal "Oceania", continent.name
+    assert_equal "oceania", continent.slug
+    assert_equal Continent.find_by_name("Oceania"), continent
+    assert_equal Continent.find_by_name("Australia"), continent
+  end
+
+  test "oceania includes Australia and New Zealand countries" do
+    continent = Continent.oceania
+    codes = continent.country_codes
+
+    assert_includes codes, "AU"
+    assert_includes codes, "NZ"
+  end
+
+  test "country continent_name returns Oceania for Australia" do
+    country = Country.find_by(country_code: "AU")
+
+    assert_equal "Oceania", country.continent_name
+    assert_equal Continent.oceania, country.continent
   end
 
   test "to_location for all continents returns name" do


### PR DESCRIPTION
## Description
Renamed  australia to oceania

## Screenshots
<img width="1293" height="682" alt="Screenshot from 2026-08-25 12-52-28" src="https://github.com/user-attachments/assets/1ce30b16-d19e-42e7-bc19-83a82ac15135" />
<img width="1293" height="682" alt="Screenshot from 2026-08-25 12-56-04" src="https://github.com/user-attachments/assets/bd2b9de2-725a-41af-b4bf-5274491e2400" />
<img width="1293" height="682" alt="Screenshot from 2026-08-25 12-57-23" src="https://github.com/user-attachments/assets/f7230d30-9972-4b88-b379-9b7e95a6b591" />


## Testing Steps

## References
https://github.com/rubyevents/rubyevents/issues/2040
