### PR TITLE
Allow an event to remove talks

### DIFF
--- a/.agents/skills/backfill-event-data/SKILL.md
+++ b/.agents/skills/backfill-event-data/SKILL.md
@@ -123,6 +123,8 @@ puts "filled #{i}/#{titles.size}"
 
 Compare titles/speakers/order against the site's schedule & speakers pages. Reorder to true running order with `yerba move ... --after ...`. A clean block move shows equal insertions/deletions in `git diff --stat` and preserves block scalars. Note `published_at` stays in upload order — it's the **entry order** that drives running order.
 
+Deleting an entry fails `validate:videos` unless the id is accounted for: `old_id` on the renamed entry if it was renamed, or `removed_talk_ids` in the sibling `event.yml` if it was dropped on purpose (`videos.yml` has a sequence root, so it can't hold a top-level key).
+
 ### speaker social handles (data/speakers.yml)
 
 - Global, flat sequence, auto-sorted by name; enforced key order: `name, github, twitter, mastodon, bluesky, linkedin, website, speakerdeck, slug, aliases`. **Required: name, slug, github** (`github: ""` if unknown).

--- a/.agents/skills/event-data/SKILL.md
+++ b/.agents/skills/event-data/SKILL.md
@@ -61,6 +61,22 @@ Do not pass `--id` when adding a new talk. Talk ids follow the "firstname-lastna
 
 If you create talks, capture a screenshot from http://localhost:3000/events/<event-slug>/talks after the changes are seeded.
 
+## Removing a talk
+
+`bin/rails validate:videos` fails when a talk id disappears from a `videos.yml`, because a vanished id
+is usually an unrecorded rename and production still knows the talk under the old id.
+
+- **Renamed?** Keep the previous id on the renamed entry as `old_id` so its record is migrated on the
+  next seed. `bin/rails talk_ids:backfill_old_ids` writes it for you.
+- **Removed on purpose?** List the id under `removed_talk_ids` in the event's `event.yml` (it lives
+  there because `videos.yml` has a sequence root and cannot hold a top-level key):
+
+```yaml
+# data/kaigi-on-rails/kaigi-on-rails-2026/event.yml
+removed_talk_ids:
+  - "dave-thomas-kaigi-on-rails-2026"
+```
+
 ## Generating a Schedule
 
 Load Documentation from docs/ADDING_SCHEDULES.md into context.

--- a/Yerbafile
+++ b/Yerbafile
@@ -74,6 +74,7 @@ rules:
             - coordinates
             - aliases
             - youtube_channels
+            - removed_talk_ids
 
       - sort_keys:
           path: "youtube_channels[]"

--- a/app/models/static/event.rb
+++ b/app/models/static/event.rb
@@ -375,10 +375,23 @@ module Static
       Static::Video.where_event_slug(slug).each do |video|
         video.import!(event: event, index: index)
       end
+
+      destroy_removed_talks!(event)
     rescue ActiveRecord::RecordInvalid => e
       puts "Couldn't save: #{talk_data["title"]} (#{talk_data["id"]}), error: #{e.message}"
       error_location = ActiveSupport::BacktraceCleaner.new.clean_locations(e.backtrace_locations).first
       puts "::error file=#{error_location&.path},line=#{error_location&.lineno}::#{e.record.class} (#{e.record&.to_param}) - #{e.detailed_message}"
+    end
+
+    def destroy_removed_talks!(event)
+      ids = Array(attributes["removed_talk_ids"])
+      return if ids.empty?
+
+      event.talks.where(static_id: ids).find_each do |talk|
+        puts "Removing talk #{talk.static_id}" unless Rails.env.test?
+
+        talk.destroy!
+      end
     end
 
     def import_sponsors!(event)

--- a/app/models/static/validators/removed_talk_ids.rb
+++ b/app/models/static/validators/removed_talk_ids.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Static
+  module Validators
+    class RemovedTalkIds
+      PATTERNS = [
+        "**/event.yml"
+      ].freeze
+
+      def initialize(file_path:, document: nil)
+        @file_path = file_path
+        @document = document
+      end
+
+      def applicable?
+        return false unless File.exist?(@file_path)
+
+        PATTERNS.any? do |pattern|
+          File.fnmatch?(pattern, @file_path, File::FNM_PATHNAME)
+        end
+      end
+
+      def errors
+        @errors ||= validate
+      end
+
+      def validate
+        return [] unless applicable?
+        return [] if removed_talk_ids.nil?
+        return [] unless File.exist?(videos_path)
+
+        removed_talk_ids.filter_map do |item|
+          id = item.value
+          next unless known_ids.include?(id)
+
+          Static::Validators::Error.new(
+            %(id "#{id}" is listed under `removed_talk_ids`, but it is still in videos.yml. Either drop it from `removed_talk_ids`, or remove the talk from videos.yml.),
+            file_path: @file_path,
+            line: item.location&.start_line || 1,
+            end_line: item.location&.end_line
+          )
+        end
+      end
+
+      private
+
+      def document
+        @document ||= Yerba.parse_file(@file_path)
+      end
+
+      def removed_talk_ids
+        @removed_talk_ids ||= document["removed_talk_ids"]
+      end
+
+      def videos_file
+        @videos_file ||= Static::VideosFile.new(videos_path)
+      end
+
+      def known_ids
+        @known_ids ||= videos_file.ids + videos_file.old_ids
+      end
+
+      def videos_path
+        @videos_path ||= File.join(File.dirname(@file_path.to_s), "videos.yml")
+      end
+    end
+  end
+end

--- a/app/models/static/validators/talk_renames.rb
+++ b/app/models/static/validators/talk_renames.rb
@@ -111,7 +111,7 @@ module Static
       def missing_ids
         return [] if baseline.nil?
 
-        baseline.ids - current.ids - current.old_ids
+        baseline.ids - current.ids - current.old_ids - current.removed_ids
       end
 
       def renamed_errors
@@ -130,7 +130,7 @@ module Static
       def disappeared_errors
         disappeared_ids.map do |id|
           Static::Validators::Error.new(
-            %(id "#{id}" disappeared from this file without being kept as an old_id. If the talk was renamed, please add `old_id: "#{id}"` to the renamed entry so its production record can be migrated on the next seed. If the talk was removed on purpose, this is fine.),
+            %(id "#{id}" disappeared from this file without being kept as an old_id. If the talk was renamed, please add `old_id: "#{id}"` to the renamed entry so its production record can be migrated on the next seed. If the talk was removed on purpose, list it under `removed_talk_ids` in event.yml.),
             file_path: @file_path,
             line: 1
           )

--- a/app/models/static/validators/validator.rb
+++ b/app/models/static/validators/validator.rb
@@ -15,6 +15,7 @@ class Static::Validators::Validator
       Static::Validators::EventDates,
       Static::Validators::EventRecordingsPublishedDate,
       Static::Validators::IdMatchesFolder,
+      Static::Validators::RemovedTalkIds,
       Static::Validators::SeriesDefaultColors
     ]
   end

--- a/app/models/static/videos_file.rb
+++ b/app/models/static/videos_file.rb
@@ -132,6 +132,20 @@ module Static
       talks.filter_map { |talk| talk.value_at("old_id") }
     end
 
+    def removed_ids
+      @removed_ids ||= if event_file_path && File.exist?(event_file_path)
+        Array(Yerba.parse_file(event_file_path).value_at("removed_talk_ids"))
+      else
+        []
+      end
+    end
+
+    def event_file_path
+      return nil if path.blank?
+
+      @event_file_path ||= File.join(File.dirname(path.to_s), "event.yml")
+    end
+
     def top_level_talks
       @top_level_talks ||= video_pairs.map(&:first)
     end

--- a/app/schemas/event_schema.rb
+++ b/app/schemas/event_schema.rb
@@ -34,6 +34,8 @@ class EventSchema < ApplicationSchema
   string :venue, description: "Name of the venue", required: false
 
   array :youtube_channels, of: YouTubeChannelSchema, description: "YouTube channels associated with this event", required: false
+
+  array :removed_talk_ids, of: :string, description: "Ids of talks that were intentionally removed from videos.yml, so the removal is not mistaken for an unrecorded rename", required: false
   string :playlist, description: "YouTube playlist/Vimeo showcase link", required: false
 
   string :website, description: "Official event website URL", required: false

--- a/data/kaigi-on-rails/kaigi-on-rails-2026/event.yml
+++ b/data/kaigi-on-rails/kaigi-on-rails-2026/event.yml
@@ -17,3 +17,5 @@ featured_color: "#CEFF05"
 coordinates:
   latitude: 35.65387810000001
   longitude: 139.6938606
+removed_talk_ids:
+  - "dave-thomas-kaigi-on-rails-2026"

--- a/data/kaigi-on-rails/kaigi-on-rails-2026/videos.yml
+++ b/data/kaigi-on-rails/kaigi-on-rails-2026/videos.yml
@@ -9,14 +9,3 @@
   description: ""
   speakers:
     - David Heinemeier Hansson
-
-- id: "dave-thomas-kaigi-on-rails-2026"
-  title: "Keynote by Dave Thomas"
-  kind: "keynote"
-  event_name: "Kaigi on Rails 2026"
-  date: "2026-10-17"
-  video_provider: "scheduled"
-  video_id: "dave-thomas-kaigi-on-rails-2026"
-  description: ""
-  speakers:
-    - Dave Thomas

--- a/docs/ADDING_VIDEOS.md
+++ b/docs/ADDING_VIDEOS.md
@@ -114,6 +114,21 @@ title: RubyConf AU 2015
 metadata_parser: "YouTube::VideoMetadata::RubyConfAu"
 ```
 
+## Removing a Talk
+
+`bin/rails validate:all` flags any talk id that disappears from a `videos.yml`, because a
+vanished id is usually an unrecorded rename and production still knows the talk under the old id.
+
+- **Renamed?** Keep the previous id on the renamed entry as `old_id`, so its record gets migrated
+  on the next seed. `bin/rails talk_ids:backfill_old_ids` writes it for you.
+- **Removed on purpose?** List the id under `removed_talk_ids` in the event's `event.yml`:
+
+```yaml
+# data/kaigi-on-rails/kaigi-on-rails-2026/event.yml
+removed_talk_ids:
+  - "dave-thomas-kaigi-on-rails-2026"
+```
+
 ## Troubleshooting
 
 **'Psych::Parser#_native_parse': (<unknown>): found unknown escape character while parsing a quoted scalar at line 10 column 19 (Psych::SyntaxError)** - something is malformed - run `bin/lint` for a clearer error

--- a/lib/schemas/event_schema.json
+++ b/lib/schemas/event_schema.json
@@ -729,6 +729,13 @@
         "additionalProperties": false
       }
     },
+    "removed_talk_ids": {
+      "type": "array",
+      "description": "Ids of talks that were intentionally removed from videos.yml, so the removal is not mistaken for an unrecorded rename",
+      "items": {
+        "type": "string"
+      }
+    },
     "playlist": {
       "type": "string",
       "description": "YouTube playlist/Vimeo showcase link"

--- a/test/models/static/event_test.rb
+++ b/test/models/static/event_test.rb
@@ -36,6 +36,35 @@ class Static::EventTest < ActiveSupport::TestCase
     assert event_record.talks.exists?
   end
 
+  test "import_videos! destroys talks listed under removed_talk_ids" do
+    Static::EventSeries.find_by_slug("helveticruby").import_series!
+    event = Static::Event.find_by_slug(SLUG)
+    event_record = event.import_event!
+    event.import_videos!(event_record)
+
+    removed_id = event_record.talks.first.static_id
+    kept_count = event_record.talks.count - 1
+
+    event.stub(:attributes, event.attributes.merge("removed_talk_ids" => [removed_id])) do
+      event.import_videos!(event_record)
+    end
+
+    assert_nil ::Talk.find_by(static_id: removed_id)
+    assert_equal kept_count, event_record.talks.reload.count
+  end
+
+  test "import_videos! leaves talks alone when removed_talk_ids is empty" do
+    Static::EventSeries.find_by_slug("helveticruby").import_series!
+    event = Static::Event.find_by_slug(SLUG)
+    event_record = event.import_event!
+    event.import_videos!(event_record)
+
+    count = event_record.talks.count
+    event.import_videos!(event_record)
+
+    assert_equal count, event_record.talks.reload.count
+  end
+
   test "import_sponsors!" do
     Static::EventSeries.find_by_slug("helveticruby").import_series!
     event = Static::Event.find_by_slug(SLUG)

--- a/test/models/static/validators/removed_talk_ids_test.rb
+++ b/test/models/static/validators/removed_talk_ids_test.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Static::Validators::RemovedTalkIdsTest < ActiveSupport::TestCase
+  EXISTING_EVENT_FILE = Rails.root.join("data/helveticruby/helveticruby-2025/event.yml").to_s
+
+  test "applicable? returns true for an event.yml file" do
+    assert Static::Validators::RemovedTalkIds.new(file_path: EXISTING_EVENT_FILE).applicable?
+  end
+
+  test "applicable? returns false for a videos.yml file" do
+    file = Rails.root.join("data/helveticruby/helveticruby-2025/videos.yml").to_s
+
+    assert_not Static::Validators::RemovedTalkIds.new(file_path: file).applicable?
+  end
+
+  test "applicable? returns false for a non-existent file" do
+    assert_not Static::Validators::RemovedTalkIds.new(file_path: "/nonexistent/event.yml").applicable?
+  end
+
+  test "returns no errors when the event does not declare removed_talk_ids" do
+    assert_empty Static::Validators::RemovedTalkIds.new(file_path: EXISTING_EVENT_FILE).errors
+  end
+
+  test "returns no errors when the removed id is gone from videos.yml" do
+    videos = [{"id" => "john-smith-testconf-2024", "title" => "B"}]
+
+    with_temp_event(removed_talk_ids: ["jane-doe-testconf-2024"], videos: videos) do |path|
+      assert_empty Static::Validators::RemovedTalkIds.new(file_path: path).errors
+    end
+  end
+
+  test "flags a removed id that is still in videos.yml" do
+    videos = [{"id" => "jane-doe-testconf-2024", "title" => "A"}]
+
+    with_temp_event(removed_talk_ids: ["jane-doe-testconf-2024"], videos: videos) do |path|
+      errors = Static::Validators::RemovedTalkIds.new(file_path: path).errors
+
+      assert_equal 1, errors.size
+      assert_includes errors.first.message, %(id "jane-doe-testconf-2024" is listed under `removed_talk_ids`, but it is still in videos.yml)
+      assert_equal 5, errors.first.line
+    end
+  end
+
+  test "flags a removed id that survives as an old_id" do
+    videos = [{"id" => "jane-doe-keynote-testconf-2024", "old_id" => "jane-doe-testconf-2024", "title" => "A"}]
+
+    with_temp_event(removed_talk_ids: ["jane-doe-testconf-2024"], videos: videos) do |path|
+      errors = Static::Validators::RemovedTalkIds.new(file_path: path).errors
+
+      assert_equal 1, errors.size
+      assert_includes errors.first.message, %(id "jane-doe-testconf-2024" is listed under `removed_talk_ids`)
+    end
+  end
+
+  test "flags a removed id nested under a parent talk" do
+    videos = [{"id" => "lightning-talks-testconf-2024", "title" => "Lightning Talks", "talks" => [{"id" => "jane-doe-testconf-2024", "title" => "A"}]}]
+
+    with_temp_event(removed_talk_ids: ["jane-doe-testconf-2024"], videos: videos) do |path|
+      assert_equal 1, Static::Validators::RemovedTalkIds.new(file_path: path).errors.size
+    end
+  end
+
+  test "only flags the ids that are still present" do
+    videos = [{"id" => "jane-doe-testconf-2024", "title" => "A"}]
+    removed = ["gone-testconf-2024", "jane-doe-testconf-2024"]
+
+    with_temp_event(removed_talk_ids: removed, videos: videos) do |path|
+      errors = Static::Validators::RemovedTalkIds.new(file_path: path).errors
+
+      assert_equal 1, errors.size
+      assert_includes errors.first.message, "jane-doe-testconf-2024"
+    end
+  end
+
+  test "returns no errors when the event has no videos.yml" do
+    with_temp_event(removed_talk_ids: ["jane-doe-testconf-2024"], videos: nil) do |path|
+      assert_empty Static::Validators::RemovedTalkIds.new(file_path: path).errors
+    end
+  end
+
+  private
+
+  def with_temp_event(removed_talk_ids:, videos:)
+    dir = Dir.mktmpdir
+    event_path = File.join(dir, "data", "testconf", "testconf-2024", "event.yml")
+    FileUtils.mkdir_p(File.dirname(event_path))
+
+    lines = ["---", %(id: "testconf-2024"), %(title: "TestConf 2024"), "removed_talk_ids:"]
+    lines += removed_talk_ids.map { |id| %(  - "#{id}") }
+    File.write(event_path, lines.join("\n") + "\n")
+
+    File.write(File.join(File.dirname(event_path), "videos.yml"), videos.to_yaml) if videos
+
+    yield event_path
+  ensure
+    FileUtils.rm_rf(dir)
+  end
+end

--- a/test/models/static/validators/talk_renames_test.rb
+++ b/test/models/static/validators/talk_renames_test.rb
@@ -81,6 +81,22 @@ class Static::Validators::TalkRenamesTest < ActiveSupport::TestCase
     end
   end
 
+  test "does not flag an id listed under removed_talk_ids in event.yml" do
+    with_temp_video([{"id" => "someone-else-testconf-2024", "title" => "Another Talk"}], removed_talk_ids: ["jane-doe-testconf-2024"]) do |path|
+      assert_empty errors_for(path)
+    end
+  end
+
+  test "still flags a disappeared id when a different id is listed under removed_talk_ids" do
+    with_temp_video([{"id" => "someone-else-testconf-2024", "title" => "Another Talk"}], removed_talk_ids: ["somebody-else-testconf-2024"]) do |path|
+      errors = errors_for(path)
+
+      assert_equal 1, errors.size
+      assert_includes errors.first.message, %(id "jane-doe-testconf-2024" disappeared from this file)
+      assert_includes errors.first.message, "`removed_talk_ids` in event.yml"
+    end
+  end
+
   test "checks nested talks" do
     baseline = [
       {
@@ -186,13 +202,21 @@ class Static::Validators::TalkRenamesTest < ActiveSupport::TestCase
     Static::Validators::TalkRenames.new(file_path: path, baseline: baseline_file).errors
   end
 
-  def with_temp_video(videos)
+  def with_temp_video(videos, removed_talk_ids: nil)
     dir = Dir.mktmpdir
     videos_path = File.join(dir, "data", "testconf", "testconf-2024", "videos.yml")
     FileUtils.mkdir_p(File.dirname(videos_path))
     File.write(videos_path, videos.to_yaml)
+    write_event_file(File.dirname(videos_path), removed_talk_ids) if removed_talk_ids
     yield videos_path
   ensure
     FileUtils.rm_rf(dir)
+  end
+
+  def write_event_file(dir, removed_talk_ids)
+    lines = ["---", %(id: "testconf-2024"), %(title: "TestConf 2024"), "removed_talk_ids:"]
+    lines += removed_talk_ids.map { |id| %(  - "#{id}") }
+
+    File.write(File.join(dir, "event.yml"), lines.join("\n") + "\n")
   end
 end


### PR DESCRIPTION
This pull request adds a `removed_talk_ids` key to `event.yml` so an event can declare that a talk was deliberately dropped from its `videos.yml`.

`bin/rails validate:videos` flags every talk id that disappears from a `videos.yml`, because a vanished id is usually an unrecorded rename and production still knows the talk under the old id. 

Until now there was no way to say the removal was intentional. `Static::Validators::TalkRenames` only subtracted `old_id`s, so a deliberate deletion failed CI with a message that ended "If the talk was removed on purpose, this is fine.", a state you could not actually express.

This came out of #2085 
