### PR TITLE
Add track and slides_url to talk generator

### DIFF
--- a/lib/generators/talk/talk_generator.rb
+++ b/lib/generators/talk/talk_generator.rb
@@ -8,6 +8,7 @@ class TalkGenerator < Generators::EventBase
   TOOL_DESC = "Create or update a new talk entry in the videos.yml file of a given event."
 
   class_option :id, type: :string, desc: "ID of an existing talk to update. New talks always get a generated id, so omit this to append one.", required: false, group: "Fields"
+  # New talks released
   class_option :title, type: :string, desc: VideoSchema.properties[:title][:description], group: "Fields"
   class_option :speakers, type: :array, desc: "Speaker names", group: "Fields"
   class_option :description, type: :string, desc: VideoSchema.properties[:description][:description], group: "Fields"
@@ -22,6 +23,8 @@ class TalkGenerator < Generators::EventBase
   class_option :date, type: :string, desc: VideoSchema.properties[:date][:description], required: false, group: "Fields"
   class_option :start_time, type: :string, desc: VideoSchema.properties[:start_time][:description], required: false, group: "Fields"
   class_option :end_time, type: :string, desc: VideoSchema.properties[:end_time][:description], required: false, group: "Fields"
+  class_option :track, type: :string, desc: VideoSchema.properties[:track][:description], required: false, group: "Fields"
+  class_option :slides_url, type: :string, desc: VideoSchema.properties[:slides_url][:description], required: false, group: "Fields"
 
   # Options
   class_option :lightning_talks, type: :boolean, default: false, desc: "Add empty group of lightning talks", group: "Options"
@@ -33,7 +36,7 @@ class TalkGenerator < Generators::EventBase
       "kind" => "lightning_talk"
     }.freeze
 
-    attr_accessor :event_slug, :event, :announced_at, :description, :original_title, :start_time, :end_time
+    attr_accessor :event_slug, :event, :announced_at, :description, :original_title, :start_time, :end_time, :track, :slides_url
     attr_writer :id, :date, :language, :speakers, :title, :kind, :existing_ids
 
     def initialize(**attributes)

--- a/lib/generators/talk/talk_generator.rb
+++ b/lib/generators/talk/talk_generator.rb
@@ -76,9 +76,11 @@ class TalkGenerator < Generators::EventBase
     end
 
     def generate_talk_id
-      candidates = ::Talk::StaticID.new(event_slug: event_slug, title: title, speakers: speakers, kind: kind).candidates
+      @generated_talk_id ||= begin
+        candidates = ::Talk::StaticID.new(event_slug: event_slug, title: title, speakers: speakers, kind: kind).candidates
 
-      candidates.find { |candidate| existing_ids.exclude?(candidate) } || candidates.last
+        candidates.find { |candidate| existing_ids.exclude?(candidate) } || candidates.last
+      end
     end
 
     def existing_ids

--- a/lib/generators/talk/templates/lightning_talks.yml.tt
+++ b/lib/generators/talk/templates/lightning_talks.yml.tt
@@ -6,6 +6,9 @@
   kind: "lightning_talk"
   language: "<%= @talk.language %>"
   date: "<%= @talk.date %>"
+<%- if @talk.track.present? -%>
+  track: "<%= @talk.track %>"
+<%- end -%>
   talks: []
   video_provider: "scheduled"
   video_id: "<%= @talk.id %>"

--- a/lib/generators/talk/templates/talk.yml.tt
+++ b/lib/generators/talk/templates/talk.yml.tt
@@ -18,6 +18,12 @@
 <%- if options[:announced_at] -%>
   announced_at: "<%= @talk.announced_at %>"
 <%- end -%>
+<%- if @talk.track.present? -%>
+  track: "<%= @talk.track %>"
+<%- end -%>
+<%- if @talk.slides_url.present? -%>
+  slides_url: "<%= @talk.slides_url %>"
+<%- end -%>
   video_provider: "scheduled"
   video_id: "<%= @talk.id %>"
 <%- if @talk.description.blank? -%>

--- a/test/lib/generators/talk_generator_test.rb
+++ b/test/lib/generators/talk_generator_test.rb
@@ -38,6 +38,8 @@ class TalkGeneratorTest < Rails::Generators::TestCase
       "--kind", "keynote",
       "--language", "Japanese",
       "--date", "2025-09-15",
+      "--track", "Main Stage",
+      "--slides-url", "https://speakerdeck.com/jane/doe",
       "--speakers", "Jane Doe"
     ]
 
@@ -47,6 +49,8 @@ class TalkGeneratorTest < Rails::Generators::TestCase
       assert_match(/kind: "keynote"/, content)
       assert_match(/language: "Japanese"/, content)
       assert_match(/date: "2025-09-15"/, content)
+      assert_match(/track: "Main Stage"/, content)
+      assert_match(/slides_url: "https:\/\/speakerdeck.com\/jane\/doe"/, content)
       assert_match(/- Jane Doe/, content)
     end
   end
@@ -361,7 +365,8 @@ class TalkGeneratorTest < Rails::Generators::TestCase
       "--id", "andy-andrea-2026",
       "--date", "2026-07-14",
       "--start-time", "16:15",
-      "--end-time", "17:00"
+      "--end-time", "17:00",
+      "--track", "Workshop Studio"
     ]
 
     assert_valid_file videos_file_path do |content|
@@ -369,6 +374,7 @@ class TalkGeneratorTest < Rails::Generators::TestCase
       assert_match(/date: "2026-07-14"/, content)
       assert_match(/start_time: 16:15/, content)
       assert_match(/end_time: 17:00/, content)
+      assert_match(/track: Workshop Studio/, content)
     end
   end
 

--- a/test/lib/generators/talk_generator_test.rb
+++ b/test/lib/generators/talk_generator_test.rb
@@ -185,7 +185,7 @@ class TalkGeneratorTest < Rails::Generators::TestCase
     ]
 
     assert_valid_file videos_file_path do |content|
-      assert_equal 1, content.scan(/- id:/).size
+      assert_equal 1, content.scan("- id:").size
       assert_match(/id: "jane-doe-john-smith-2025"/, content)
       assert_match(/title: "Workshop: Jane Doe"/, content)
       assert_match(/description: "A workshop about Ruby!"/, content)

--- a/test/lib/generators/talk_generator_test.rb
+++ b/test/lib/generators/talk_generator_test.rb
@@ -149,6 +149,61 @@ class TalkGeneratorTest < Rails::Generators::TestCase
     end
   end
 
+  test "update maximum videos.yml entry" do
+    seed_speakers_file
+
+    videos_file_path = File.join(destination_root, "data/rubyconf/2025/videos.yml")
+    run_generator [
+      "--event-series", "rubyconf",
+      "--event", "2025",
+      "--title", "Keynote: Jane Doe",
+      "--description", "An insightful talk about Ruby and its future.",
+      "--kind", "keynote",
+      "--language", "Japanese",
+      "--date", "2025-09-15",
+      "--start-time", "09:00",
+      "--end_time", "10:00",
+      "--track", "Main Stage",
+      "--slides-url", "https://speakerdeck.com/jane/doe",
+      "--speakers", "Jane Doe", "John Smith"
+    ]
+
+    run_generator [
+      "--event-series", "rubyconf",
+      "--event", "2025",
+      "--id", "jane-doe-john-smith-2025",
+      "--title", "Workshop: Jane Doe",
+      "--description", "A workshop about Ruby!",
+      "--kind", "workshop",
+      "--language", "English",
+      "--date", "2025-09-16",
+      "--start-time", "13:30",
+      "--end_time", "15:00",
+      "--track", "Workshop",
+      "--slides-url", "https://speakerdeck.com/jane/doe/workshop",
+      "--speakers", "Jane Doe", "John Smith"
+    ]
+
+    assert_valid_file videos_file_path do |content|
+      assert_equal 1, content.scan(/- id:/).size
+      assert_match(/id: "jane-doe-john-smith-2025"/, content)
+      assert_match(/title: "Workshop: Jane Doe"/, content)
+      assert_match(/description: "A workshop about Ruby!"/, content)
+      assert_match(/kind: "workshop"/, content)
+      assert_match(/language: "English"/, content)
+      assert_match(/date: "2025-09-16"/, content)
+      assert_match(/start_time: "13:30"/, content)
+      assert_match(/end_time: "15:00"/, content)
+      assert_match(/track: "Workshop"/, content)
+      assert_match(%r{slides_url: "https://speakerdeck.com/jane/doe/workshop"}, content)
+      assert_no_match(/Keynote/, content)
+      assert_no_match(/Japanese/, content)
+      assert_no_match(/Main Stage/, content)
+      assert_match(/- Jane Doe/, content)
+      assert_match(/- John Smith/, content)
+    end
+  end
+
   test "append to videos.yml if called with a different details" do
     seed_speakers_file
 


### PR DESCRIPTION
## Description
Adds the `track` and `slides_url` fields to the talk generator.

- New `class_option`s using the `VideoSchema` descriptions
- Emitted in `talk.yml.tt` and `lightning_talks.yml.tt` templates in the Yerbafile key order
- Coverage in the talk generator tests (maximal talk + schedule update)

## Screenshots
N/A

## Testing Steps
```
bin/rails g talk --event event-slug --id talk-id --track "Track Name" --slides_url "https://speakerdeck.com/url-for-slides-<3"
```

## References
- 