### PR TITLE
Update XO Ruby CFPs and EuRuKo 2026 workshops

### DIFF
--- a/data/euruko/euruko-2026/schedule.yml
+++ b/data/euruko/euruko-2026/schedule.yml
@@ -143,7 +143,7 @@ days:
 
       - start_time: "14:30"
         end_time: "17:30"
-        slots: 4
+        slots: 6
         description: |-
           Workshops run in parallel in this slot. Pick the one you want and register — places are limited.
 

--- a/data/euruko/euruko-2026/videos.yml
+++ b/data/euruko/euruko-2026/videos.yml
@@ -124,25 +124,27 @@
   speakers:
     - Tim Kächele
 
-- id: "koichi-sasada-euruko-2026"
+- id: "koichi-sasada-keynote-euruko-2026"
+  old_id: "koichi-sasada-euruko-2026"
   title: "Closing Keynote: Parallel Programming with Ractors"
   kind: "keynote"
   date: "2026-09-18"
   language: "English"
   video_provider: "scheduled"
-  video_id: "koichi-sasada-euruko-2026"
+  video_id: "koichi-sasada-keynote-euruko-2026"
   description: ""
   speakers:
     - Koichi Sasada
 
 - id: "kasper-timm-hansen-andre-arko-euruko-2026"
-  title: "Workshop: jj, or what if git made sense"
+  title: "Workshop: Go beyond git with jj"
   kind: "workshop"
   date: "2026-09-18"
   language: "English"
   video_provider: "scheduled"
   video_id: "kasper-timm-hansen-andre-arko-euruko-2026"
-  description: ""
+  description: |-
+    jj is a newer version control system that's gaining traction. Come see how it's both simpler and more powerful than git — while being fully compatible with git and GitHub. We'll give you hands-on experience with using jj, explain how it's conceptually different from git, and how you can use it on an existing team.
   speakers:
     - Kasper Timm Hansen
     - André Arko
@@ -168,7 +170,10 @@
   language: "English"
   video_provider: "scheduled"
   video_id: "hasumi-hitoshi-euruko-2026"
-  description: "" # TODO
+  description: |-
+    In this workshop, we'll write BLE apps in Ruby — yes, Bluetooth on a microcontroller, in the language you already love. If you've ever wanted your gadgets to talk to each other (wirelessly, and without much fuss), this is your chance.
+
+    Come with low energy; leave with a wireless Ruby app you built yourself.
   speakers:
     - HASUMI Hitoshi
 
@@ -184,3 +189,34 @@
   speakers:
     - Sarah Lima
     - Rémy Hannequin
+
+- id: "lucian-ghinda-stanislav-katkov-euruko-2026"
+  title: "Workshop: Good Enough Agents: How Coding Agents Actually Work"
+  kind: "workshop"
+  date: "2026-09-18"
+  language: "English"
+  video_provider: "scheduled"
+  video_id: "lucian-ghinda-stanislav-katkov-euruko-2026"
+  description: |-
+    Your agent is not an assistant. It is a loop over a stateless function with a fixed context budget, and once you can see that loop, you can debug it, verify it, and trust what it ships. Knowing all of this helps you use LLMs as a successful companion in producing high quality code while maintaining reliability.
+  speakers:
+    - Lucian Ghinda
+    - Stanislav Katkov
+
+- id: "koichi-sasada-workshop-euruko-2026"
+  title: "Workshop: Ruby Hack Challenge"
+  kind: "workshop"
+  date: "2026-09-18"
+  language: "English"
+  video_provider: "scheduled"
+  video_id: "koichi-sasada-workshop-euruko-2026"
+  description: |-
+    This is a self-paced hands-on workshop for participants who want to try recent Ruby features on their own laptops. The main goal is to build the latest Ruby HEAD and try features such as Ractor, Box, and other recent additions to Ruby.
+
+    There will be no formal lecture. Participants can choose topics that interest them and work through the materials at their own pace. I will be there to help with setup, answer questions, and discuss the features or Ruby internals when needed.
+
+    If participants are interested, they can also try making small changes to the Ruby source code and rebuilding it.
+
+    No prior experience with Ruby internals is required. Basic Ruby programming experience and familiarity with using a terminal should be enough.
+  speakers:
+    - Koichi Sasada

--- a/data/xoruby/xoruby-montreal-2026/cfp.yml
+++ b/data/xoruby/xoruby-montreal-2026/cfp.yml
@@ -3,4 +3,4 @@
 
 - name: "Call for Proposals"
   link: "https://www.xoruby.com/speak/"
-  close_date: "2026-10-17"
+  close_date: "2026-09-09"

--- a/data/xoruby/xoruby-new-york-city-2026/cfp.yml
+++ b/data/xoruby/xoruby-new-york-city-2026/cfp.yml
@@ -3,4 +3,4 @@
 
 - name: "Call for Proposals"
   link: "https://www.xoruby.com/speak/"
-  close_date: "2026-10-10"
+  close_date: "2026-09-09"

--- a/data/xoruby/xoruby-toronto-2026/cfp.yml
+++ b/data/xoruby/xoruby-toronto-2026/cfp.yml
@@ -3,4 +3,4 @@
 
 - name: "Call for Proposals"
   link: "https://www.xoruby.com/speak/"
-  close_date: "2026-10-03"
+  close_date: "2026-09-09"


### PR DESCRIPTION
## Description
- Updated CFP close dates for XO Ruby Toronto, New York, and Montreal 2026 events to September 9, 2026
- Added 6 workshops to EuRuKo 2026 with descriptions
- Updated schedule to show 6 parallel workshop slots

## Screenshots
### XO Ruby CFPs
![Toronto CFP](https://github.com/user-attachments/assets/xoruby-toronto-2026-cfps.png)
![New York CFP](https://github.com/user-attachments/assets/xoruby-new-york-city-2026-cfps.png)
![Montreal CFP](https://github.com/user-attachments/assets/xoruby-montreal-2026-cfps.png)

### EuRuKo 2026
![EuRuKo Talks](https://github.com/user-attachments/assets/euruko-2026-talks.png)
![EuRuKo Schedule](https://github.com/user-attachments/assets/euruko-2026-schedule.png)

## Testing Steps
1. Visit http://localhost:3000/events/xoruby-toronto-2026/cfps
2. Visit http://localhost:3000/events/xoruby-new-york-city-2026/cfps
3. Visit http://localhost:3000/events/xoruby-montreal-2026/cfps
4. Verify all CFPs show September 9, 2026 as the close date
5. Visit http://localhost:3000/events/euruko-2026/talks
6. Visit http://localhost:3000/events/euruko-2026/schedule
7. Verify all 6 workshops are listed with correct details

## References
- Updated CFP files for three XO Ruby 2026 events
- Added workshops: It'\''s about Time, A Hands-On Guide to C Extensions, Go beyond git with jj, Good Enough Agents, PicoRuby: Low Energy Edition, Ruby Hack Challenge