### PR TITLE
Remove redundant name from talk description

### DIFF
--- a/app/views/talks/_talk.html.erb
+++ b/app/views/talks/_talk.html.erb
@@ -320,10 +320,6 @@
           </p>
 
           <%= simple_format auto_link(talk.description, html: {target: "_blank", class: "link"}) %>
-
-          <p class="flex">
-            <span><%= talk.event_name %></span>
-          </p>
         </article>
       </div>
 


### PR DESCRIPTION
## Description
Removed a redundant event name from the bottom of the description block for talks. The name already appears in the header above it.

## Screenshots

Before:
<img width="1866" height="876" alt="image" src="https://github.com/user-attachments/assets/038717fd-2bdc-4e17-a964-70ae86b28d5e" />

After:
<img width="1866" height="830" alt="image" src="https://github.com/user-attachments/assets/379ae117-03e6-4fe4-b09d-ad297138292c" />


## Testing Steps
- Visit any talk page (e.g. `/talks/:slug`)
- Confirm the event name still shows in the header
- Confirm the duplicate event name no longer appears below the description

## References
N/A
