### PR TITLE
Merge duplicate Baltic Ruby 2026 CFPs into one entry

### DIFF
--- a/app/models/static/event.rb
+++ b/app/models/static/event.rb
@@ -355,12 +355,10 @@ module Static
       cfps = Yerba.parse_file(cfp_file_path.to_s).to_a
 
       cfps.each do |cfp_data|
-        cfp = event.cfps.find_or_initialize_by(
-          link: cfp_data["link"],
-          open_date: cfp_data["open_date"]
-        )
+        cfp = event.cfps.find_or_initialize_by(link: cfp_data["link"])
         cfp.assign_attributes(
           name: cfp_data["name"],
+          open_date: cfp_data["open_date"],
           close_date: cfp_data["close_date"]
         )
 

--- a/data/balticruby/balticruby-2026/cfp.yml
+++ b/data/balticruby/balticruby-2026/cfp.yml
@@ -2,9 +2,4 @@
 - name: "Call for Proposals"
   link: "https://www.papercall.io/balticruby2026"
   open_date: "2025-09-04"
-  close_date: "2025-12-31"
-
-- name: "Call for Proposals Extension"
-  link: "https://www.papercall.io/balticruby2026"
-  open_date: "2026-01-05"
   close_date: "2026-01-31"


### PR DESCRIPTION
## Description
Update CFP seeding logic to key CFPs by link only (instead of link + open_date), so `open_date` becomes an updatable attribute.

Merge the Baltic Ruby 2026 "Call for Proposals" and "Call for Proposals Extension" — which shared the same link — into a single CFP entry (open 2025-09-04, close 2026-01-31).

**Reminder:** after deploying/importing, manually delete the stale Baltic Ruby 2026 CFP row via Avo in prod — it shares the same link as the merged entry, so the import will not remove it.

## Screenshots
<img width="1518" height="606" alt="image" src="https://github.com/user-attachments/assets/14d8e41a-77e8-4983-855e-b993708dd81b" />

## Testing Steps
- Reseed all cfps

## References
N/A