### PR TITLE
BlastoffRails schedule updates

### DIFF
--- a/data/blastoffrails/blastoffrails-2026/schedule.yml
+++ b/data/blastoffrails/blastoffrails-2026/schedule.yml
@@ -47,6 +47,14 @@ days:
           - "Lunch"
 
       - start_time: "14:30"
+        end_time: "15:00"
+        slots: 1
+      
+      - start_time: "15:00"
+        end_time: "15:15"
+        slots: 1
+      
+      - start_time: "15:15"
         end_time: "15:30"
         slots: 1
 
@@ -102,6 +110,14 @@ days:
           - "Lunch"
 
       - start_time: "14:00"
+        end_time: "14:30"
+        slots: 1
+      
+      - start_time: "14:30"
+        end_time: "14:45"
+        slots: 1
+      
+      - start_time: "14:45"
         end_time: "15:00"
         slots: 1
 

--- a/data/blastoffrails/blastoffrails-2026/videos.yml
+++ b/data/blastoffrails/blastoffrails-2026/videos.yml
@@ -72,6 +72,32 @@
     # - TODO: name
     - Neha Abraham
 
+- id: "sarah-ruth-finkel-blastoffrails-2026"
+  title: "Lightning Talk: Five Dollar Website"
+  raw_title: "Blastoff Rails 2026 - Lightning Talk: Five Dollar Website by Sarah Ruth Finkel"
+  kind: "lightning_talk"
+  event_name: "Blastoff Rails 2026"
+  date: "2026-06-11"
+  published_at: "2026-06-26T15:00:25Z"
+  video_provider: "youtube"
+  video_id: "qPxgaxzACp4"
+  description: ""
+  speakers:
+    - Sarah Ruth Finkel
+
+- id: "jed-schneider-blastoffrails-2026"
+  title: "Lightning Talk: F̶r̶a̶m̶e̶w̶o̶r̶k̶ Core focus in the AI age"
+  raw_title: "Blastoff Rails 2026 - Lightning Talk: F̶r̶a̶m̶e̶w̶o̶r̶k̶  Core focus in the AI age by Jed Schneider"
+  kind: "lightning_talk"
+  event_name: "Blastoff Rails 2026"
+  date: "2026-06-11"
+  published_at: "2026-06-27T15:00:06Z"
+  video_provider: "youtube"
+  video_id: "tE0ZUg8xRuQ"
+  description: ""
+  speakers:
+    - Jed Schneider
+
 - id: "stephen-mckeon-blastoffrails-2026"
   title: "Why We're Still Training Rails Developers in an Age of AI"
   raw_title: "Blastoff Rails 2026 - Why We're Still Training Rails Developers in an Age of AI by Stephen McKeon"
@@ -145,6 +171,33 @@
     # - TODO: contestant 3
     # - TODO: contestant 4
 
+- id: "kyle-powers-blastoffrails-2026"
+  title: "Lightning Talk: Rails Performance and Sky Cards"
+  raw_title: "Blastoff Rails 2026 - Lightning Talk: Rails Performance and Sky Cards by Kyle Powers"
+  kind: "lightning_talk"
+  event_name: "Blastoff Rails 2026"
+  date: "2026-06-12" # TODO - add to schedule
+  published_at: "2026-06-28T15:00:34Z"
+  video_provider: "youtube"
+  video_id: "09wta3ujhzY"
+  description: ""
+  speakers:
+    - Kyle Powers
+
+- id: "sam-williams-blastoffrails-2026"
+  title: "Lightning Talk: Keep your Dependencies Fresh"
+  raw_title: "Blastoff Rails 2026 - Lightning Talk: Keep your Dependencies Fresh by  Sam Williams"
+  kind: "lightning_talk"
+  event_name: "Blastoff Rails 2026"
+  date: "2026-06-12" # TODO - add to schedule
+  published_at: "2026-06-29T15:00:35Z"
+  video_provider: "youtube"
+  video_id: "bMOwjrSeCIU"
+  description: |-
+    Automated updates with Renovate.
+  speakers:
+    - Sam Williams
+
 - id: "ifat-ribon-blastoffrails-2026"
   title: "Fewer Tests, More Confidence"
   raw_title: "Blastoff Rails 2026 - Fewer Tests, More Confidence by Ifat Ribon"
@@ -183,56 +236,3 @@
   description: ""
   speakers:
     - Travis Dockter
-
-- id: "sarah-ruth-finkel-blastoffrails-2026"
-  title: "Lightning Talk: Five Dollar Website"
-  raw_title: "Blastoff Rails 2026 - Lightning Talk: Five Dollar Website by Sarah Ruth Finkel"
-  kind: "lightning_talk"
-  event_name: "Blastoff Rails 2026"
-  date: "2026-06-11"
-  published_at: "2026-06-26T15:00:25Z"
-  video_provider: "youtube"
-  video_id: "qPxgaxzACp4"
-  description: ""
-  speakers:
-    - Sarah Ruth Finkel
-
-- id: "jed-schneider-blastoffrails-2026"
-  title: "Lightning Talk: F̶r̶a̶m̶e̶w̶o̶r̶k̶ Core focus in the AI age"
-  raw_title: "Blastoff Rails 2026 - Lightning Talk: F̶r̶a̶m̶e̶w̶o̶r̶k̶  Core focus in the AI age by Jed Schneider"
-  kind: "lightning_talk"
-  event_name: "Blastoff Rails 2026"
-  date: "2026-06-11"
-  published_at: "2026-06-27T15:00:06Z"
-  video_provider: "youtube"
-  video_id: "tE0ZUg8xRuQ"
-  description: ""
-  speakers:
-    - Jed Schneider
-
-- id: "kyle-powers-blastoffrails-2026"
-  title: "Lightning Talk: Rails Performance and Sky Cards"
-  raw_title: "Blastoff Rails 2026 - Lightning Talk: Rails Performance and Sky Cards by Kyle Powers"
-  kind: "lightning_talk"
-  event_name: "Blastoff Rails 2026"
-  date: "2026-06-12"
-  published_at: "2026-06-28T15:00:34Z"
-  video_provider: "youtube"
-  video_id: "09wta3ujhzY"
-  description: ""
-  speakers:
-    - Kyle Powers
-
-- id: "sam-williams-blastoffrails-2026"
-  title: "Lightning Talk: Keep your Dependencies Fresh"
-  raw_title: "Blastoff Rails 2026 - Lightning Talk: Keep your Dependencies Fresh by  Sam Williams"
-  kind: "lightning_talk"
-  event_name: "Blastoff Rails 2026"
-  date: "2026-06-12"
-  published_at: "2026-06-29T15:00:35Z"
-  video_provider: "youtube"
-  video_id: "bMOwjrSeCIU"
-  description: |-
-    Automated updates with Renovate.
-  speakers:
-    - Sam Williams


### PR DESCRIPTION
## Description
<!-- Please describe your changes. -->
Lightning talks now share time with the activities instead of being at the end of the videos file with no schedule.

## Screenshots
<!-- Add screenshots or GIFs if applicable. -->

Day one | Day two
---|---
<img width="795" height="5130" alt="schedule-day-one" src="https://github.com/user-attachments/assets/d5f94b38-7832-4c9a-9617-aae77287f029" /> | <img width="795" height="5441" alt="schedule-day-two" src="https://github.com/user-attachments/assets/2d159bd2-7d59-4710-846c-1e6cde0ac8f3" />

## Testing Steps
<!-- List steps to test your changes. -->
<!-- If this is a content PR, link to the affected pages -->
- https://www.rubyevents.org/events/blastoffrails-2026/schedule/day/2026-06-12

## References
<!-- Link to related issues, discussions, other PRs, or references you used to write the PR. -->
- closes #<!-- issue number -->
