### PR TITLE
Add CFPs for XO Ruby Toronto, New York City, and Montréal 2026

### DIFF
--- a/data/xoruby/xoruby-montreal-2026/cfp.yml
+++ b/data/xoruby/xoruby-montreal-2026/cfp.yml
@@ -1,0 +1,6 @@
+# docs/ADDING_CFPS.md
+---
+
+- name: "Call for Proposals"
+  link: "https://www.xoruby.com/speak/"
+  close_date: "2026-10-17"

--- a/data/xoruby/xoruby-new-york-city-2026/cfp.yml
+++ b/data/xoruby/xoruby-new-york-city-2026/cfp.yml
@@ -1,0 +1,6 @@
+# docs/ADDING_CFPS.md
+---
+
+- name: "Call for Proposals"
+  link: "https://www.xoruby.com/speak/"
+  close_date: "2026-10-10"

--- a/data/xoruby/xoruby-toronto-2026/cfp.yml
+++ b/data/xoruby/xoruby-toronto-2026/cfp.yml
@@ -1,0 +1,6 @@
+# docs/ADDING_CFPS.md
+---
+
+- name: "Call for Proposals"
+  link: "https://www.xoruby.com/speak/"
+  close_date: "2026-10-03"


### PR DESCRIPTION
## Description
Adds Call for Proposals for the XO Ruby 2026 events in:
- Toronto (Oct 3)
- New York City (Oct 10)
- Montréal (Oct 17)

## Screenshots
![xoruby-toronto-2026-cfps.png](https://github.com/user-attachments/assets/0fed64da-e842-4d12-bbe7-10743e377ed1)
![xoruby-new-york-city-2026-cfps.png](https://github.com/user-attachments/assets/92246f92-b60a-4d61-a078-3a5f26bcf7bb)
![xoruby-montreal-2026-cfps.png](https://github.com/user-attachments/assets/464d6458-0e50-446d-bedd-ce2ede297fa6)

## Testing Steps
- http://rubyevents.org/events/xoruby-toronto-2026/cfp
- http://rubyevents.org/events/xoruby-new-york-city-2026/cfp
- http://rubyevents.org/events/xoruby-montreal-2026/cfp

## References
- CFP page: https://www.xoruby.com/speak/
